### PR TITLE
Move ESLint ignore patterns into config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,0 @@
-*.js
-!.eslintrc.js
-!jest.config.js
-node_modules
-dist
-coverage
-*.d.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,15 @@ module.exports = {
     '@metamask/eslint-config/config/nodejs',
     '@metamask/eslint-config/config/typescript',
   ],
+  ignorePatterns: [
+    '*.js',
+    '!.eslintrc.js',
+    '!jest.config.js',
+    'node_modules',
+    'dist',
+    'coverage',
+    '*.d.ts',
+  ],
   overrides: [{
     files: [
       '.eslintrc.js',


### PR DESCRIPTION
This PR moves the ESLint ignore patterns into the `.eslintrc.js` file to keep everything together.