### PR TITLE
Add publish config for scoped pkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "dist/"
   ],
   "main": "./dist/index.js",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
   "scripts": {
     "lint": "tslint src/**/*.ts",
     "test": "jest --coverage",


### PR DESCRIPTION
This PR adds the `.publishConfig` entry to the `package.json` file that is required to publish a public scoped npm package.