### PR TITLE
Use jsDelivr instead of the GitHub API for content

### DIFF
--- a/src/third-party/PhishingController.ts
+++ b/src/third-party/PhishingController.ts
@@ -52,7 +52,7 @@ export interface PhishingState extends BaseState {
  * Controller that passively polls on a set interval for approved and unapproved website origins
  */
 export class PhishingController extends BaseController<PhishingConfig, PhishingState> {
-	private configUrl = 'https://api.github.com/repos/MetaMask/eth-phishing-detect/contents/src/config.json';
+	private configUrl = 'https://cdn.jsdelivr.net/gh/MetaMask/eth-phishing-detect@master/src/config.json';
 	private configEtag: string = '';
 	private detector: any;
 	private handle?: NodeJS.Timer;
@@ -140,7 +140,6 @@ export class PhishingController extends BaseController<PhishingConfig, PhishingS
 	private async queryConfig(input: RequestInfo): Promise<EthPhishingResponse | null> {
 		const response = await fetch(input, {
 			headers: {
-				'Accept': 'application/vnd.github.v3.raw+json',
 				'If-None-Match': this.configEtag
 			}
 		});


### PR DESCRIPTION
Refs #219

At the request of GitHub, this change updates how we query for the latest blocklist content. We now hit [jsDelivr][1] instead of the GitHub API.

  [1]:https://www.jsdelivr.com