### PR TITLE
Lower phishing config poll rate to 1 req/hr

### DIFF
--- a/src/third-party/PhishingController.ts
+++ b/src/third-party/PhishingController.ts
@@ -70,7 +70,7 @@ export class PhishingController extends BaseController<PhishingConfig, PhishingS
 	 */
 	constructor(config?: Partial<PhishingConfig>, state?: Partial<PhishingState>) {
 		super(config, state);
-		this.defaultConfig = { interval: 180000 };
+		this.defaultConfig = { interval: 60 * 60 * 1000 };
 		this.defaultState = {
 			phishing: DEFAULT_PHISHING_RESPONSE,
 			whitelist: []

--- a/tests/PhishingController.test.ts
+++ b/tests/PhishingController.test.ts
@@ -12,7 +12,7 @@ describe('PhishingController', () => {
 
 	it('should set default config', () => {
 		const controller = new PhishingController();
-		expect(controller.config).toEqual({ interval: 180000 });
+		expect(controller.config).toEqual({ interval: 3_600_000 });
 	});
 
 	it('should poll and update rate in the right interval', () => {


### PR DESCRIPTION
This PR lowers the rate at which we are checking the phishing blocklist from every 3 minutes to every 60 minutes.