### PR TITLE
Mark initial state and config as readonly

### DIFF
--- a/src/BaseController.ts
+++ b/src/BaseController.ts
@@ -63,9 +63,9 @@ export class BaseController<C extends BaseConfig, S extends BaseState> {
    */
   requiredControllers: string[] = [];
 
-  private initialConfig: C;
+  private readonly initialConfig: C;
 
-  private initialState: S;
+  private readonly initialState: S;
 
   private internalConfig: C = this.defaultConfig;
 


### PR DESCRIPTION
The `initialState` and `initialConfig` properties are only assigned in the constructor so they can be marked as `readonly`.