### PR TITLE
Add addNewAccountWithoutUpdate method

### DIFF
--- a/src/keyring/KeyringController.ts
+++ b/src/keyring/KeyringController.ts
@@ -152,6 +152,22 @@ export class KeyringController extends BaseController<KeyringConfig, KeyringStat
   }
 
   /**
+   * Adds a new account to the default (first) HD seed phrase keyring without updating identities in preferences
+   *
+   * @returns - Promise resolving to current state when the account is added
+   */
+  async addNewAccountWithoutUpdate(): Promise<KeyringMemState> {
+    const primaryKeyring = privates.get(this).keyring.getKeyringsByType('HD Key Tree')[0];
+    /* istanbul ignore if */
+    if (!primaryKeyring) {
+      throw new Error('No HD keyring found');
+    }
+    await privates.get(this).keyring.addNewAccount(primaryKeyring);
+    await this.verifySeedPhrase();
+    return this.fullUpdate();
+  }
+
+  /**
    * Effectively the same as creating a new keychain then populating it
    * using the given seed phrase
    *

--- a/tests/KeyringController.test.ts
+++ b/tests/KeyringController.test.ts
@@ -40,10 +40,23 @@ describe('KeyringController', () => {
   });
 
   it('should add new account', async () => {
+    const initialIdentitiesLength = Object.keys(preferences.state.identities).length;
     const currentKeyringMemState = await keyringController.addNewAccount();
     expect(initialState.keyrings).toHaveLength(1);
     expect(initialState.keyrings[0].accounts).not.toBe(currentKeyringMemState.keyrings);
     expect(currentKeyringMemState.keyrings[0].accounts).toHaveLength(2);
+    const identitiesLength = Object.keys(preferences.state.identities).length;
+    expect(identitiesLength).toBeGreaterThan(initialIdentitiesLength);
+  });
+
+  it('should add new account without updating', async () => {
+    const initialIdentitiesLength = Object.keys(preferences.state.identities).length;
+    const currentKeyringMemState = await keyringController.addNewAccountWithoutUpdate();
+    expect(initialState.keyrings).toHaveLength(1);
+    expect(initialState.keyrings[0].accounts).not.toBe(currentKeyringMemState.keyrings);
+    expect(currentKeyringMemState.keyrings[0].accounts).toHaveLength(2);
+    const identitiesLength = Object.keys(preferences.state.identities).length;
+    expect(identitiesLength).toEqual(initialIdentitiesLength);
   });
 
   it('should create new vault and keychain', async () => {


### PR DESCRIPTION
This adds a new method for adding accounts _without_ updating identities in the preferences controller

this is currently being used in https://github.com/MetaMask/metamask-mobile/pull/1879