### PR TITLE
Poll GitHub for phishing config file

### DIFF
--- a/tests/PhishingController.test.ts
+++ b/tests/PhishingController.test.ts
@@ -87,4 +87,22 @@ describe('PhishingController', () => {
 		controller.bypass('electrum.mx');
 		expect(controller.test('electrum.mx')).toBe(false);
 	});
+
+	it('should not update phishing lists if fetch returns 304', async () => {
+		const mock = stub(window, 'fetch');
+		mock.resolves({ status: 304 });
+		const controller = new PhishingController();
+		const oldState = controller.state.phishing;
+		await controller.updatePhishingLists();
+		expect(controller.state.phishing).toBe(oldState);
+		mock.restore();
+	});
+
+	it('should not update phishing lists if fetch returns error', async () => {
+		const mock = stub(window, 'fetch');
+		mock.resolves({ status: 500 });
+		const controller = new PhishingController();
+		await expect(controller.updatePhishingLists()).rejects.toThrowError(/Fetch failed with status '500'/u);
+		mock.restore();
+	});
 });


### PR DESCRIPTION
Refs #219

This PR removes the usage of the `https://api.infura.io/v2/blacklist` endpoint, replacing it with fetching the config from GitHub directly.