### PR TITLE
bugfix/speedup cancel transaction

### DIFF
--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -542,7 +542,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 		const existingGasPrice = transactionMeta.transaction.gasPrice;
 		/* istanbul ignore next */
 		const existingGasPriceDecimal = parseInt(existingGasPrice === undefined ? '0x0' : existingGasPrice, 16);
-		const gasPrice = addHexPrefix(`${parseInt(`${existingGasPriceDecimal * CANCEL_RATE}`).toString(16)}`);
+		const gasPrice = addHexPrefix(`${parseInt(`${existingGasPriceDecimal * CANCEL_RATE}`, 10).toString(16)}`);
 
 		const ethTransaction = new Transaction({
 			from: transactionMeta.transaction.from,
@@ -581,7 +581,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 		const existingGasPrice = transactionMeta.transaction.gasPrice;
 		/* istanbul ignore next */
 		const existingGasPriceDecimal = parseInt(existingGasPrice === undefined ? '0x0' : existingGasPrice, 16);
-		const gasPrice = addHexPrefix(`${parseInt(`${existingGasPriceDecimal * SPEED_UP_RATE}`).toString(16)}`);
+		const gasPrice = addHexPrefix(`${parseInt(`${existingGasPriceDecimal * SPEED_UP_RATE}`, 10).toString(16)}`);
 		const ethTransaction = new Transaction({ ...transactionMeta.transaction, gasPrice });
 		await this.sign(ethTransaction, transactionMeta.transaction.from);
 		const rawTransaction = bufferToHex(ethTransaction.serialize());

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -542,7 +542,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 		const existingGasPrice = transactionMeta.transaction.gasPrice;
 		/* istanbul ignore next */
 		const existingGasPriceDecimal = parseInt(existingGasPrice === undefined ? '0x0' : existingGasPrice, 16);
-		const gasPrice = addHexPrefix(`${parseFloat(`${existingGasPriceDecimal * CANCEL_RATE}`).toString(16)}`);
+		const gasPrice = addHexPrefix(`${parseInt(`${existingGasPriceDecimal * CANCEL_RATE}`).toString(16)}`);
 
 		const ethTransaction = new Transaction({
 			from: transactionMeta.transaction.from,
@@ -581,7 +581,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 		const existingGasPrice = transactionMeta.transaction.gasPrice;
 		/* istanbul ignore next */
 		const existingGasPriceDecimal = parseInt(existingGasPrice === undefined ? '0x0' : existingGasPrice, 16);
-		const gasPrice = addHexPrefix(`${parseFloat(`${existingGasPriceDecimal * SPEED_UP_RATE}`).toString(16)}`);
+		const gasPrice = addHexPrefix(`${parseInt(`${existingGasPriceDecimal * SPEED_UP_RATE}`).toString(16)}`);
 		const ethTransaction = new Transaction({ ...transactionMeta.transaction, gasPrice });
 		await this.sign(ethTransaction, transactionMeta.transaction.from);
 		const rawTransaction = bufferToHex(ethTransaction.serialize());

--- a/tests/TransactionController.test.ts
+++ b/tests/TransactionController.test.ts
@@ -775,14 +775,14 @@ describe('TransactionController', () => {
 			await controller.addTransaction({
 				from,
 				gas: '0x0',
-				gasPrice: '0x1',
+				gasPrice: '0x50fd51da',
 				to: from,
 				value: '0x0'
 			});
 			await controller.speedUpTransaction(controller.state.transactions[0].id);
 
 			expect(controller.state.transactions.length).toBe(2);
-			expect(controller.state.transactions[1].transaction.gasPrice).toBe('0x1.199999999999a');
+			expect(controller.state.transactions[1].transaction.gasPrice).toBe('0x5916a6d6');
 			resolve();
 		});
 	});


### PR DESCRIPTION
There was a bug that it could be seen on mobile, where a speedup transaction action would end up on `insufficient funds for gas * price + value` error because the conversion was taking decimals (float) as wei for that transaction. This PR ignores that and only takes the int part of the new `gasPrice` that it will be used to try to speed up or cancel a transaction.