### PR TITLE
Enable and fix jest/no-identical-title issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -71,7 +71,6 @@ module.exports = {
     'require-unicode-regexp': 'off',
 
     'jest/expect-expect': 'off',
-    'jest/no-identical-title': 'off',
     'jest/no-test-return-statement': 'off',
     'jest/no-truthy-falsy': 'off',
     'jest/no-try-expect': 'off',

--- a/tests/AddressBookController.test.ts
+++ b/tests/AddressBookController.test.ts
@@ -42,24 +42,6 @@ describe('AddressBookController', () => {
     });
   });
 
-  it('should add a contact entry with chainId and memo', () => {
-    const controller = new AddressBookController();
-    controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo', '2', 'account 2');
-    expect(controller.state).toEqual({
-      addressBook: {
-        2: {
-          '0x32Be343B94f860124dC4fEe278FDCBD38C102D88': {
-            address: '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
-            chainId: '2',
-            isEns: false,
-            memo: 'account 2',
-            name: 'foo',
-          },
-        },
-      },
-    });
-  });
-
   it('should add multiple contact entries with different chainIds', () => {
     const controller = new AddressBookController();
     controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo', '1', 'account 2');

--- a/tests/PreferencesController.test.ts
+++ b/tests/PreferencesController.test.ts
@@ -45,7 +45,7 @@ describe('PreferencesController', () => {
     expect(controller.state.identities['0xBaZ'].name).toBe('qux');
   });
 
-  it('should set identity label', () => {
+  it('should sync identities', () => {
     const controller = new PreferencesController();
     controller.addIdentities(['foo', 'bar']);
     controller.syncIdentities(['foo', 'bar']);

--- a/tests/TypedMessageManager.test.ts
+++ b/tests/TypedMessageManager.test.ts
@@ -108,7 +108,7 @@ describe('TypedMessageManager', () => {
     });
   });
 
-  it('should reject a message', () => {
+  it("should set message status as 'errored'", () => {
     return new Promise(async (resolve) => {
       const controller = new TypedMessageManager();
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -351,7 +351,7 @@ describe('util', () => {
       ).not.toThrow();
     });
 
-    it('should not throw if data is correct', () => {
+    it('should identify smart contract code', () => {
       const toSmartContract1 = util.isSmartContractCode('');
       const toSmartContract2 = util.isSmartContractCode('0x');
       const toSmartContract3 = util.isSmartContractCode('0x0');
@@ -478,7 +478,7 @@ describe('util', () => {
       expect(parsed).toEqual({});
     });
 
-    it('should fetch first if response is faster than timeout', async () => {
+    it('should fail fetch with timeout', async () => {
       let error;
       try {
         await util.timeoutFetch(SOME_API, {}, 100);


### PR DESCRIPTION
This PR enables `jest/no-identical-title` and fixes the issues raised. 5 issues were fixed, one of which was a duplicate test.