### PR TITLE
Remove duplicate call to setupInfuraProvider

### DIFF
--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -76,8 +76,6 @@ export class NetworkController extends BaseController<NetworkConfig, NetworkStat
     switch (type) {
       case 'kovan':
       case 'mainnet':
-        this.setupInfuraProvider(type);
-        break;
       case 'rinkeby':
       case 'goerli':
       case 'ropsten':


### PR DESCRIPTION
This PR removes a duplicate call to `setupInfuraProvider` and merges all of the Infura cases into the single call.