### PR TITLE
Use Infura v3 API

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "await-semaphore": "^0.1.3",
     "eth-contract-metadata": "^1.11.0",
     "eth-ens-namehash": "^2.0.8",
-    "eth-json-rpc-infura": "^4.0.1",
+    "eth-json-rpc-infura": "^5.0.0",
     "eth-keyring-controller": "^5.6.1",
     "eth-method-registry": "1.1.0",
     "eth-phishing-detect": "^1.1.13",

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -35,9 +35,11 @@ export interface ProviderConfig {
  *
  * Network controller configuration
  *
+ * @property infuraProjectId - an Infura project ID
  * @property providerConfig - web3-provider-engine configuration
  */
 export interface NetworkConfig extends BaseConfig {
+  infuraProjectId?: string;
   providerConfig: ProviderConfig;
 }
 
@@ -103,7 +105,7 @@ export class NetworkController extends BaseController<NetworkConfig, NetworkStat
   }
 
   private setupInfuraProvider(type: NetworkType) {
-    const infuraProvider = createInfuraProvider({ network: type });
+    const infuraProvider = createInfuraProvider({ network: type, projectId: this.config.infuraProjectId });
     const infuraSubprovider = new Subprovider(infuraProvider);
     const config = {
       ...this.internalProviderConfig,

--- a/tests/NetworkController.test.ts
+++ b/tests/NetworkController.test.ts
@@ -17,32 +17,47 @@ describe('NetworkController', () => {
   });
 
   it('should create a provider instance for default infura network', () => {
-    const controller = new NetworkController();
+    const testConfig = {
+      infuraProjectId: 'foo',
+    };
+    const controller = new NetworkController(testConfig);
     controller.providerConfig = {} as ProviderConfig;
     controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
   });
 
   it('should create a provider instance for kovan infura network', () => {
-    const controller = new NetworkController(undefined, { network: '0', provider: { type: 'kovan' } });
+    const testConfig = {
+      infuraProjectId: 'foo',
+    };
+    const controller = new NetworkController(testConfig, { network: '0', provider: { type: 'kovan' } });
     controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
   });
 
   it('should create a provider instance for rinkeby infura network', () => {
-    const controller = new NetworkController(undefined, { network: '0', provider: { type: 'rinkeby' } });
+    const testConfig = {
+      infuraProjectId: 'foo',
+    };
+    const controller = new NetworkController(testConfig, { network: '0', provider: { type: 'rinkeby' } });
     controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
   });
 
   it('should create a provider instance for ropsten infura network', () => {
-    const controller = new NetworkController(undefined, { network: '0', provider: { type: 'ropsten' } });
+    const testConfig = {
+      infuraProjectId: 'foo',
+    };
+    const controller = new NetworkController(testConfig, { network: '0', provider: { type: 'ropsten' } });
     controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
   });
 
   it('should create a provider instance for mainnet infura network', () => {
-    const controller = new NetworkController(undefined, { network: '0', provider: { type: 'mainnet' } });
+    const testConfig = {
+      infuraProjectId: 'foo',
+    };
+    const controller = new NetworkController(testConfig, { network: '0', provider: { type: 'mainnet' } });
     controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
   });
@@ -78,7 +93,10 @@ describe('NetworkController', () => {
   });
 
   it('should verify the network on an error', async () => {
-    const controller = new NetworkController(undefined, { network: 'loading' });
+    const testConfig = {
+      infuraProjectId: 'foo',
+    };
+    const controller = new NetworkController(testConfig, { network: 'loading' });
     controller.providerConfig = {} as ProviderConfig;
     controller.lookupNetwork = stub();
     controller.provider.emit('error', {});
@@ -87,7 +105,12 @@ describe('NetworkController', () => {
 
   it('should look up the network', () => {
     return new Promise((resolve) => {
-      const controller = new NetworkController();
+      const testConfig = {
+        // This test needs a real project ID as it makes a test
+        // `eth_version` call; https://github.com/MetaMask/controllers/issues/1
+        infuraProjectId: '341eacb578dd44a1a049cbc5f6fd4035',
+      };
+      const controller = new NetworkController(testConfig);
       controller.providerConfig = {} as ProviderConfig;
       setTimeout(() => {
         expect(controller.state.network !== 'loading').toBe(true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2517,10 +2517,20 @@ eth-json-rpc-infura@^4.0.1:
     json-rpc-engine "^5.1.3"
     tape "^4.8.0"
 
-eth-json-rpc-middleware@^4.1.4, eth-json-rpc-middleware@^4.1.5:
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/eth-json-rpc-middleware/-/eth-json-rpc-middleware-4.1.6.tgz#c625a38888b7697fbb4fcbf06dae17251ac3b76e"
-  integrity sha512-8AdegPz5qmSRKYyFJhVdkM5Uv3L3AOqD8sIctZuQxmyCsUoZDfDwbElpcrAODAA43cei69t64leis016rR690g==
+eth-json-rpc-infura@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eth-json-rpc-infura/-/eth-json-rpc-infura-5.0.0.tgz#a666efe860659ffa09e918abdf9aab9f2434e508"
+  integrity sha512-TvRgnDHsxNblUpFo1KTqsgfeZ0rMEg6Ga+v+Zbqjb467txODg6oPamKJKh/odOs+MXtYpt9e7d4yJCy+5azq5w==
+  dependencies:
+    eth-json-rpc-middleware "^4.4.0"
+    eth-rpc-errors "^3.0.0"
+    json-rpc-engine "^5.1.3"
+    node-fetch "^2.6.0"
+
+eth-json-rpc-middleware@^4.1.4, eth-json-rpc-middleware@^4.1.5, eth-json-rpc-middleware@^4.4.0:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/eth-json-rpc-middleware/-/eth-json-rpc-middleware-4.4.1.tgz#07d3dd0724c24a8d31e4a172ee96271da71b4228"
+  integrity sha512-yoSuRgEYYGFdVeZg3poWOwAlRI+MoBIltmOB86MtpoZjvLbou9EB/qWMOWSmH2ryCWLW97VYY6NWsmWm3OAA7A==
   dependencies:
     btoa "^1.2.1"
     clone "^2.1.1"
@@ -2578,6 +2588,13 @@ eth-rpc-errors@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/eth-rpc-errors/-/eth-rpc-errors-2.1.1.tgz#00a7d6c8a9c864a8ab7d0356be20964e5bee4b13"
   integrity sha512-MY3zAa5ZF8hvgQu1HOF9agaK5GgigBRGpTJ8H0oVlE0NqMu13CW6syyjLXdeIDCGQTbUeHliU1z9dVmvMKx1Tg==
+  dependencies:
+    fast-safe-stringify "^2.0.6"
+
+eth-rpc-errors@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eth-rpc-errors/-/eth-rpc-errors-3.0.0.tgz#d7b22653c70dbf9defd4ef490fd08fe70608ca10"
+  integrity sha512-iPPNHPrLwUlR9xCSYm7HHQjWBasor3+KZfRvwEWxMz3ca0yqnlBeJrnyphkGIXZ4J7AMAaOLmwy4AWhnxOiLxg==
   dependencies:
     fast-safe-stringify "^2.0.6"
 
@@ -5165,6 +5182,11 @@ node-fetch@^1.0.1, node-fetch@~1.7.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-fetch@^2.6.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
This PR updates the project to use Infura's v3 API.

Tasks:

- [x] Merge MetaMask/eth-json-rpc-infura#32
- [x] Update the `eth-json-rpc-infura` dependency here
- [x] Pass a project ID to the `NetworkController`

**Breaking change**:

A project ID is now required for all instantiations of the `NetworkController` that are backed by Infura.

```ts
const controller = new NetworkController({
  infuraProjectId: 'foo',
}, {
  network: '1',
  provider: { type: 'mainnet' },
});
```