### PR TITLE
Remove If-None-Match header from phishing config requests

### DIFF
--- a/src/third-party/PhishingController.ts
+++ b/src/third-party/PhishingController.ts
@@ -54,8 +54,6 @@ export interface PhishingState extends BaseState {
 export class PhishingController extends BaseController<PhishingConfig, PhishingState> {
   private configUrl = 'https://cdn.jsdelivr.net/gh/MetaMask/eth-phishing-detect@master/src/config.json';
 
-  private configEtag = '';
-
   private detector: any;
 
   private handle?: NodeJS.Timer;
@@ -141,15 +139,10 @@ export class PhishingController extends BaseController<PhishingConfig, PhishingS
   }
 
   private async queryConfig(input: RequestInfo): Promise<EthPhishingResponse | null> {
-    const response = await fetch(input, {
-      headers: {
-        'If-None-Match': this.configEtag,
-      },
-    });
+    const response = await fetch(input);
 
     switch (response.status) {
       case 200: {
-        this.configEtag = response.headers.get('ETag') || /* istanbul ignore next */ '';
         return await response.json();
       }
       case 304:


### PR DESCRIPTION
Refs #256

This PR removes the ` If-None-Match` header from the requests for the phishing list. The header was a holder from the old implementation that used GitHub's content API (#232) and is no longer needed. (The header also caused the request to fail when a UA enforced `Access-Control-Allow-Headers`, which is missing on the jsDelivr response.)

Removing this header reverts the fetch cache mode to `default`:

> `"default"`
>
> Fetch will inspect the HTTP cache on the way to the network. If the HTTP cache contains a matching fresh response it will be returned. If the HTTP cache contains a matching stale-while-revalidate response it will be returned, and a conditional network fetch will be made to update the entry in the HTTP cache. If the HTTP cache contains a matching stale response, a conditional network fetch will be returned to update the entry in the HTTP cache. Otherwise, a non-conditional network fetch will be returned to update the entry in the HTTP cache.

As a result the browser will take care of the conditional network fetch.

This—as a bonus—removes the CORS preflight request as there are no custom options anymore.