### PR TITLE
Update phishing config request logic

### DIFF
--- a/src/third-party/PhishingController.ts
+++ b/src/third-party/PhishingController.ts
@@ -52,7 +52,7 @@ export interface PhishingState extends BaseState {
  * Controller that passively polls on a set interval for approved and unapproved website origins
  */
 export class PhishingController extends BaseController<PhishingConfig, PhishingState> {
-	private configUrl = 'https://raw.githubusercontent.com/MetaMask/eth-phishing-detect/master/src/config.json';
+	private configUrl = 'https://api.github.com/repos/MetaMask/eth-phishing-detect/contents/src/config.json';
 	private configEtag: string = '';
 	private detector: any;
 	private handle?: NodeJS.Timer;
@@ -140,6 +140,7 @@ export class PhishingController extends BaseController<PhishingConfig, PhishingS
 	private async queryConfig(input: RequestInfo): Promise<EthPhishingResponse | null> {
 		const response = await fetch(input, {
 			headers: {
+				'Accept': 'application/vnd.github.v3.raw+json',
 				'If-None-Match': this.configEtag
 			}
 		});
@@ -149,7 +150,8 @@ export class PhishingController extends BaseController<PhishingConfig, PhishingS
 				this.configEtag = response.headers.get('ETag') || /* istanbul ignore next */ '';
 				return await response.json();
 			}
-			case 304: {
+			case 304:
+			case 403: {
 				return null;
 			}
 			default: {


### PR DESCRIPTION
This change updates the `PhishingController` config request logic to:

1. Use the official GitHub API for repo contents (see #219)
2. Handle 403 responses, as the GH API will rate limit with that status code

Note that the current query interval, 180000 ms, will be fewer than 60 requests per hour:

> For unauthenticated requests, the rate limit allows for up to 60 requests per hour. Unauthenticated requests are associated with the originating IP address, and not the user making requests.

And, per the docs, 304 responses don't count towards the rate limit:

> Making a conditional request and receiving a 304 response does not count against your Rate Limit, so we encourage you to use it whenever possible.

See also:

- [GitHub REST API v3 - Media Types](https://developer.github.com/v3/media/)
- [GitHub REST API v3 - Rate limiting](https://developer.github.com/v3/#rate-limiting)
- [GitHub REST API v3 - Conditional requests](https://developer.github.com/v3/#conditional-requests)