### PR TITLE
Feature/add currencies

### DIFF
--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -1,6 +1,6 @@
 interface Options {
-  code?: string
-  name?: string
+  code: string
+  name: string
 }
 
 const currencies: Array<Options> = [

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -1,0 +1,455 @@
+const objects = [
+  {
+    "symbol": "ethaud",
+    "quote": {
+      "code": "aud",
+      "name": "Australian Dollar"
+    }
+  },
+  {
+    "symbol": "ethhkd",
+    "quote": {
+      "code": "hkd",
+      "name": "Hong Kong Dollar"
+    }
+  },
+  {
+    "symbol": "ethsgd",
+    "quote": {
+      "code": "sgd",
+      "name": "Singapore Dollar"
+    }
+  },
+  {
+    "symbol": "ethidr",
+    "quote": {
+      "code": "idr",
+      "name": "Indonesian Rupiah"
+    }
+  },
+  {
+    "symbol": "ethphp",
+    "quote": {
+      "code": "php",
+      "name": "Philippine Peso"
+    }
+  },
+  {
+    "symbol": "ethadt",
+    "quote": {
+      "code": "adt",
+      "name": "adToken"
+    }
+  },
+  {
+    "symbol": "ethadx",
+    "quote": {
+      "code": "adx",
+      "name": "AdEx"
+    }
+  },
+  {
+    "symbol": "ethant",
+    "quote": {
+      "code": "ant",
+      "name": "Aragon"
+    }
+  },
+  {
+    "symbol": "ethbat",
+    "quote": {
+      "code": "bat",
+      "name": "Basic Attention Token"
+    }
+  },
+  {
+    "symbol": "ethbnt",
+    "quote": {
+      "code": "bnt",
+      "name": "Bancor"
+    }
+  },
+  {
+    "symbol": "ethbtc",
+    "quote": {
+      "code": "btc",
+      "name": "Bitcoin"
+    }
+  },
+  {
+    "symbol": "ethcad",
+    "quote": {
+      "code": "cad",
+      "name": "Canadian Dollar"
+    }
+  },
+  {
+    "symbol": "ethcfi",
+    "quote": {
+      "code": "cfi",
+      "name": "Cofound.it"
+    }
+  },
+  {
+    "symbol": "ethcrb",
+    "quote": {
+      "code": "crb",
+      "name": "CreditBit"
+    }
+  },
+  {
+    "symbol": "ethcvc",
+    "quote": {
+      "code": "cvc",
+      "name": "Civic"
+    }
+  },
+  {
+    "symbol": "ethdash",
+    "quote": {
+      "code": "dash",
+      "name": "Dash"
+    }
+  },
+  {
+    "symbol": "ethdgd",
+    "quote": {
+      "code": "dgd",
+      "name": "DigixDAO"
+    }
+  },
+  {
+    "symbol": "ethetc",
+    "quote": {
+      "code": "etc",
+      "name": "Ethereum Classic"
+    }
+  },
+  {
+    "symbol": "etheur",
+    "quote": {
+      "code": "eur",
+      "name": "Euro"
+    }
+  },
+  {
+    "symbol": "ethfun",
+    "quote": {
+      "code": "fun",
+      "name": "FunFair"
+    }
+  },
+  {
+    "symbol": "ethgbp",
+    "quote": {
+      "code": "gbp",
+      "name": "Pound Sterling"
+    }
+  },
+  {
+    "symbol": "ethgno",
+    "quote": {
+      "code": "gno",
+      "name": "Gnosis"
+    }
+  },
+  {
+    "symbol": "ethgnt",
+    "quote": {
+      "code": "gnt",
+      "name": "Golem"
+    }
+  },
+  {
+    "symbol": "ethgup",
+    "quote": {
+      "code": "gup",
+      "name": "Matchpool"
+    }
+  },
+  {
+    "symbol": "ethhmq",
+    "quote": {
+      "code": "hmq",
+      "name": "Humaniq"
+    }
+  },
+  {
+    "symbol": "ethjpy",
+    "quote": {
+      "code": "jpy",
+      "name": "Japanese Yen"
+    }
+  },
+  {
+    "symbol": "ethlgd",
+    "quote": {
+      "code": "lgd",
+      "name": "Legends Room"
+    }
+  },
+  {
+    "symbol": "ethlsk",
+    "quote": {
+      "code": "lsk",
+      "name": "Lisk"
+    }
+  },
+  {
+    "symbol": "ethltc",
+    "quote": {
+      "code": "ltc",
+      "name": "Litecoin"
+    }
+  },
+  {
+    "symbol": "ethlun",
+    "quote": {
+      "code": "lun",
+      "name": "Lunyr"
+    }
+  },
+  {
+    "symbol": "ethmco",
+    "quote": {
+      "code": "mco",
+      "name": "Monaco"
+    }
+  },
+  {
+    "symbol": "ethmtl",
+    "quote": {
+      "code": "mtl",
+      "name": "Metal"
+    }
+  },
+  {
+    "symbol": "ethmyst",
+    "quote": {
+      "code": "myst",
+      "name": "Mysterium"
+    }
+  },
+  {
+    "symbol": "ethnmr",
+    "quote": {
+      "code": "nmr",
+      "name": "Numeraire"
+    }
+  },
+  {
+    "symbol": "ethomg",
+    "quote": {
+      "code": "omg",
+      "name": "OmiseGO"
+    }
+  },
+  {
+    "symbol": "ethpay",
+    "quote": {
+      "code": "pay",
+      "name": "TenX"
+    }
+  },
+  {
+    "symbol": "ethptoy",
+    "quote": {
+      "code": "ptoy",
+      "name": "Patientory"
+    }
+  },
+  {
+    "symbol": "ethqrl",
+    "quote": {
+      "code": "qrl",
+      "name": "Quantum-Resistant Ledger"
+    }
+  },
+  {
+    "symbol": "ethqtum",
+    "quote": {
+      "code": "qtum",
+      "name": "Qtum"
+    }
+  },
+  {
+    "symbol": "ethrep",
+    "quote": {
+      "code": "rep",
+      "name": "Augur"
+    }
+  },
+  {
+    "symbol": "ethrlc",
+    "quote": {
+      "code": "rlc",
+      "name": "iEx.ec"
+    }
+  },
+  {
+    "symbol": "ethrub",
+    "quote": {
+      "code": "rub",
+      "name": "Russian Ruble"
+    }
+  },
+  {
+    "symbol": "ethsc",
+    "quote": {
+      "code": "sc",
+      "name": "Siacoin"
+    }
+  },
+  {
+    "symbol": "ethsngls",
+    "quote": {
+      "code": "sngls",
+      "name": "SingularDTV"
+    }
+  },
+  {
+    "symbol": "ethsnt",
+    "quote": {
+      "code": "snt",
+      "name": "Status"
+    }
+  },
+  {
+    "symbol": "ethsteem",
+    "quote": {
+      "code": "steem",
+      "name": "Steem"
+    }
+  },
+  {
+    "symbol": "ethstorj",
+    "quote": {
+      "code": "storj",
+      "name": "Storj"
+    }
+  },
+  {
+    "symbol": "ethtime",
+    "quote": {
+      "code": "time",
+      "name": "ChronoBank"
+    }
+  },
+  {
+    "symbol": "ethtkn",
+    "quote": {
+      "code": "tkn",
+      "name": "TokenCard"
+    }
+  },
+  {
+    "symbol": "ethtrst",
+    "quote": {
+      "code": "trst",
+      "name": "WeTrust"
+    }
+  },
+  {
+    "symbol": "ethusd",
+    "quote": {
+      "code": "usd",
+      "name": "United States Dollar"
+    }
+  },
+  {
+    "symbol": "ethwings",
+    "quote": {
+      "code": "wings",
+      "name": "Wings"
+    }
+  },
+  {
+    "symbol": "ethxem",
+    "quote": {
+      "code": "xem",
+      "name": "NEM"
+    }
+  },
+  {
+    "symbol": "ethxlm",
+    "quote": {
+      "code": "xlm",
+      "name": "Stellar Lumen"
+    }
+  },
+  {
+    "symbol": "ethxmr",
+    "quote": {
+      "code": "xmr",
+      "name": "Monero"
+    }
+  },
+  {
+    "symbol": "ethxrp",
+    "quote": {
+      "code": "xrp",
+      "name": "Ripple"
+    }
+  },
+  {
+    "symbol": "ethzec",
+    "quote": {
+      "code": "zec",
+      "name": "Zcash"
+    }
+  },
+  {
+    "symbol": "ethdai",
+    "quote": {
+      "code": "dai",
+      "name": "DAI"
+    }
+  },
+  {
+    "symbol": "ethusdc",
+    "quote": {
+      "code": "usdc",
+      "name": "USD Coin"
+    }
+  },
+  {
+    "symbol": "ethusdt",
+    "quote": {
+      "code": "usdt",
+      "name": "Tether"
+    }
+  },
+  {
+    "symbol": "ethinr",
+    "quote": {
+      "code": "inr",
+      "name": "Indian Rupee"
+    }
+  },
+  {
+    "symbol": "eth1st",
+    "quote": {
+      "code": "1st",
+      "name": "FirstBlood"
+    }
+  },
+  {
+    "symbol": "ethuah",
+    "quote": {
+      "code": "uah",
+      "name": "Ukrainian Hryvnia"
+    }
+  },
+  {
+    "symbol": "ethsai",
+    "quote": {
+      "code": "sai",
+      "name": "SAI"
+    }
+  }
+]
+
+const wrapper = { objects };
+
+export default wrapper;
+

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -1,455 +1,252 @@
-const objects = [
+const currencies: Array<object> = [
   {
-    "symbol": "ethaud",
-    "quote": {
-      "code": "aud",
-      "name": "Australian Dollar"
-    }
+    "code": "aud",
+    "name": "Australian Dollar"
   },
   {
-    "symbol": "ethhkd",
-    "quote": {
-      "code": "hkd",
-      "name": "Hong Kong Dollar"
-    }
+    "code": "hkd",
+    "name": "Hong Kong Dollar"
   },
   {
-    "symbol": "ethsgd",
-    "quote": {
-      "code": "sgd",
-      "name": "Singapore Dollar"
-    }
+    "code": "sgd",
+    "name": "Singapore Dollar"
   },
   {
-    "symbol": "ethidr",
-    "quote": {
-      "code": "idr",
-      "name": "Indonesian Rupiah"
-    }
+    "code": "idr",
+    "name": "Indonesian Rupiah"
   },
   {
-    "symbol": "ethphp",
-    "quote": {
-      "code": "php",
-      "name": "Philippine Peso"
-    }
+    "code": "inr",
+    "name": "Indian Rupee"
   },
   {
-    "symbol": "ethadt",
-    "quote": {
-      "code": "adt",
-      "name": "adToken"
-    }
+    "code": "php",
+    "name": "Philippine Peso"
   },
   {
-    "symbol": "ethadx",
-    "quote": {
-      "code": "adx",
-      "name": "AdEx"
-    }
+    "code": "1st",
+    "name": "FirstBlood"
   },
   {
-    "symbol": "ethant",
-    "quote": {
-      "code": "ant",
-      "name": "Aragon"
-    }
+    "code": "adt",
+    "name": "adToken"
   },
   {
-    "symbol": "ethbat",
-    "quote": {
-      "code": "bat",
-      "name": "Basic Attention Token"
-    }
+    "code": "adx",
+    "name": "AdEx"
   },
   {
-    "symbol": "ethbnt",
-    "quote": {
-      "code": "bnt",
-      "name": "Bancor"
-    }
+    "code": "ant",
+    "name": "Aragon"
   },
   {
-    "symbol": "ethbtc",
-    "quote": {
-      "code": "btc",
-      "name": "Bitcoin"
-    }
+    "code": "bat",
+    "name": "Basic Attention Token"
   },
   {
-    "symbol": "ethcad",
-    "quote": {
-      "code": "cad",
-      "name": "Canadian Dollar"
-    }
+    "code": "bnt",
+    "name": "Bancor"
   },
   {
-    "symbol": "ethcfi",
-    "quote": {
-      "code": "cfi",
-      "name": "Cofound.it"
-    }
+    "code": "btc",
+    "name": "Bitcoin"
   },
   {
-    "symbol": "ethcrb",
-    "quote": {
-      "code": "crb",
-      "name": "CreditBit"
-    }
+    "code": "cad",
+    "name": "Canadian Dollar"
   },
   {
-    "symbol": "ethcvc",
-    "quote": {
-      "code": "cvc",
-      "name": "Civic"
-    }
+    "code": "cfi",
+    "name": "Cofound.it"
   },
   {
-    "symbol": "ethdash",
-    "quote": {
-      "code": "dash",
-      "name": "Dash"
-    }
+    "code": "crb",
+    "name": "CreditBit"
   },
   {
-    "symbol": "ethdgd",
-    "quote": {
-      "code": "dgd",
-      "name": "DigixDAO"
-    }
+    "code": "cvc",
+    "name": "Civic"
   },
   {
-    "symbol": "ethetc",
-    "quote": {
-      "code": "etc",
-      "name": "Ethereum Classic"
-    }
+    "code": "dash",
+    "name": "Dash"
   },
   {
-    "symbol": "etheur",
-    "quote": {
-      "code": "eur",
-      "name": "Euro"
-    }
+    "code": "dgd",
+    "name": "DigixDAO"
   },
   {
-    "symbol": "ethfun",
-    "quote": {
-      "code": "fun",
-      "name": "FunFair"
-    }
+    "code": "etc",
+    "name": "Ethereum Classic"
   },
   {
-    "symbol": "ethgbp",
-    "quote": {
-      "code": "gbp",
-      "name": "Pound Sterling"
-    }
+    "code": "eur",
+    "name": "Euro"
   },
   {
-    "symbol": "ethgno",
-    "quote": {
-      "code": "gno",
-      "name": "Gnosis"
-    }
+    "code": "fun",
+    "name": "FunFair"
   },
   {
-    "symbol": "ethgnt",
-    "quote": {
-      "code": "gnt",
-      "name": "Golem"
-    }
+    "code": "gbp",
+    "name": "Pound Sterling"
   },
   {
-    "symbol": "ethgup",
-    "quote": {
-      "code": "gup",
-      "name": "Matchpool"
-    }
+    "code": "gno",
+    "name": "Gnosis"
   },
   {
-    "symbol": "ethhmq",
-    "quote": {
-      "code": "hmq",
-      "name": "Humaniq"
-    }
+    "code": "gnt",
+    "name": "Golem"
   },
   {
-    "symbol": "ethjpy",
-    "quote": {
-      "code": "jpy",
-      "name": "Japanese Yen"
-    }
+    "code": "gup",
+    "name": "Matchpool"
   },
   {
-    "symbol": "ethlgd",
-    "quote": {
-      "code": "lgd",
-      "name": "Legends Room"
-    }
+    "code": "hmq",
+    "name": "Humaniq"
   },
   {
-    "symbol": "ethlsk",
-    "quote": {
-      "code": "lsk",
-      "name": "Lisk"
-    }
+    "code": "jpy",
+    "name": "Japanese Yen"
   },
   {
-    "symbol": "ethltc",
-    "quote": {
-      "code": "ltc",
-      "name": "Litecoin"
-    }
+    "code": "lgd",
+    "name": "Legends Room"
   },
   {
-    "symbol": "ethlun",
-    "quote": {
-      "code": "lun",
-      "name": "Lunyr"
-    }
+    "code": "lsk",
+    "name": "Lisk"
   },
   {
-    "symbol": "ethmco",
-    "quote": {
-      "code": "mco",
-      "name": "Monaco"
-    }
+    "code": "ltc",
+    "name": "Litecoin"
   },
   {
-    "symbol": "ethmtl",
-    "quote": {
-      "code": "mtl",
-      "name": "Metal"
-    }
+    "code": "lun",
+    "name": "Lunyr"
   },
   {
-    "symbol": "ethmyst",
-    "quote": {
-      "code": "myst",
-      "name": "Mysterium"
-    }
+    "code": "mco",
+    "name": "Monaco"
   },
   {
-    "symbol": "ethnmr",
-    "quote": {
-      "code": "nmr",
-      "name": "Numeraire"
-    }
+    "code": "mtl",
+    "name": "Metal"
   },
   {
-    "symbol": "ethomg",
-    "quote": {
-      "code": "omg",
-      "name": "OmiseGO"
-    }
+    "code": "myst",
+    "name": "Mysterium"
   },
   {
-    "symbol": "ethpay",
-    "quote": {
-      "code": "pay",
-      "name": "TenX"
-    }
+    "code": "nmr",
+    "name": "Numeraire"
   },
   {
-    "symbol": "ethptoy",
-    "quote": {
-      "code": "ptoy",
-      "name": "Patientory"
-    }
+    "code": "omg",
+    "name": "OmiseGO"
   },
   {
-    "symbol": "ethqrl",
-    "quote": {
-      "code": "qrl",
-      "name": "Quantum-Resistant Ledger"
-    }
+    "code": "pay",
+    "name": "TenX"
   },
   {
-    "symbol": "ethqtum",
-    "quote": {
-      "code": "qtum",
-      "name": "Qtum"
-    }
+    "code": "ptoy",
+    "name": "Patientory"
   },
   {
-    "symbol": "ethrep",
-    "quote": {
-      "code": "rep",
-      "name": "Augur"
-    }
+    "code": "qrl",
+    "name": "Quantum-Resistant Ledger"
   },
   {
-    "symbol": "ethrlc",
-    "quote": {
-      "code": "rlc",
-      "name": "iEx.ec"
-    }
+    "code": "qtum",
+    "name": "Qtum"
   },
   {
-    "symbol": "ethrub",
-    "quote": {
-      "code": "rub",
-      "name": "Russian Ruble"
-    }
+    "code": "rep",
+    "name": "Augur"
   },
   {
-    "symbol": "ethsc",
-    "quote": {
-      "code": "sc",
-      "name": "Siacoin"
-    }
+    "code": "rlc",
+    "name": "iEx.ec"
   },
   {
-    "symbol": "ethsngls",
-    "quote": {
-      "code": "sngls",
-      "name": "SingularDTV"
-    }
+    "code": "rub",
+    "name": "Russian Ruble"
   },
   {
-    "symbol": "ethsnt",
-    "quote": {
-      "code": "snt",
-      "name": "Status"
-    }
+    "code": "sc",
+    "name": "Siacoin"
   },
   {
-    "symbol": "ethsteem",
-    "quote": {
-      "code": "steem",
-      "name": "Steem"
-    }
+    "code": "sngls",
+    "name": "SingularDTV"
   },
   {
-    "symbol": "ethstorj",
-    "quote": {
-      "code": "storj",
-      "name": "Storj"
-    }
+    "code": "snt",
+    "name": "Status"
   },
   {
-    "symbol": "ethtime",
-    "quote": {
-      "code": "time",
-      "name": "ChronoBank"
-    }
+    "code": "steem",
+    "name": "Steem"
   },
   {
-    "symbol": "ethtkn",
-    "quote": {
-      "code": "tkn",
-      "name": "TokenCard"
-    }
+    "code": "storj",
+    "name": "Storj"
   },
   {
-    "symbol": "ethtrst",
-    "quote": {
-      "code": "trst",
-      "name": "WeTrust"
-    }
+    "code": "time",
+    "name": "ChronoBank"
   },
   {
-    "symbol": "ethusd",
-    "quote": {
-      "code": "usd",
-      "name": "United States Dollar"
-    }
+    "code": "tkn",
+    "name": "TokenCard"
   },
   {
-    "symbol": "ethwings",
-    "quote": {
-      "code": "wings",
-      "name": "Wings"
-    }
+    "code": "trst",
+    "name": "WeTrust"
   },
   {
-    "symbol": "ethxem",
-    "quote": {
-      "code": "xem",
-      "name": "NEM"
-    }
+    "code": "uah",
+    "name": "Ukrainian Hryvnia"
   },
   {
-    "symbol": "ethxlm",
-    "quote": {
-      "code": "xlm",
-      "name": "Stellar Lumen"
-    }
+    "code": "usd",
+    "name": "United States Dollar"
   },
   {
-    "symbol": "ethxmr",
-    "quote": {
-      "code": "xmr",
-      "name": "Monero"
-    }
+    "code": "wings",
+    "name": "Wings"
   },
   {
-    "symbol": "ethxrp",
-    "quote": {
-      "code": "xrp",
-      "name": "Ripple"
-    }
+    "code": "xem",
+    "name": "NEM"
   },
   {
-    "symbol": "ethzec",
-    "quote": {
-      "code": "zec",
-      "name": "Zcash"
-    }
+    "code": "xlm",
+    "name": "Stellar Lumen"
   },
   {
-    "symbol": "ethdai",
-    "quote": {
-      "code": "dai",
-      "name": "DAI"
-    }
+    "code": "xmr",
+    "name": "Monero"
   },
   {
-    "symbol": "ethusdc",
-    "quote": {
-      "code": "usdc",
-      "name": "USD Coin"
-    }
+    "code": "xrp",
+    "name": "Ripple"
   },
   {
-    "symbol": "ethusdt",
-    "quote": {
-      "code": "usdt",
-      "name": "Tether"
-    }
+    "code": "zec",
+    "name": "Zcash"
   },
   {
-    "symbol": "ethinr",
-    "quote": {
-      "code": "inr",
-      "name": "Indian Rupee"
-    }
+    "code": "dai",
+    "name": "DAI"
   },
   {
-    "symbol": "eth1st",
-    "quote": {
-      "code": "1st",
-      "name": "FirstBlood"
-    }
-  },
-  {
-    "symbol": "ethuah",
-    "quote": {
-      "code": "uah",
-      "name": "Ukrainian Hryvnia"
-    }
-  },
-  {
-    "symbol": "ethsai",
-    "quote": {
-      "code": "sai",
-      "name": "SAI"
-    }
+    "code": "sai",
+    "name": "SAI"
   }
 ]
 
-const wrapper = { objects };
-
-export default wrapper;
-
+export default currencies;

--- a/src/currencies.ts
+++ b/src/currencies.ts
@@ -1,251 +1,256 @@
-const currencies: Array<object> = [
+interface Options {
+  code?: string
+  name?: string
+}
+
+const currencies: Array<Options> = [
   {
-    "code": "aud",
-    "name": "Australian Dollar"
+    code: "aud",
+    name: "Australian Dollar"
   },
   {
-    "code": "hkd",
-    "name": "Hong Kong Dollar"
+    code: "hkd",
+    name: "Hong Kong Dollar"
   },
   {
-    "code": "sgd",
-    "name": "Singapore Dollar"
+    code: "sgd",
+    name: "Singapore Dollar"
   },
   {
-    "code": "idr",
-    "name": "Indonesian Rupiah"
+    code: "idr",
+    name: "Indonesian Rupiah"
   },
   {
-    "code": "inr",
-    "name": "Indian Rupee"
+    code: "inr",
+    name: "Indian Rupee"
   },
   {
-    "code": "php",
-    "name": "Philippine Peso"
+    code: "php",
+    name: "Philippine Peso"
   },
   {
-    "code": "1st",
-    "name": "FirstBlood"
+    code: "1st",
+    name: "FirstBlood"
   },
   {
-    "code": "adt",
-    "name": "adToken"
+    code: "adt",
+    name: "adToken"
   },
   {
-    "code": "adx",
-    "name": "AdEx"
+    code: "adx",
+    name: "AdEx"
   },
   {
-    "code": "ant",
-    "name": "Aragon"
+    code: "ant",
+    name: "Aragon"
   },
   {
-    "code": "bat",
-    "name": "Basic Attention Token"
+    code: "bat",
+    name: "Basic Attention Token"
   },
   {
-    "code": "bnt",
-    "name": "Bancor"
+    code: "bnt",
+    name: "Bancor"
   },
   {
-    "code": "btc",
-    "name": "Bitcoin"
+    code: "btc",
+    name: "Bitcoin"
   },
   {
-    "code": "cad",
-    "name": "Canadian Dollar"
+    code: "cad",
+    name: "Canadian Dollar"
   },
   {
-    "code": "cfi",
-    "name": "Cofound.it"
+    code: "cfi",
+    name: "Cofound.it"
   },
   {
-    "code": "crb",
-    "name": "CreditBit"
+    code: "crb",
+    name: "CreditBit"
   },
   {
-    "code": "cvc",
-    "name": "Civic"
+    code: "cvc",
+    name: "Civic"
   },
   {
-    "code": "dash",
-    "name": "Dash"
+    code: "dash",
+    name: "Dash"
   },
   {
-    "code": "dgd",
-    "name": "DigixDAO"
+    code: "dgd",
+    name: "DigixDAO"
   },
   {
-    "code": "etc",
-    "name": "Ethereum Classic"
+    code: "etc",
+    name: "Ethereum Classic"
   },
   {
-    "code": "eur",
-    "name": "Euro"
+    code: "eur",
+    name: "Euro"
   },
   {
-    "code": "fun",
-    "name": "FunFair"
+    code: "fun",
+    name: "FunFair"
   },
   {
-    "code": "gbp",
-    "name": "Pound Sterling"
+    code: "gbp",
+    name: "Pound Sterling"
   },
   {
-    "code": "gno",
-    "name": "Gnosis"
+    code: "gno",
+    name: "Gnosis"
   },
   {
-    "code": "gnt",
-    "name": "Golem"
+    code: "gnt",
+    name: "Golem"
   },
   {
-    "code": "gup",
-    "name": "Matchpool"
+    code: "gup",
+    name: "Matchpool"
   },
   {
-    "code": "hmq",
-    "name": "Humaniq"
+    code: "hmq",
+    name: "Humaniq"
   },
   {
-    "code": "jpy",
-    "name": "Japanese Yen"
+    code: "jpy",
+    name: "Japanese Yen"
   },
   {
-    "code": "lgd",
-    "name": "Legends Room"
+    code: "lgd",
+    name: "Legends Room"
   },
   {
-    "code": "lsk",
-    "name": "Lisk"
+    code: "lsk",
+    name: "Lisk"
   },
   {
-    "code": "ltc",
-    "name": "Litecoin"
+    code: "ltc",
+    name: "Litecoin"
   },
   {
-    "code": "lun",
-    "name": "Lunyr"
+    code: "lun",
+    name: "Lunyr"
   },
   {
-    "code": "mco",
-    "name": "Monaco"
+    code: "mco",
+    name: "Monaco"
   },
   {
-    "code": "mtl",
-    "name": "Metal"
+    code: "mtl",
+    name: "Metal"
   },
   {
-    "code": "myst",
-    "name": "Mysterium"
+    code: "myst",
+    name: "Mysterium"
   },
   {
-    "code": "nmr",
-    "name": "Numeraire"
+    code: "nmr",
+    name: "Numeraire"
   },
   {
-    "code": "omg",
-    "name": "OmiseGO"
+    code: "omg",
+    name: "OmiseGO"
   },
   {
-    "code": "pay",
-    "name": "TenX"
+    code: "pay",
+    name: "TenX"
   },
   {
-    "code": "ptoy",
-    "name": "Patientory"
+    code: "ptoy",
+    name: "Patientory"
   },
   {
-    "code": "qrl",
-    "name": "Quantum-Resistant Ledger"
+    code: "qrl",
+    name: "Quantum-Resistant Ledger"
   },
   {
-    "code": "qtum",
-    "name": "Qtum"
+    code: "qtum",
+    name: "Qtum"
   },
   {
-    "code": "rep",
-    "name": "Augur"
+    code: "rep",
+    name: "Augur"
   },
   {
-    "code": "rlc",
-    "name": "iEx.ec"
+    code: "rlc",
+    name: "iEx.ec"
   },
   {
-    "code": "rub",
-    "name": "Russian Ruble"
+    code: "rub",
+    name: "Russian Ruble"
   },
   {
-    "code": "sc",
-    "name": "Siacoin"
+    code: "sc",
+    name: "Siacoin"
   },
   {
-    "code": "sngls",
-    "name": "SingularDTV"
+    code: "sngls",
+    name: "SingularDTV"
   },
   {
-    "code": "snt",
-    "name": "Status"
+    code: "snt",
+    name: "Status"
   },
   {
-    "code": "steem",
-    "name": "Steem"
+    code: "steem",
+    name: "Steem"
   },
   {
-    "code": "storj",
-    "name": "Storj"
+    code: "storj",
+    name: "Storj"
   },
   {
-    "code": "time",
-    "name": "ChronoBank"
+    code: "time",
+    name: "ChronoBank"
   },
   {
-    "code": "tkn",
-    "name": "TokenCard"
+    code: "tkn",
+    name: "TokenCard"
   },
   {
-    "code": "trst",
-    "name": "WeTrust"
+    code: "trst",
+    name: "WeTrust"
   },
   {
-    "code": "uah",
-    "name": "Ukrainian Hryvnia"
+    code: "uah",
+    name: "Ukrainian Hryvnia"
   },
   {
-    "code": "usd",
-    "name": "United States Dollar"
+    code: "usd",
+    name: "United States Dollar"
   },
   {
-    "code": "wings",
-    "name": "Wings"
+    code: "wings",
+    name: "Wings"
   },
   {
-    "code": "xem",
-    "name": "NEM"
+    code: "xem",
+    name: "NEM"
   },
   {
-    "code": "xlm",
-    "name": "Stellar Lumen"
+    code: "xlm",
+    name: "Stellar Lumen"
   },
   {
-    "code": "xmr",
-    "name": "Monero"
+    code: "xmr",
+    name: "Monero"
   },
   {
-    "code": "xrp",
-    "name": "Ripple"
+    code: "xrp",
+    name: "Ripple"
   },
   {
-    "code": "zec",
-    "name": "Zcash"
+    code: "zec",
+    name: "Zcash"
   },
   {
-    "code": "dai",
-    "name": "DAI"
+    code: "dai",
+    name: "DAI"
   },
   {
-    "code": "sai",
-    "name": "SAI"
+    code: "sai",
+    name: "SAI"
   }
 ]
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import 'isomorphic-fetch';
 import * as util from './util';
+import currencies from './currencies';
 
 export * from './assets/AccountTrackerController';
 export * from './user/AddressBookController';
@@ -20,4 +21,7 @@ export * from './assets/TokenRatesController';
 export * from './transaction/TransactionController';
 export * from './message-manager/PersonalMessageManager';
 export * from './message-manager/TypedMessageManager';
-export { util };
+export {
+  util,
+  currencies
+};

--- a/tests/currencies.test.ts
+++ b/tests/currencies.test.ts
@@ -1,0 +1,16 @@
+import currencies from '../src/currencies';
+
+const toCheck = [
+  "eur",
+  "etc",
+  "usd",
+  "sai"
+];
+
+describe('Test for some currencies', () => {
+  it('should have the important ones', () => {
+    toCheck.forEach(value => {
+      expect(currencies.some(currency => currency.code === value))
+    })
+	});
+})


### PR DESCRIPTION
A user reported https://github.com/MetaMask/metamask-mobile/issues/1777 for which I patched with https://github.com/MetaMask/metamask-mobile/pull/1787 but after giving it some further thought I realised it would probably make _more_ sense to add this to `controllers` so we can share this across products (making this the single source of truth for both the extension and mobile).

TLDR; this will effectively replace: https://github.com/MetaMask/metamask-mobile/blob/master/app/util/infura-conversion.json (on mobile) and https://github.com/MetaMask/metamask-extension/blob/develop/ui/app/helpers/constants/available-conversions.json (on the extension). 

<strike>I'm going to open a corresponding PR in mobile that will work with this (once it's merged and published)</strike>

that's done now, the mobile PR changes to consume this are open here: https://github.com/MetaMask/metamask-mobile/pull/1792

if it makes sense I can also open one on the extension so we're using this for conversions in both.

I'm also not entirely satisfied with this structure and open to suggestions. this might be a little weird because it doesn't really follow the "controllers" conversion we're using?

<strike>it would also probably make sense to add a couple tests verifying some of the more important currencies are here (I was surprised to discover we were missing SAI on mobile)</strike>

I added this and now I am contemplating if it's of value :thinking: 

/cc @whymarrh @Gudahtt @estebanmino 