### PR TITLE
Add prepublishOnly build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "access": "public"
   },
   "scripts": {
+    "prepublishOnly": "yarn build",
     "lint": "tslint src/**/*.ts",
     "test": "jest --coverage",
     "format": "prettier **/*.ts --write --ignore-path=.gitignore",


### PR DESCRIPTION
This PR adds a `prepublishOnly` script entry to run the build process before publishing.