### PR TITLE
Add approval controller

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ workflows:
   build-test:
     jobs:
       - prep-deps
-      - test-build:
+      - prep-build:
           requires:
             - prep-deps
       - test-lint:
@@ -12,13 +12,12 @@ workflows:
             - prep-deps
       - test-unit:
           requires:
-            - prep-deps
+            - prep-build
       - test-format:
           requires:
-            - prep-deps
+            - prep-build
       - all-tests-pass:
           requires:
-            - test-build
             - test-lint
             - test-unit
             - test-format
@@ -43,6 +42,21 @@ jobs:
           - node_modules
           - build-artifacts
 
+  prep-build:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Build
+          command: yarn build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dist
+
   test-format:
     docker:
       - image: circleci/node:10
@@ -53,17 +67,6 @@ jobs:
       - run:
           name: Format
           command: yarn format
-
-  test-build:
-    docker:
-      - image: circleci/node:10
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: Build project
-          command: yarn build
 
   test-lint:
     docker:

--- a/package.json
+++ b/package.json
@@ -95,10 +95,12 @@
       "^.+\\.tsx?$": "ts-jest"
     },
     "testMatch": [
-      "**/*.test.ts"
+      "**/*.test.ts",
+      "**/*.test.js"
     ],
     "coveragePathIgnorePatterns": [
       "/node_modules/",
+      "dist/BaseController*",
       "tests/"
     ],
     "coverageThreshold": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "human-standard-token-abi": "^2.0.0",
     "isomorphic-fetch": "^3.0.0",
     "jsonschema": "^1.2.4",
+    "nanoid": "^3.1.12",
     "percentile": "^1.2.1",
     "single-call-balance-checker-abi": "^1.0.0",
     "uuid": "^3.3.2",

--- a/src/approval/ApprovalController.ts
+++ b/src/approval/ApprovalController.ts
@@ -1,0 +1,382 @@
+import BaseController, { BaseConfig, BaseState } from '../BaseController';
+
+const { ethErrors } = require('eth-rpc-errors');
+const nanoid: () => string = require('nanoid');
+
+const DEFAULT_TYPE = Symbol('DEFAULT_APPROVAL_TYPE');
+const STORE_KEY = 'pendingApprovals';
+
+type ApprovalType = string | typeof DEFAULT_TYPE;
+
+type ApprovalPromiseResolve = (value?: unknown) => void;
+type ApprovalPromiseReject = (error?: Error) => void;
+
+type RequestData = Record<string, unknown>;
+
+interface ApprovalCallbacks {
+  resolve: ApprovalPromiseResolve;
+  reject: ApprovalPromiseReject;
+}
+
+/**
+ * Data associated with a pending approval.
+ */
+export interface ApprovalInfo {
+  id: string;
+  origin: string;
+  type?: string;
+  requestData?: RequestData;
+}
+
+export interface ApprovalConfig extends BaseConfig {
+  showApprovalRequest: () => void;
+}
+
+export interface ApprovalState extends BaseState {
+  [STORE_KEY]: { [approvalId: string]: ApprovalInfo };
+}
+
+const getAlreadyPendingMessage = (origin: string, type: ApprovalType) => (
+  `Request ${type === DEFAULT_TYPE ? '' : `of type '${type}' `}already pending for origin ${origin}. Please wait.`
+);
+
+const defaultState = { [STORE_KEY]: {} };
+
+/**
+ * Controller for keeping track of pending approvals by id and/or origin and
+ * type pair.
+ *
+ * Useful for managing requests that require user approval, and restricting
+ * the number of approvals a particular origin can have pending at any one time.
+ */
+export default class ApprovalController extends BaseController<ApprovalConfig, ApprovalState> {
+
+  private _approvals: Map<string, ApprovalCallbacks>;
+
+  private _origins: Map<string, Set<ApprovalType>>;
+
+  private _showApprovalRequest: () => void;
+
+  /**
+   * @param opts - Options bag
+   * @param opts.showApprovalRequest - Function for opening the MetaMask user
+   * confirmation UI.
+   */
+  constructor(config: ApprovalConfig, state?: ApprovalState) {
+    super(config, state || defaultState);
+
+    this._approvals = new Map();
+
+    this._origins = new Map();
+
+    this._showApprovalRequest = config.showApprovalRequest;
+  }
+
+  /**
+   * Adds a pending approval per the given arguments, opens the MetaMask user
+   * confirmation UI, and returns the associated id and approval promise.
+   * An internal, default type will be used if none is specified.
+   *
+   * There can only be one approval per origin and type. An error is thrown if
+   * attempting
+   *
+   * @param opts - Options bag.
+   * @param opts.id - The id of the approval request. A random id will be
+   * generated if none is provided.
+   * @param opts.origin - The origin of the approval request.
+   * @param opts.type - The type associated with the approval request, if
+   * applicable.
+   * @param opts.requestData - The request data associated with the approval
+   * request.
+   * @returns The approval promise.
+   */
+  addAndShowApprovalRequest(opts: {
+    id?: string;
+    origin: string;
+    type?: string;
+    requestData?: RequestData;
+  }): Promise<unknown> {
+    const promise = this._add(opts.origin, opts.requestData, opts.id, opts.type);
+    this._showApprovalRequest();
+    return promise;
+  }
+
+  /**
+   * Adds a pending approval per the given arguments, and returns the associated
+   * id and approval promise. An internal, default type will be used if none is
+   * specified.
+   *
+   * There can only be one approval per origin and type. An error is thrown if
+   * attempting
+   *
+   * @param opts - Options bag.
+   * @param opts.id - The id of the approval request. A random id will be
+   * generated if none is provided.
+   * @param opts.origin - The origin of the approval request.
+   * @param opts.type - The type associated with the approval request, if
+   * applicable.
+   * @param opts.requestData - The request data associated with the approval
+   * request.
+   * @returns The approval promise.
+   */
+  add(opts: {
+    id?: string;
+    origin: string;
+    type?: string;
+    requestData?: RequestData;
+  }): Promise<unknown> {
+    return this._add(opts.origin, opts.requestData, opts.id, opts.type);
+  }
+
+  /**
+   * Gets the pending approval info for the given id.
+   *
+   * @param id - The id of the approval request.
+   * @returns The pending approval data associated with the id.
+   */
+  get(id: string): ApprovalInfo | undefined {
+    const info = this.state[STORE_KEY][id];
+    return info
+      ? { ...info }
+      : undefined;
+  }
+
+  /**
+   * Checks if there's a pending approval request for the given id, or origin
+   * and type pair if no id is specified.
+   * If no type is specified, the default type will be used.
+   *
+   * @param opts - Options bag.
+   * @param opts.id - The id of the approval request.
+   * @param opts.origin - The origin of the approval request.
+   * @param opts.type - The type of the approval request.
+   * @returns True if an approval is found, false otherwise.
+   */
+  has(opts: { id?: string; origin?: string; type?: string }): boolean {
+    const _type = opts.type === undefined ? DEFAULT_TYPE : opts.type;
+    if (!_type) {
+      throw new Error('May not specify falsy type.');
+    }
+
+    if (opts.id) {
+      return this._approvals.has(opts.id);
+    } else if (opts.origin) {
+      return Boolean(this._origins.get(opts.origin)?.has(_type));
+    }
+    throw new Error('Must specify id or origin.');
+  }
+
+  /**
+   * Resolves the promise of the approval with the given id, and deletes the
+   * approval. Throws an error if no such approval exists.
+   *
+   * @param id - The id of the approval request.
+   * @param value - The value to resolve the approval promise with.
+   */
+  resolve(id: string, value?: unknown): void {
+    this._deleteApprovalAndGetCallbacks(id).resolve(value);
+  }
+
+  /**
+   * Rejects the promise of the approval with the given id, and deletes the
+   * approval. Throws an error if no such approval exists.
+   *
+   * @param id - The id of the approval request.
+   * @param error - The error to reject the approval promise with.
+   */
+  reject(id: string, error: Error): void {
+    this._deleteApprovalAndGetCallbacks(id).reject(error);
+  }
+
+  /**
+   * Rejects and deletes all pending approval requests.
+   */
+  clear(): void {
+    const rejectionError = ethErrors.rpc.resourceUnavailable(
+      'The request was rejected; please try again.'
+    );
+
+    for (const id of this._approvals.keys()) {
+      this.reject(id, rejectionError);
+    }
+    this._origins.clear();
+    this.update(defaultState, true);
+  }
+
+  /**
+   * Implementation of add operation.
+   *
+   * @param id - The id of the approval request.
+   * @param origin - The origin of the approval request.
+   * @param type - The type associated with the approval request, if applicable.
+   * @param requestData - The request data associated with the approval request.
+   * @returns The approval promise.
+   */
+  private _add(
+    origin: string,
+    requestData?: RequestData,
+    id: string = nanoid(),
+    type: ApprovalType = DEFAULT_TYPE,
+  ): Promise<unknown> {
+    this._validateAddParams(id, origin, type, requestData);
+
+    if (this._origins.get(origin)?.has(type)) {
+      throw ethErrors.rpc.resourceUnavailable(
+        getAlreadyPendingMessage(origin, type),
+      );
+    }
+
+    // add pending approval
+    return new Promise((resolve, reject) => {
+      this._approvals.set(id, { resolve, reject });
+      this._addPendingApprovalOrigin(origin, type);
+      this._addToStore(id, origin, type, requestData);
+    });
+  }
+
+  /**
+   * Validates parameters to the add method.
+   *
+   * @param id - The id of the approval request.
+   * @param origin - The origin of the approval request.
+   * @param type - The type associated with the approval request.
+   * @param requestData - The request data associated with the approval request.
+   */
+  private _validateAddParams(
+    id: string,
+    origin: string,
+    type: ApprovalType,
+    requestData?: RequestData
+  ): void {
+    let errorMessage = null;
+    if (!id && id !== undefined) {
+      errorMessage = 'May not specify falsy id.';
+    } else if (!origin) {
+      errorMessage = 'Must specify origin.';
+    } else if (this._approvals.has(id)) {
+      errorMessage = `Approval with id '${id}' already exists.`;
+    } else if (!type) {
+      errorMessage = 'May not specify falsy type.';
+    } else if (requestData && (
+      typeof requestData !== 'object' || Array.isArray(requestData)
+    )) {
+      errorMessage = 'Request data must be a plain object if specified.';
+    }
+
+    if (errorMessage) {
+      throw ethErrors.rpc.internal(errorMessage);
+    }
+  }
+
+  /**
+   * Adds an entry to _origins.
+   * Performs no validation.
+   *
+   * @param origin - The origin of the approval request.
+   * @param type - The type associated with the approval request.
+   */
+  private _addPendingApprovalOrigin(origin: string, type: ApprovalType): void {
+    const originSet = this._origins.get(origin) || new Set();
+    originSet.add(type);
+
+    if (!this._origins.has(origin)) {
+      this._origins.set(origin, originSet);
+    }
+  }
+
+  /**
+   * Adds an entry to the store.
+   * Performs no validation.
+   *
+   * @param id - The id of the approval request.
+   * @param origin - The origin of the approval request.
+   * @param type - The type associated with the approval request.
+   * @param requestData - The request data associated with the approval request.
+   */
+  private _addToStore(
+    id: string,
+    origin: string,
+    type: ApprovalType,
+    requestData?: RequestData
+  ): void {
+    const info: ApprovalInfo = { id, origin };
+    // default type is for internal bookkeeping only
+    if (type !== DEFAULT_TYPE) {
+      info.type = type;
+    }
+    if (requestData) {
+      info.requestData = requestData;
+    }
+
+    this.update({
+      [STORE_KEY]: {
+        ...this.state[STORE_KEY],
+        [id]: info,
+      },
+    }, true);
+  }
+
+  /**
+   * Deletes the approval with the given id. The approval promise must be
+   * resolved or reject before this method is called.
+   * Deletion is an internal operation because approval state is solely
+   * managed by this controller.
+   *
+   * @param id - The id of the approval request to be deleted.
+   */
+  private _delete(id: string): void {
+    if (!id) {
+      throw new Error('Expected id to be specified.');
+    }
+
+    if (this._approvals.has(id)) {
+      this._approvals.delete(id);
+
+      const state = this.state[STORE_KEY];
+      const {
+        origin,
+        type = DEFAULT_TYPE,
+      } = state[id] || {};
+
+      this._origins.get(origin)?.delete(type);
+      if (this._isEmptyOrigin(origin)) {
+        this._origins.delete(origin);
+      }
+
+      const newState = { ...state };
+      delete newState[id];
+      this.update({
+        [STORE_KEY]: newState,
+      }, true);
+    }
+  }
+
+  /**
+   * Gets the approval callbacks for the given id, deletes the entry, and then
+   * returns the callbacks for promise resolution.
+   * Throws an error if no approval is found for the given id.
+   *
+   * @param id - The id of the approval request.
+   * @returns The pending approval callbacks associated with the id.
+   */
+  private _deleteApprovalAndGetCallbacks(id: string): ApprovalCallbacks {
+    const callbacks = this._approvals.get(id);
+    if (!callbacks) {
+      throw new Error(`Approval with id '${id}' not found.`);
+    }
+
+    this._delete(id);
+    return callbacks;
+  }
+
+  /**
+   * Checks whether there are any pending approvals associated with the given
+   * origin.
+   *
+   * @param origin - The origin to check.
+   * @returns True if the origin has no pending approvals, false otherwise.
+   */
+  private _isEmptyOrigin(origin: string): boolean {
+    return !this._origins.get(origin)?.size;
+  }
+}

--- a/src/approval/ApprovalController.ts
+++ b/src/approval/ApprovalController.ts
@@ -1,7 +1,6 @@
 import { nanoid } from 'nanoid';
+import { ethErrors } from 'eth-rpc-errors';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
-
-const { ethErrors } = require('eth-rpc-errors');
 
 const NO_TYPE = Symbol('NO_APPROVAL_TYPE');
 const STORE_KEY = 'pendingApprovals';

--- a/src/approval/ApprovalController.ts
+++ b/src/approval/ApprovalController.ts
@@ -1,7 +1,7 @@
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 
 const { ethErrors } = require('eth-rpc-errors');
-const nanoid: () => string = require('nanoid');
+const { nanoid } = require('nanoid');
 
 const DEFAULT_TYPE = Symbol('DEFAULT_APPROVAL_TYPE');
 const STORE_KEY = 'pendingApprovals';
@@ -255,8 +255,10 @@ export default class ApprovalController extends BaseController<ApprovalConfig, A
       errorMessage = 'Must specify origin.';
     } else if (this._approvals.has(id)) {
       errorMessage = `Approval with id '${id}' already exists.`;
+    } else if (typeof type !== 'string' && type !== DEFAULT_TYPE) {
+      errorMessage = 'Must specify string type.';
     } else if (!type) {
-      errorMessage = 'May not specify falsy type.';
+      errorMessage = 'May not specify empty string type.';
     } else if (requestData && (
       typeof requestData !== 'object' || Array.isArray(requestData)
     )) {
@@ -325,10 +327,6 @@ export default class ApprovalController extends BaseController<ApprovalConfig, A
    * @param id - The id of the approval request to be deleted.
    */
   private _delete(id: string): void {
-    if (!id) {
-      throw new Error('Expected id to be specified.');
-    }
-
     if (this._approvals.has(id)) {
       this._approvals.delete(id);
 
@@ -336,8 +334,9 @@ export default class ApprovalController extends BaseController<ApprovalConfig, A
       const {
         origin,
         type = DEFAULT_TYPE,
-      } = state[id] || {};
+      } = state[id];
 
+      /* istanbul ignore next */
       this._origins.get(origin)?.delete(type);
       if (this._isEmptyOrigin(origin)) {
         this._origins.delete(origin);

--- a/tests/ApprovalController.test.js
+++ b/tests/ApprovalController.test.js
@@ -9,7 +9,6 @@ const getApprovalController = () => new ApprovalController({ ...defaultConfig })
 const STORE_KEY = 'pendingApprovals';
 
 describe('ApprovalController: Input Validation', () => {
-
   describe('add', () => {
     it('validates input', () => {
       const approvalController = getApprovalController();
@@ -39,11 +38,12 @@ describe('ApprovalController: Input Validation', () => {
       );
 
       assert.throws(
-        () => approvalController.add({
-          id: 'foo',
-          origin: 'bar.baz',
-          requestData: 'foo',
-        }),
+        () =>
+          approvalController.add({
+            id: 'foo',
+            origin: 'bar.baz',
+            requestData: 'foo',
+          }),
         getInvalidRequestDataError(),
         'should throw on non-object requestData',
       );
@@ -56,23 +56,11 @@ describe('ApprovalController: Input Validation', () => {
 
       approvalController.add({ id: 'foo', origin: 'bar.baz' });
 
-      assert.strictEqual(
-        approvalController.get('fizz'),
-        undefined,
-        'should return undefined',
-      );
+      assert.strictEqual(approvalController.get('fizz'), undefined, 'should return undefined');
 
-      assert.strictEqual(
-        approvalController.get(),
-        undefined,
-        'should return undefined',
-      );
+      assert.strictEqual(approvalController.get(), undefined, 'should return undefined');
 
-      assert.strictEqual(
-        approvalController.get({}),
-        undefined,
-        'should return undefined',
-      );
+      assert.strictEqual(approvalController.get({}), undefined, 'should return undefined');
     });
   });
 
@@ -86,18 +74,13 @@ describe('ApprovalController: Input Validation', () => {
         'should throw on falsy id and origin',
       );
 
-      assert.throws(
-        () => approvalController.has({ type: false }),
-        getNoFalsyTypeError(),
-        'should throw on falsy type',
-      );
+      assert.throws(() => approvalController.has({ type: false }), getNoFalsyTypeError(), 'should throw on falsy type');
     });
   });
 
   // We test this internal function before resolve, reject, and clear because
   // they are heavily dependent upon it.
   describe('_delete', () => {
-
     let approvalController;
 
     beforeEach(() => {
@@ -110,11 +93,9 @@ describe('ApprovalController: Input Validation', () => {
       approvalController._delete('foo');
 
       assert.ok(
-        (
-          !approvalController.has({ id: 'foo' }) &&
+        !approvalController.has({ id: 'foo' }) &&
           !approvalController.has({ origin: 'bar.baz' }) &&
-          !approvalController.state[STORE_KEY].foo
-        ),
+          !approvalController.state[STORE_KEY].foo,
         'should have deleted entry',
       );
     });
@@ -126,18 +107,12 @@ describe('ApprovalController: Input Validation', () => {
       approvalController._delete('fizz');
 
       assert.ok(
-        (
-          !approvalController.has({ id: 'fizz' }) &&
-          !approvalController.has({ origin: 'bar.baz', type: 'myType' })
-        ),
+        !approvalController.has({ id: 'fizz' }) && !approvalController.has({ origin: 'bar.baz', type: 'myType' }),
         'should have deleted entry',
       );
 
       assert.ok(
-        (
-          approvalController.has({ id: 'foo' }) &&
-          approvalController.has({ origin: 'bar.baz' })
-        ),
+        approvalController.has({ id: 'foo' }) && approvalController.has({ origin: 'bar.baz' }),
         'should still have non-deleted entry',
       );
     });
@@ -151,10 +126,7 @@ describe('ApprovalController: Input Validation', () => {
       );
 
       assert.ok(
-        (
-          approvalController.has({ id: 'foo' }) &&
-          approvalController.has({ origin: 'bar.baz' })
-        ),
+        approvalController.has({ id: 'foo' }) && approvalController.has({ origin: 'bar.baz' }),
         'should still have non-deleted entry',
       );
     });
@@ -163,9 +135,7 @@ describe('ApprovalController: Input Validation', () => {
   describe('miscellaneous', () => {
     it('isEmptyOrigin: handles non-existing origin', () => {
       const approvalController = getApprovalController();
-      assert.doesNotThrow(
-        () => approvalController._isEmptyOrigin('kaplar')
-      );
+      assert.doesNotThrow(() => approvalController._isEmptyOrigin('kaplar'));
     });
   });
 });

--- a/tests/ApprovalController.test.js
+++ b/tests/ApprovalController.test.js
@@ -1,4 +1,4 @@
-const { ERROR_CODES } = require('eth-rpc-errors');
+const { errorCodes } = require('eth-rpc-errors');
 const ApprovalController = require('../dist/approval/ApprovalController.js').default;
 
 const defaultConfig = { showApprovalRequest: () => undefined };
@@ -17,11 +17,11 @@ describe('ApprovalController: Input Validation', () => {
       expect(() => approvalController.add({ id: 'foo' })).toThrow(getMissingOriginError());
 
       expect(() => approvalController.add({ id: 'foo', origin: 'bar.baz', type: {} })).toThrow(
-        getNonStringTypeError(ERROR_CODES.rpc.internal),
+        getNonStringTypeError(errorCodes.rpc.internal),
       );
 
       expect(() => approvalController.add({ id: 'foo', origin: 'bar.baz', type: '' })).toThrow(
-        getEmptyStringTypeError(ERROR_CODES.rpc.internal),
+        getEmptyStringTypeError(errorCodes.rpc.internal),
       );
 
       expect(() =>
@@ -112,15 +112,15 @@ describe('ApprovalController: Input Validation', () => {
 // helpers
 
 function getInvalidIdError() {
-  return getError('Must specify non-empty string id.', ERROR_CODES.rpc.internal);
+  return getError('Must specify non-empty string id.', errorCodes.rpc.internal);
 }
 
 function getMissingOriginError() {
-  return getError('Must specify origin.', ERROR_CODES.rpc.internal);
+  return getError('Must specify origin.', errorCodes.rpc.internal);
 }
 
 function getInvalidRequestDataError() {
-  return getError('Request data must be a plain object if specified.', ERROR_CODES.rpc.internal);
+  return getError('Request data must be a plain object if specified.', errorCodes.rpc.internal);
 }
 
 function getNoFalsyTypeError() {

--- a/tests/ApprovalController.test.js
+++ b/tests/ApprovalController.test.js
@@ -1,4 +1,3 @@
-const assert = require('assert');
 const { ERROR_CODES } = require('eth-rpc-errors');
 const ApprovalController = require('../dist/approval/ApprovalController.js').default;
 
@@ -13,40 +12,25 @@ describe('ApprovalController: Input Validation', () => {
     it('validates input', () => {
       const approvalController = getApprovalController();
 
-      assert.throws(
-        () => approvalController.add({ id: null, origin: 'bar.baz' }),
-        getNoFalsyIdError(),
-        'should throw on falsy id',
-      );
+      expect(() => approvalController.add({ id: null, origin: 'bar.baz' })).toThrow(getNoFalsyIdError());
 
-      assert.throws(
-        () => approvalController.add({ id: 'foo' }),
-        getMissingOriginError(),
-        'should throw on falsy origin',
-      );
+      expect(() => approvalController.add({ id: 'foo' })).toThrow(getMissingOriginError());
 
-      assert.throws(
-        () => approvalController.add({ id: 'foo', origin: 'bar.baz', type: {} }),
+      expect(() => approvalController.add({ id: 'foo', origin: 'bar.baz', type: {} })).toThrow(
         getNonStringTypeError(ERROR_CODES.rpc.internal),
-        'should throw on non-string type',
       );
 
-      assert.throws(
-        () => approvalController.add({ id: 'foo', origin: 'bar.baz', type: '' }),
+      expect(() => approvalController.add({ id: 'foo', origin: 'bar.baz', type: '' })).toThrow(
         getEmptyStringTypeError(ERROR_CODES.rpc.internal),
-        'should throw on empty string type',
       );
 
-      assert.throws(
-        () =>
-          approvalController.add({
-            id: 'foo',
-            origin: 'bar.baz',
-            requestData: 'foo',
-          }),
-        getInvalidRequestDataError(),
-        'should throw on non-object requestData',
-      );
+      expect(() =>
+        approvalController.add({
+          id: 'foo',
+          origin: 'bar.baz',
+          requestData: 'foo',
+        }),
+      ).toThrow(getInvalidRequestDataError());
     });
   });
 
@@ -56,11 +40,11 @@ describe('ApprovalController: Input Validation', () => {
 
       approvalController.add({ id: 'foo', origin: 'bar.baz' });
 
-      assert.strictEqual(approvalController.get('fizz'), undefined, 'should return undefined');
+      expect(approvalController.get('fizz')).toBeUndefined();
 
-      assert.strictEqual(approvalController.get(), undefined, 'should return undefined');
+      expect(approvalController.get()).toBeUndefined();
 
-      assert.strictEqual(approvalController.get({}), undefined, 'should return undefined');
+      expect(approvalController.get({})).toBeUndefined();
     });
   });
 
@@ -68,13 +52,9 @@ describe('ApprovalController: Input Validation', () => {
     it('validates input', () => {
       const approvalController = getApprovalController();
 
-      assert.throws(
-        () => approvalController.has({}),
-        getMissingIdOrOriginError(),
-        'should throw on falsy id and origin',
-      );
+      expect(() => approvalController.has({})).toThrow(getMissingIdOrOriginError());
 
-      assert.throws(() => approvalController.has({ type: false }), getNoFalsyTypeError(), 'should throw on falsy type');
+      expect(() => approvalController.has({ type: false })).toThrow(getNoFalsyTypeError());
     });
   });
 
@@ -92,12 +72,11 @@ describe('ApprovalController: Input Validation', () => {
 
       approvalController._delete('foo');
 
-      assert.ok(
+      expect(
         !approvalController.has({ id: 'foo' }) &&
           !approvalController.has({ origin: 'bar.baz' }) &&
           !approvalController.state[STORE_KEY].foo,
-        'should have deleted entry',
-      );
+      ).toEqual(true);
     });
 
     it('deletes one entry out of many without side-effects', () => {
@@ -106,36 +85,26 @@ describe('ApprovalController: Input Validation', () => {
 
       approvalController._delete('fizz');
 
-      assert.ok(
+      expect(
         !approvalController.has({ id: 'fizz' }) && !approvalController.has({ origin: 'bar.baz', type: 'myType' }),
-        'should have deleted entry',
-      );
+      ).toEqual(true);
 
-      assert.ok(
-        approvalController.has({ id: 'foo' }) && approvalController.has({ origin: 'bar.baz' }),
-        'should still have non-deleted entry',
-      );
+      expect(approvalController.has({ id: 'foo' }) && approvalController.has({ origin: 'bar.baz' })).toEqual(true);
     });
 
     it('does nothing when deleting non-existing entry', () => {
       approvalController.add({ id: 'foo', origin: 'bar.baz' });
 
-      assert.doesNotThrow(
-        () => approvalController._delete('fizz'),
-        'should not throw when deleting non-existing entry',
-      );
+      expect(() => approvalController._delete('fizz')).not.toThrow();
 
-      assert.ok(
-        approvalController.has({ id: 'foo' }) && approvalController.has({ origin: 'bar.baz' }),
-        'should still have non-deleted entry',
-      );
+      expect(approvalController.has({ id: 'foo' }) && approvalController.has({ origin: 'bar.baz' })).toEqual(true);
     });
   });
 
   describe('miscellaneous', () => {
     it('isEmptyOrigin: handles non-existing origin', () => {
       const approvalController = getApprovalController();
-      assert.doesNotThrow(() => approvalController._isEmptyOrigin('kaplar'));
+      expect(() => approvalController._isEmptyOrigin('kaplar')).not.toThrow();
     });
   });
 });

--- a/tests/ApprovalController.test.js
+++ b/tests/ApprovalController.test.js
@@ -12,7 +12,7 @@ describe('ApprovalController: Input Validation', () => {
     it('validates input', () => {
       const approvalController = getApprovalController();
 
-      expect(() => approvalController.add({ id: null, origin: 'bar.baz' })).toThrow(getNoFalsyIdError());
+      expect(() => approvalController.add({ id: null, origin: 'bar.baz' })).toThrow(getInvalidIdError());
 
       expect(() => approvalController.add({ id: 'foo' })).toThrow(getMissingOriginError());
 
@@ -111,8 +111,8 @@ describe('ApprovalController: Input Validation', () => {
 
 // helpers
 
-function getNoFalsyIdError() {
-  return getError('May not specify falsy id.', ERROR_CODES.rpc.internal);
+function getInvalidIdError() {
+  return getError('Must specify non-empty string id.', ERROR_CODES.rpc.internal);
 }
 
 function getMissingOriginError() {

--- a/tests/ApprovalController.test.js
+++ b/tests/ApprovalController.test.js
@@ -1,0 +1,212 @@
+const assert = require('assert');
+const { ERROR_CODES } = require('eth-rpc-errors');
+const ApprovalController = require('../dist/approval/ApprovalController.js').default;
+
+const defaultConfig = { showApprovalRequest: () => undefined };
+
+const getApprovalController = () => new ApprovalController({ ...defaultConfig });
+
+const STORE_KEY = 'pendingApprovals';
+
+describe('ApprovalController: Input Validation', () => {
+
+  describe('add', () => {
+    it('validates input', () => {
+      const approvalController = getApprovalController();
+
+      assert.throws(
+        () => approvalController.add({ id: null, origin: 'bar.baz' }),
+        getNoFalsyIdError(),
+        'should throw on falsy id',
+      );
+
+      assert.throws(
+        () => approvalController.add({ id: 'foo' }),
+        getMissingOriginError(),
+        'should throw on falsy origin',
+      );
+
+      assert.throws(
+        () => approvalController.add({ id: 'foo', origin: 'bar.baz', type: {} }),
+        getNonStringTypeError(ERROR_CODES.rpc.internal),
+        'should throw on non-string type',
+      );
+
+      assert.throws(
+        () => approvalController.add({ id: 'foo', origin: 'bar.baz', type: '' }),
+        getEmptyStringTypeError(ERROR_CODES.rpc.internal),
+        'should throw on empty string type',
+      );
+
+      assert.throws(
+        () => approvalController.add({
+          id: 'foo',
+          origin: 'bar.baz',
+          requestData: 'foo',
+        }),
+        getInvalidRequestDataError(),
+        'should throw on non-object requestData',
+      );
+    });
+  });
+
+  describe('get', () => {
+    it('returns undefined for non-existing entry', () => {
+      const approvalController = getApprovalController();
+
+      approvalController.add({ id: 'foo', origin: 'bar.baz' });
+
+      assert.strictEqual(
+        approvalController.get('fizz'),
+        undefined,
+        'should return undefined',
+      );
+
+      assert.strictEqual(
+        approvalController.get(),
+        undefined,
+        'should return undefined',
+      );
+
+      assert.strictEqual(
+        approvalController.get({}),
+        undefined,
+        'should return undefined',
+      );
+    });
+  });
+
+  describe('has', () => {
+    it('validates input', () => {
+      const approvalController = getApprovalController();
+
+      assert.throws(
+        () => approvalController.has({}),
+        getMissingIdOrOriginError(),
+        'should throw on falsy id and origin',
+      );
+
+      assert.throws(
+        () => approvalController.has({ type: false }),
+        getNoFalsyTypeError(),
+        'should throw on falsy type',
+      );
+    });
+  });
+
+  // We test this internal function before resolve, reject, and clear because
+  // they are heavily dependent upon it.
+  describe('_delete', () => {
+
+    let approvalController;
+
+    beforeEach(() => {
+      approvalController = new ApprovalController({ ...defaultConfig });
+    });
+
+    it('deletes entry', () => {
+      approvalController.add({ id: 'foo', origin: 'bar.baz' });
+
+      approvalController._delete('foo');
+
+      assert.ok(
+        (
+          !approvalController.has({ id: 'foo' }) &&
+          !approvalController.has({ origin: 'bar.baz' }) &&
+          !approvalController.state[STORE_KEY].foo
+        ),
+        'should have deleted entry',
+      );
+    });
+
+    it('deletes one entry out of many without side-effects', () => {
+      approvalController.add({ id: 'foo', origin: 'bar.baz' });
+      approvalController.add({ id: 'fizz', origin: 'bar.baz', type: 'myType' });
+
+      approvalController._delete('fizz');
+
+      assert.ok(
+        (
+          !approvalController.has({ id: 'fizz' }) &&
+          !approvalController.has({ origin: 'bar.baz', type: 'myType' })
+        ),
+        'should have deleted entry',
+      );
+
+      assert.ok(
+        (
+          approvalController.has({ id: 'foo' }) &&
+          approvalController.has({ origin: 'bar.baz' })
+        ),
+        'should still have non-deleted entry',
+      );
+    });
+
+    it('does nothing when deleting non-existing entry', () => {
+      approvalController.add({ id: 'foo', origin: 'bar.baz' });
+
+      assert.doesNotThrow(
+        () => approvalController._delete('fizz'),
+        'should not throw when deleting non-existing entry',
+      );
+
+      assert.ok(
+        (
+          approvalController.has({ id: 'foo' }) &&
+          approvalController.has({ origin: 'bar.baz' })
+        ),
+        'should still have non-deleted entry',
+      );
+    });
+  });
+
+  describe('miscellaneous', () => {
+    it('isEmptyOrigin: handles non-existing origin', () => {
+      const approvalController = getApprovalController();
+      assert.doesNotThrow(
+        () => approvalController._isEmptyOrigin('kaplar')
+      );
+    });
+  });
+});
+
+// helpers
+
+function getNoFalsyIdError() {
+  return getError('May not specify falsy id.', ERROR_CODES.rpc.internal);
+}
+
+function getMissingOriginError() {
+  return getError('Must specify origin.', ERROR_CODES.rpc.internal);
+}
+
+function getInvalidRequestDataError() {
+  return getError('Request data must be a plain object if specified.', ERROR_CODES.rpc.internal);
+}
+
+function getNoFalsyTypeError() {
+  return getError('May not specify falsy type.');
+}
+
+function getNonStringTypeError(code) {
+  return getError('Must specify string type.', code);
+}
+
+function getEmptyStringTypeError(code) {
+  return getError('May not specify empty string type.', code);
+}
+
+function getMissingIdOrOriginError() {
+  return getError('Must specify id or origin.');
+}
+
+function getError(message, code) {
+  const err = {
+    name: 'Error',
+    message,
+  };
+  if (code !== undefined) {
+    err.code = code;
+  }
+  return err;
+}

--- a/tests/ApprovalController.test.ts
+++ b/tests/ApprovalController.test.ts
@@ -1,6 +1,5 @@
 import ApprovalController from '../dist/approval/ApprovalController';
 
-const assert = require('assert');
 const { ERROR_CODES } = require('eth-rpc-errors');
 const sinon = require('sinon');
 
@@ -24,100 +23,73 @@ describe('approval controller', () => {
     });
 
     it('adds id if non provided', () => {
-      assert.doesNotThrow(() => approvalController.add({ id: undefined, origin: 'bar.baz' }), 'should add entry');
+      expect(() => approvalController.add({ id: undefined, origin: 'bar.baz' })).not.toThrow();
 
       const id = Object.keys(approvalController.state[STORE_KEY])[0];
-      assert.ok(id && typeof id === 'string', 'should have added entry with string id');
+      expect(id && typeof id === 'string').toBeTruthy();
     });
 
     it('adds correctly specified entry with custom type', () => {
-      assert.doesNotThrow(() => approvalController.add({ id: 'foo', origin: 'bar.baz', type: 'myType' }));
+      expect(() => approvalController.add({ id: 'foo', origin: 'bar.baz', type: 'myType' })).not.toThrow();
 
-      assert.ok(approvalController.has({ id: 'foo' }), 'should have added entry');
-      assert.ok(approvalController.has({ origin: 'bar.baz', type: 'myType' }), 'should have added entry');
-      assert.deepStrictEqual(
-        approvalController.state[STORE_KEY],
-        { foo: { id: 'foo', origin: 'bar.baz', type: 'myType' } },
-        'should have added entry to store',
-      );
+      expect(approvalController.has({ id: 'foo' })).toEqual(true);
+      expect(approvalController.has({ origin: 'bar.baz', type: 'myType' })).toEqual(true);
+      expect(approvalController.state[STORE_KEY]).toEqual({ foo: { id: 'foo', origin: 'bar.baz', type: 'myType' } });
     });
 
     it('adds correctly specified entry with request data', () => {
-      assert.doesNotThrow(() =>
+      expect(() =>
         approvalController.add({
           id: 'foo',
           origin: 'bar.baz',
           type: undefined,
           requestData: { foo: 'bar' },
         }),
-      );
+      ).not.toThrow();
 
-      assert.ok(approvalController.has({ id: 'foo' }), 'should have added entry');
-      assert.ok(approvalController.has({ origin: 'bar.baz' }), 'should have added entry');
-      assert.deepStrictEqual(
-        approvalController.state[STORE_KEY].foo.requestData,
-        { foo: 'bar' },
-        'should have added entry with correct request data',
-      );
+      expect(approvalController.has({ id: 'foo' })).toEqual(true);
+      expect(approvalController.has({ origin: 'bar.baz' })).toEqual(true);
+      expect(approvalController.state[STORE_KEY].foo.requestData).toEqual({ foo: 'bar' });
     });
 
     it('adds multiple entries for same origin with different types and ids', () => {
       const ORIGIN = 'bar.baz';
 
-      assert.doesNotThrow(() => approvalController.add({ id: 'foo1', origin: ORIGIN }), 'should add entry');
-      assert.doesNotThrow(
-        () => approvalController.add({ id: 'foo2', origin: ORIGIN, type: 'myType1' }),
-        'should add entry',
-      );
-      assert.doesNotThrow(
-        () => approvalController.add({ id: 'foo3', origin: ORIGIN, type: 'myType2' }),
-        'should add entry',
-      );
+      expect(() => approvalController.add({ id: 'foo1', origin: ORIGIN })).not.toThrow();
+      expect(() => approvalController.add({ id: 'foo2', origin: ORIGIN, type: 'myType1' })).not.toThrow();
+      expect(() => approvalController.add({ id: 'foo3', origin: ORIGIN, type: 'myType2' })).not.toThrow();
 
-      assert.ok(
+      expect(
         approvalController.has({ id: 'foo1' }) &&
           approvalController.has({ id: 'foo3' }) &&
           approvalController.has({ id: 'foo3' }),
-        'should have added entries',
-      );
-      assert.ok(
+      ).toEqual(true);
+      expect(
         approvalController.has({ origin: ORIGIN }) &&
           approvalController.has({ origin: ORIGIN, type: 'myType1' }) &&
           approvalController.has({ origin: ORIGIN, type: 'myType2' }),
-        'should have added entries',
-      );
+      ).toEqual(true);
     });
 
     it('throws on id collision', () => {
-      assert.doesNotThrow(() => approvalController.add({ id: 'foo', origin: 'bar.baz' }), 'should add entry');
+      expect(() => approvalController.add({ id: 'foo', origin: 'bar.baz' })).not.toThrow();
 
-      assert.throws(
-        () => approvalController.add({ id: 'foo', origin: 'fizz.buzz' }),
-        getIdCollisionError('foo'),
-        'should have thrown expected error',
-      );
+      expect(() => approvalController.add({ id: 'foo', origin: 'fizz.buzz' })).toThrow(getIdCollisionError('foo'));
     });
 
     it('throws on origin and default type collision', () => {
-      assert.doesNotThrow(() => approvalController.add({ id: 'foo', origin: 'bar.baz' }), 'should add entry');
+      expect(() => approvalController.add({ id: 'foo', origin: 'bar.baz' })).not.toThrow();
 
-      assert.throws(
-        () => approvalController.add({ id: 'foo1', origin: 'bar.baz' }),
+      expect(() => approvalController.add({ id: 'foo1', origin: 'bar.baz' })).toThrow(
         getOriginTypeCollisionError('bar.baz'),
-        'should have thrown expected error',
       );
     });
 
     it('throws on origin and custom type collision', () => {
-      assert.doesNotThrow(
-        () => approvalController.add({ id: 'foo', origin: 'bar.baz', type: 'myType' }),
-        'should add entry',
-      );
+      expect(() => approvalController.add({ id: 'foo', origin: 'bar.baz', type: 'myType' })).not.toThrow();
 
-      assert.throws(
-        () => approvalController.add({ id: 'foo1', origin: 'bar.baz', type: 'myType' }),
+      expect(() => approvalController.add({ id: 'foo1', origin: 'bar.baz', type: 'myType' })).toThrow(
         getOriginTypeCollisionError('bar.baz', 'myType'),
-        'should have thrown expected error',
       );
     });
   });
@@ -136,8 +108,8 @@ describe('approval controller', () => {
         type: 'myType',
         requestData: { foo: 'bar' },
       });
-      assert.ok(result instanceof Promise, 'should return expected result');
-      assert.ok(showApprovalSpy.calledOnce, 'should have called _showApprovalRequest once');
+      expect(result instanceof Promise).toEqual(true);
+      expect(showApprovalSpy.calledOnce).toEqual(true);
     });
   });
 
@@ -151,21 +123,13 @@ describe('approval controller', () => {
     it('gets entry with default type', () => {
       approvalController.add({ id: 'foo', origin: 'bar.baz' });
 
-      assert.deepStrictEqual(
-        approvalController.get('foo'),
-        { id: 'foo', origin: 'bar.baz' },
-        'should retrieve expected entry',
-      );
+      expect(approvalController.get('foo')).toEqual({ id: 'foo', origin: 'bar.baz' });
     });
 
     it('gets entry with custom type', () => {
       approvalController.add({ id: 'foo', origin: 'bar.baz', type: 'myType' });
 
-      assert.deepStrictEqual(
-        approvalController.get('foo'),
-        { id: 'foo', origin: 'bar.baz', type: 'myType' },
-        'should retrieve expected entry',
-      );
+      expect(approvalController.get('foo')).toEqual({ id: 'foo', origin: 'bar.baz', type: 'myType' });
     });
   });
 
@@ -179,57 +143,37 @@ describe('approval controller', () => {
     it('returns true for existing entry by id', () => {
       approvalController.add({ id: 'foo', origin: 'bar.baz' });
 
-      assert.strictEqual(approvalController.has({ id: 'foo' }), true, 'should return true for existing entry by id');
+      expect(approvalController.has({ id: 'foo' })).toEqual(true);
     });
 
     it('returns true for existing entry by origin', () => {
       approvalController.add({ id: 'foo', origin: 'bar.baz' });
 
-      assert.strictEqual(
-        approvalController.has({ origin: 'bar.baz' }),
-        true,
-        'should return true for existing entry by origin',
-      );
+      expect(approvalController.has({ origin: 'bar.baz' })).toEqual(true);
     });
 
     it('returns true for existing entry by origin and custom type', () => {
       approvalController.add({ id: 'foo', origin: 'bar.baz', type: 'myType' });
 
-      assert.strictEqual(
-        approvalController.has({ origin: 'bar.baz', type: 'myType' }),
-        true,
-        'should return true for existing entry by origin and custom type',
-      );
+      expect(approvalController.has({ origin: 'bar.baz', type: 'myType' })).toEqual(true);
     });
 
     it('returns false for non-existing entry by id', () => {
       approvalController.add({ id: 'foo', origin: 'bar.baz' });
 
-      assert.strictEqual(
-        approvalController.has({ id: 'fizz' }),
-        false,
-        'should return false for non-existing entry by id',
-      );
+      expect(approvalController.has({ id: 'fizz' })).toEqual(false);
     });
 
     it('returns false for non-existing entry by origin', () => {
       approvalController.add({ id: 'foo', origin: 'bar.baz' });
 
-      assert.strictEqual(
-        approvalController.has({ origin: 'fizz.buzz' }),
-        false,
-        'should return false for non-existing entry by origin',
-      );
+      expect(approvalController.has({ origin: 'fizz.buzz' })).toEqual(false);
     });
 
     it('returns false for non-existing entry by origin and type', () => {
       approvalController.add({ id: 'foo', origin: 'bar.baz' });
 
-      assert.strictEqual(
-        approvalController.has({ origin: 'bar.baz', type: 'myType' }),
-        false,
-        'should return false for non-existing entry by origin and type',
-      );
+      expect(approvalController.has({ origin: 'bar.baz', type: 'myType' })).toEqual(false);
     });
   });
 
@@ -244,10 +188,6 @@ describe('approval controller', () => {
       numDeletions = 0;
     });
 
-    afterEach(() => {
-      assert.strictEqual(deleteSpy.callCount, numDeletions, `should have called '_delete' ${numDeletions} times`);
-    });
-
     it('resolves approval promise', async () => {
       numDeletions = 1;
 
@@ -255,7 +195,8 @@ describe('approval controller', () => {
       approvalController.resolve('foo', 'success');
 
       const result = await approvalPromise;
-      assert.strictEqual(result, 'success', 'should have resolved expected value');
+      expect(result).toEqual('success');
+      expect(deleteSpy.callCount).toEqual(numDeletions);
     });
 
     it('resolves multiple approval promises out of order', async () => {
@@ -267,16 +208,18 @@ describe('approval controller', () => {
       approvalController.resolve('foo2', 'success2');
 
       let result = await approvalPromise2;
-      assert.strictEqual(result, 'success2', 'should have resolved expected value');
+      expect(result).toEqual('success2');
 
       approvalController.resolve('foo1', 'success1');
 
       result = await approvalPromise1;
-      assert.strictEqual(result, 'success1', 'should have resolved expected value');
+      expect(result).toEqual('success1');
+      expect(deleteSpy.callCount).toEqual(numDeletions);
     });
 
     it('throws on unknown id', () => {
-      assert.throws(() => approvalController.resolve('foo'), getIdNotFoundError('foo'), 'should reject on unknown id');
+      expect(() => approvalController.resolve('foo')).toThrow(getIdNotFoundError('foo'));
+      expect(deleteSpy.callCount).toEqual(numDeletions);
     });
   });
 
@@ -291,50 +234,41 @@ describe('approval controller', () => {
       numDeletions = 0;
     });
 
-    afterEach(() => {
-      assert.strictEqual(deleteSpy.callCount, numDeletions, `should have called '_delete' ${numDeletions} times`);
-    });
-
     it('rejects approval promise', async () => {
       numDeletions = 1;
 
-      const approvalPromise = assert.rejects(
-        () => approvalController.add({ id: 'foo', origin: 'bar.baz' }),
-        getError('failure'),
-        'should reject with expected error',
-      );
-      approvalController.reject('foo', new Error('failure'));
+      const approvalPromise = approvalController.add({ id: 'foo', origin: 'bar.baz' }).catch((error) => {
+        expect(error).toMatchObject(getError('failure'));
+      });
 
+      approvalController.reject('foo', new Error('failure'));
       await approvalPromise;
+      expect(deleteSpy.callCount).toEqual(numDeletions);
     });
 
     it('rejects multiple approval promises out of order', async () => {
       numDeletions = 2;
 
-      const rejectionPromise1 = assert.rejects(
-        () => approvalController.add({ id: 'foo1', origin: 'bar.baz' }),
-        getError('failure1'),
-        'should reject with expected error',
-      );
-      const rejectionPromise2 = assert.rejects(
-        () => approvalController.add({ id: 'foo2', origin: 'bar.baz', type: 'myType2' }),
-        getError('failure2'),
-        'should reject with expected error',
-      );
+      const rejectionPromise1 = approvalController.add({ id: 'foo1', origin: 'bar.baz' }).catch((error) => {
+        expect(error).toMatchObject(getError('failure1'));
+      });
+      const rejectionPromise2 = approvalController
+        .add({ id: 'foo2', origin: 'bar.baz', type: 'myType2' })
+        .catch((error) => {
+          expect(error).toMatchObject(getError('failure2'));
+        });
 
       approvalController.reject('foo2', new Error('failure2'));
       await rejectionPromise2;
 
       approvalController.reject('foo1', new Error('failure1'));
       await rejectionPromise1;
+      expect(deleteSpy.callCount).toEqual(numDeletions);
     });
 
     it('throws on unknown id', () => {
-      assert.throws(
-        () => approvalController.reject('foo', new Error('bar')),
-        getIdNotFoundError('foo'),
-        'should reject on unknown id',
-      );
+      expect(() => approvalController.reject('foo', new Error('bar'))).toThrow(getIdNotFoundError('foo'));
+      expect(deleteSpy.callCount).toEqual(numDeletions);
     });
   });
 
@@ -344,21 +278,17 @@ describe('approval controller', () => {
 
       const promise1 = approvalController.add({ id: 'foo1', origin: 'bar.baz' });
       const promise2 = approvalController.add({ id: 'foo2', origin: 'bar.baz', type: 'myType2' });
-      const promise3 = assert.rejects(
-        () => approvalController.add({ id: 'foo3', origin: 'fizz.buzz' }),
-        getError('failure3'),
-        'should reject with expected error',
-      );
-      const promise4 = assert.rejects(
-        () => approvalController.add({ id: 'foo4', origin: 'bar.baz', type: 'myType4' }),
-        getError('failure4'),
-        'should reject with expected error',
-      );
+      const promise3 = approvalController.add({ id: 'foo3', origin: 'fizz.buzz' }).catch((error) => {
+        expect(error).toMatchObject(getError('failure3'));
+      });
+      const promise4 = approvalController.add({ id: 'foo4', origin: 'bar.baz', type: 'myType4' }).catch((error) => {
+        expect(error).toMatchObject(getError('failure4'));
+      });
 
       approvalController.resolve('foo2', 'success2');
 
       let result = await promise2;
-      assert.strictEqual(result, 'success2', 'should have resolved expected value');
+      expect(result).toEqual('success2');
 
       approvalController.reject('foo4', new Error('failure4'));
       await promise4;
@@ -366,57 +296,40 @@ describe('approval controller', () => {
       approvalController.reject('foo3', new Error('failure3'));
       await promise3;
 
-      assert.ok(!approvalController.has({ origin: 'fizz.buzz' }), 'should have deleted origin');
-      assert.ok(approvalController.has({ origin: 'bar.baz' }), 'should have origin with remaining approval');
+      expect(approvalController.has({ origin: 'fizz.buzz' })).toEqual(false);
+      expect(approvalController.has({ origin: 'bar.baz' })).toEqual(true);
 
       approvalController.resolve('foo1', 'success1');
 
       result = await promise1;
-      assert.strictEqual(result, 'success1', 'should have resolved expected value');
+      expect(result).toEqual('success1');
 
-      assert.ok(!approvalController.has({ origin: 'bar.baz' }), 'origins should be removed');
+      expect(approvalController.has({ origin: 'bar.baz' })).toEqual(false);
     });
   });
 
   describe('clear', () => {
-    let approvalController: ApprovalController, numDeletions: number, deleteSpy: any;
+    let approvalController: ApprovalController;
 
     beforeEach(() => {
       approvalController = new ApprovalController({ ...defaultConfig });
-      deleteSpy = sinon.spy(approvalController, '_delete');
-      numDeletions = 0;
-    });
-
-    afterEach(() => {
-      assert.strictEqual(deleteSpy.callCount, numDeletions, `should have called '_delete' ${numDeletions} times`);
     });
 
     it('does nothing if state is already empty', () => {
-      assert.doesNotThrow(() => approvalController.clear(), 'should not throw');
+      expect(() => approvalController.clear()).not.toThrow();
     });
 
     it('deletes existing entries', async () => {
-      numDeletions = 3;
+      const rejectSpy = sinon.spy(approvalController, 'reject');
 
-      const clearPromise = Promise.all([
-        assert.rejects(
-          () => approvalController.add({ id: 'foo1', origin: 'bar.baz' }),
-          'every approval promise should reject',
-        ),
-        assert.rejects(
-          () => approvalController.add({ id: 'foo2', origin: 'bar.baz', type: 'myType' }),
-          'every approval promise should reject',
-        ),
-        assert.rejects(
-          () => approvalController.add({ id: 'foo3', origin: 'fizz.buzz', type: 'myType' }),
-          'every approval promise should reject',
-        ),
-      ]);
+      approvalController.add({ id: 'foo1', origin: 'bar.baz' }).catch((_error) => undefined);
+      approvalController.add({ id: 'foo2', origin: 'bar.baz', type: 'myType' }).catch((_error) => undefined);
+      approvalController.add({ id: 'foo3', origin: 'fizz.buzz', type: 'myType' }).catch((_error) => undefined);
 
       approvalController.clear();
-      await clearPromise;
 
-      assert.deepStrictEqual(approvalController.state[STORE_KEY], {}, 'store should be empty');
+      expect(approvalController.state[STORE_KEY]).toEqual({});
+      expect(rejectSpy.callCount).toEqual(3);
     });
   });
 });

--- a/tests/ApprovalController.test.ts
+++ b/tests/ApprovalController.test.ts
@@ -1,6 +1,6 @@
+import { errorCodes } from 'eth-rpc-errors';
 import ApprovalController from '../dist/approval/ApprovalController';
 
-const { ERROR_CODES } = require('eth-rpc-errors');
 const sinon = require('sinon');
 
 const STORE_KEY = 'pendingApprovals';
@@ -337,14 +337,14 @@ describe('approval controller', () => {
 // helpers
 
 function getIdCollisionError(id: string) {
-  return getError(`Approval with id '${id}' already exists.`, ERROR_CODES.rpc.internal);
+  return getError(`Approval with id '${id}' already exists.`, errorCodes.rpc.internal);
 }
 
 function getOriginTypeCollisionError(origin: string, type = '_default') {
   const message = `Request${
     type === '_default' ? '' : ` of type '${type}'`
   } already pending for origin ${origin}. Please wait.`;
-  return getError(message, ERROR_CODES.rpc.resourceUnavailable);
+  return getError(message, errorCodes.rpc.resourceUnavailable);
 }
 
 function getIdNotFoundError(id: string) {

--- a/tests/ApprovalController.test.ts
+++ b/tests/ApprovalController.test.ts
@@ -1,0 +1,450 @@
+import ApprovalController from '../dist/approval/ApprovalController';
+
+const assert = require('assert');
+const { ERROR_CODES } = require('eth-rpc-errors');
+const sinon = require('sinon');
+
+const STORE_KEY = 'pendingApprovals';
+
+const defaultConfig = { showApprovalRequest: () => undefined };
+
+describe('approval controller', () => {
+  describe('add', () => {
+    let approvalController: ApprovalController;
+
+    beforeEach(() => {
+      approvalController = new ApprovalController({ ...defaultConfig });
+    });
+
+    it('adds correctly specified entry', () => {
+      expect(() => approvalController.add({ id: 'foo', origin: 'bar.baz' })).not.toThrow();
+
+      expect(approvalController.has({ id: 'foo' })).toEqual(true);
+      expect(approvalController.state[STORE_KEY]).toEqual({ foo: { id: 'foo', origin: 'bar.baz' } });
+    });
+
+    it('adds id if non provided', () => {
+      assert.doesNotThrow(() => approvalController.add({ id: undefined, origin: 'bar.baz' }), 'should add entry');
+
+      const id = Object.keys(approvalController.state[STORE_KEY])[0];
+      assert.ok(id && typeof id === 'string', 'should have added entry with string id');
+    });
+
+    it('adds correctly specified entry with custom type', () => {
+      assert.doesNotThrow(() => approvalController.add({ id: 'foo', origin: 'bar.baz', type: 'myType' }));
+
+      assert.ok(approvalController.has({ id: 'foo' }), 'should have added entry');
+      assert.ok(approvalController.has({ origin: 'bar.baz', type: 'myType' }), 'should have added entry');
+      assert.deepStrictEqual(
+        approvalController.state[STORE_KEY],
+        { foo: { id: 'foo', origin: 'bar.baz', type: 'myType' } },
+        'should have added entry to store',
+      );
+    });
+
+    it('adds correctly specified entry with request data', () => {
+      assert.doesNotThrow(() =>
+        approvalController.add({
+          id: 'foo',
+          origin: 'bar.baz',
+          type: undefined,
+          requestData: { foo: 'bar' },
+        }),
+      );
+
+      assert.ok(approvalController.has({ id: 'foo' }), 'should have added entry');
+      assert.ok(approvalController.has({ origin: 'bar.baz' }), 'should have added entry');
+      assert.deepStrictEqual(
+        approvalController.state[STORE_KEY].foo.requestData,
+        { foo: 'bar' },
+        'should have added entry with correct request data',
+      );
+    });
+
+    it('adds multiple entries for same origin with different types and ids', () => {
+      const ORIGIN = 'bar.baz';
+
+      assert.doesNotThrow(() => approvalController.add({ id: 'foo1', origin: ORIGIN }), 'should add entry');
+      assert.doesNotThrow(
+        () => approvalController.add({ id: 'foo2', origin: ORIGIN, type: 'myType1' }),
+        'should add entry',
+      );
+      assert.doesNotThrow(
+        () => approvalController.add({ id: 'foo3', origin: ORIGIN, type: 'myType2' }),
+        'should add entry',
+      );
+
+      assert.ok(
+        approvalController.has({ id: 'foo1' }) &&
+          approvalController.has({ id: 'foo3' }) &&
+          approvalController.has({ id: 'foo3' }),
+        'should have added entries',
+      );
+      assert.ok(
+        approvalController.has({ origin: ORIGIN }) &&
+          approvalController.has({ origin: ORIGIN, type: 'myType1' }) &&
+          approvalController.has({ origin: ORIGIN, type: 'myType2' }),
+        'should have added entries',
+      );
+    });
+
+    it('throws on id collision', () => {
+      assert.doesNotThrow(() => approvalController.add({ id: 'foo', origin: 'bar.baz' }), 'should add entry');
+
+      assert.throws(
+        () => approvalController.add({ id: 'foo', origin: 'fizz.buzz' }),
+        getIdCollisionError('foo'),
+        'should have thrown expected error',
+      );
+    });
+
+    it('throws on origin and default type collision', () => {
+      assert.doesNotThrow(() => approvalController.add({ id: 'foo', origin: 'bar.baz' }), 'should add entry');
+
+      assert.throws(
+        () => approvalController.add({ id: 'foo1', origin: 'bar.baz' }),
+        getOriginTypeCollisionError('bar.baz'),
+        'should have thrown expected error',
+      );
+    });
+
+    it('throws on origin and custom type collision', () => {
+      assert.doesNotThrow(
+        () => approvalController.add({ id: 'foo', origin: 'bar.baz', type: 'myType' }),
+        'should add entry',
+      );
+
+      assert.throws(
+        () => approvalController.add({ id: 'foo1', origin: 'bar.baz', type: 'myType' }),
+        getOriginTypeCollisionError('bar.baz', 'myType'),
+        'should have thrown expected error',
+      );
+    });
+  });
+
+  // otherwise tested by 'add' above
+  describe('addAndShowApprovalRequest', () => {
+    it('addAndShowApprovalRequest', () => {
+      const showApprovalSpy = sinon.spy();
+      const approvalController = new ApprovalController({
+        showApprovalRequest: showApprovalSpy,
+      });
+
+      const result = approvalController.addAndShowApprovalRequest({
+        id: 'foo',
+        origin: 'bar.baz',
+        type: 'myType',
+        requestData: { foo: 'bar' },
+      });
+      assert.ok(result instanceof Promise, 'should return expected result');
+      assert.ok(showApprovalSpy.calledOnce, 'should have called _showApprovalRequest once');
+    });
+  });
+
+  describe('get', () => {
+    let approvalController: ApprovalController;
+
+    beforeEach(() => {
+      approvalController = new ApprovalController({ ...defaultConfig });
+    });
+
+    it('gets entry with default type', () => {
+      approvalController.add({ id: 'foo', origin: 'bar.baz' });
+
+      assert.deepStrictEqual(
+        approvalController.get('foo'),
+        { id: 'foo', origin: 'bar.baz' },
+        'should retrieve expected entry',
+      );
+    });
+
+    it('gets entry with custom type', () => {
+      approvalController.add({ id: 'foo', origin: 'bar.baz', type: 'myType' });
+
+      assert.deepStrictEqual(
+        approvalController.get('foo'),
+        { id: 'foo', origin: 'bar.baz', type: 'myType' },
+        'should retrieve expected entry',
+      );
+    });
+  });
+
+  describe('has', () => {
+    let approvalController: ApprovalController;
+
+    beforeEach(() => {
+      approvalController = new ApprovalController({ ...defaultConfig });
+    });
+
+    it('returns true for existing entry by id', () => {
+      approvalController.add({ id: 'foo', origin: 'bar.baz' });
+
+      assert.strictEqual(approvalController.has({ id: 'foo' }), true, 'should return true for existing entry by id');
+    });
+
+    it('returns true for existing entry by origin', () => {
+      approvalController.add({ id: 'foo', origin: 'bar.baz' });
+
+      assert.strictEqual(
+        approvalController.has({ origin: 'bar.baz' }),
+        true,
+        'should return true for existing entry by origin',
+      );
+    });
+
+    it('returns true for existing entry by origin and custom type', () => {
+      approvalController.add({ id: 'foo', origin: 'bar.baz', type: 'myType' });
+
+      assert.strictEqual(
+        approvalController.has({ origin: 'bar.baz', type: 'myType' }),
+        true,
+        'should return true for existing entry by origin and custom type',
+      );
+    });
+
+    it('returns false for non-existing entry by id', () => {
+      approvalController.add({ id: 'foo', origin: 'bar.baz' });
+
+      assert.strictEqual(
+        approvalController.has({ id: 'fizz' }),
+        false,
+        'should return false for non-existing entry by id',
+      );
+    });
+
+    it('returns false for non-existing entry by origin', () => {
+      approvalController.add({ id: 'foo', origin: 'bar.baz' });
+
+      assert.strictEqual(
+        approvalController.has({ origin: 'fizz.buzz' }),
+        false,
+        'should return false for non-existing entry by origin',
+      );
+    });
+
+    it('returns false for non-existing entry by origin and type', () => {
+      approvalController.add({ id: 'foo', origin: 'bar.baz' });
+
+      assert.strictEqual(
+        approvalController.has({ origin: 'bar.baz', type: 'myType' }),
+        false,
+        'should return false for non-existing entry by origin and type',
+      );
+    });
+  });
+
+  describe('resolve', () => {
+    let approvalController: ApprovalController;
+    let numDeletions: number;
+    let deleteSpy: typeof sinon.spy;
+
+    beforeEach(() => {
+      approvalController = new ApprovalController({ ...defaultConfig });
+      deleteSpy = sinon.spy(approvalController, '_delete');
+      numDeletions = 0;
+    });
+
+    afterEach(() => {
+      assert.strictEqual(deleteSpy.callCount, numDeletions, `should have called '_delete' ${numDeletions} times`);
+    });
+
+    it('resolves approval promise', async () => {
+      numDeletions = 1;
+
+      const approvalPromise = approvalController.add({ id: 'foo', origin: 'bar.baz' });
+      approvalController.resolve('foo', 'success');
+
+      const result = await approvalPromise;
+      assert.strictEqual(result, 'success', 'should have resolved expected value');
+    });
+
+    it('resolves multiple approval promises out of order', async () => {
+      numDeletions = 2;
+
+      const approvalPromise1 = approvalController.add({ id: 'foo1', origin: 'bar.baz' });
+      const approvalPromise2 = approvalController.add({ id: 'foo2', origin: 'bar.baz', type: 'myType2' });
+
+      approvalController.resolve('foo2', 'success2');
+
+      let result = await approvalPromise2;
+      assert.strictEqual(result, 'success2', 'should have resolved expected value');
+
+      approvalController.resolve('foo1', 'success1');
+
+      result = await approvalPromise1;
+      assert.strictEqual(result, 'success1', 'should have resolved expected value');
+    });
+
+    it('throws on unknown id', () => {
+      assert.throws(() => approvalController.resolve('foo'), getIdNotFoundError('foo'), 'should reject on unknown id');
+    });
+  });
+
+  describe('reject', () => {
+    let approvalController: ApprovalController;
+    let numDeletions: number;
+    let deleteSpy: typeof sinon.spy;
+
+    beforeEach(() => {
+      approvalController = new ApprovalController({ ...defaultConfig });
+      deleteSpy = sinon.spy(approvalController, '_delete');
+      numDeletions = 0;
+    });
+
+    afterEach(() => {
+      assert.strictEqual(deleteSpy.callCount, numDeletions, `should have called '_delete' ${numDeletions} times`);
+    });
+
+    it('rejects approval promise', async () => {
+      numDeletions = 1;
+
+      const approvalPromise = assert.rejects(
+        () => approvalController.add({ id: 'foo', origin: 'bar.baz' }),
+        getError('failure'),
+        'should reject with expected error',
+      );
+      approvalController.reject('foo', new Error('failure'));
+
+      await approvalPromise;
+    });
+
+    it('rejects multiple approval promises out of order', async () => {
+      numDeletions = 2;
+
+      const rejectionPromise1 = assert.rejects(
+        () => approvalController.add({ id: 'foo1', origin: 'bar.baz' }),
+        getError('failure1'),
+        'should reject with expected error',
+      );
+      const rejectionPromise2 = assert.rejects(
+        () => approvalController.add({ id: 'foo2', origin: 'bar.baz', type: 'myType2' }),
+        getError('failure2'),
+        'should reject with expected error',
+      );
+
+      approvalController.reject('foo2', new Error('failure2'));
+      await rejectionPromise2;
+
+      approvalController.reject('foo1', new Error('failure1'));
+      await rejectionPromise1;
+    });
+
+    it('throws on unknown id', () => {
+      assert.throws(
+        () => approvalController.reject('foo', new Error('bar')),
+        getIdNotFoundError('foo'),
+        'should reject on unknown id',
+      );
+    });
+  });
+
+  describe('resolve and reject', () => {
+    it('resolves and rejects multiple approval promises out of order', async () => {
+      const approvalController = new ApprovalController({ ...defaultConfig });
+
+      const promise1 = approvalController.add({ id: 'foo1', origin: 'bar.baz' });
+      const promise2 = approvalController.add({ id: 'foo2', origin: 'bar.baz', type: 'myType2' });
+      const promise3 = assert.rejects(
+        () => approvalController.add({ id: 'foo3', origin: 'fizz.buzz' }),
+        getError('failure3'),
+        'should reject with expected error',
+      );
+      const promise4 = assert.rejects(
+        () => approvalController.add({ id: 'foo4', origin: 'bar.baz', type: 'myType4' }),
+        getError('failure4'),
+        'should reject with expected error',
+      );
+
+      approvalController.resolve('foo2', 'success2');
+
+      let result = await promise2;
+      assert.strictEqual(result, 'success2', 'should have resolved expected value');
+
+      approvalController.reject('foo4', new Error('failure4'));
+      await promise4;
+
+      approvalController.reject('foo3', new Error('failure3'));
+      await promise3;
+
+      assert.ok(!approvalController.has({ origin: 'fizz.buzz' }), 'should have deleted origin');
+      assert.ok(approvalController.has({ origin: 'bar.baz' }), 'should have origin with remaining approval');
+
+      approvalController.resolve('foo1', 'success1');
+
+      result = await promise1;
+      assert.strictEqual(result, 'success1', 'should have resolved expected value');
+
+      assert.ok(!approvalController.has({ origin: 'bar.baz' }), 'origins should be removed');
+    });
+  });
+
+  describe('clear', () => {
+    let approvalController: ApprovalController, numDeletions: number, deleteSpy: any;
+
+    beforeEach(() => {
+      approvalController = new ApprovalController({ ...defaultConfig });
+      deleteSpy = sinon.spy(approvalController, '_delete');
+      numDeletions = 0;
+    });
+
+    afterEach(() => {
+      assert.strictEqual(deleteSpy.callCount, numDeletions, `should have called '_delete' ${numDeletions} times`);
+    });
+
+    it('does nothing if state is already empty', () => {
+      assert.doesNotThrow(() => approvalController.clear(), 'should not throw');
+    });
+
+    it('deletes existing entries', async () => {
+      numDeletions = 3;
+
+      const clearPromise = Promise.all([
+        assert.rejects(
+          () => approvalController.add({ id: 'foo1', origin: 'bar.baz' }),
+          'every approval promise should reject',
+        ),
+        assert.rejects(
+          () => approvalController.add({ id: 'foo2', origin: 'bar.baz', type: 'myType' }),
+          'every approval promise should reject',
+        ),
+        assert.rejects(
+          () => approvalController.add({ id: 'foo3', origin: 'fizz.buzz', type: 'myType' }),
+          'every approval promise should reject',
+        ),
+      ]);
+
+      approvalController.clear();
+      await clearPromise;
+
+      assert.deepStrictEqual(approvalController.state[STORE_KEY], {}, 'store should be empty');
+    });
+  });
+});
+
+// helpers
+
+function getIdCollisionError(id: string) {
+  return getError(`Approval with id '${id}' already exists.`, ERROR_CODES.rpc.internal);
+}
+
+function getOriginTypeCollisionError(origin: string, type = '_default') {
+  const message = `Request${
+    type === '_default' ? '' : ` of type '${type}'`
+  } already pending for origin ${origin}. Please wait.`;
+  return getError(message, ERROR_CODES.rpc.resourceUnavailable);
+}
+
+function getIdNotFoundError(id: string) {
+  return getError(`Approval with id '${id}' not found.`);
+}
+
+function getError(message: string, code?: number) {
+  const err: any = {
+    name: 'Error',
+    message,
+  };
+  if (code !== undefined) {
+    err.code = code;
+  }
+  return err;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5090,6 +5090,11 @@ nan@^2.0.8, nan@^2.14.0, nan@^2.2.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
+nanoid@^3.1.12:
+  version "3.1.12"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.12.tgz#6f7736c62e8d39421601e4a0c77623a97ea69654"
+  integrity sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"


### PR DESCRIPTION
### Summary

This PR adds a generic "approval" controller for managing user confirmations and displaying them in the MetaMask UI. The controller is designed to be used in both the extension and mobile.

The approval controller accepts a single config argument, `showApprovalRequest`, which is a function that should trigger the display of a user confirmation in the MetaMask UI. `ApprovalController.addAndShowApprovalRequest` adds a pending request to the controller's state, and _then_ calls `showApprovalRequest`. This allows the UI to select the pending request via the approval controller's state.

Optionally, a pending request can be added without calling `showApprovalRequest`, via `ApprovalController.add`.

The approval controller was originally implemented in JavaScript in [this extension PR](https://github.com/MetaMask/metamask-extension/pull/9401), which will be updated to import the approval controller from `@metamask/controllers` once this PR has been merged.

### CI Changes

For the original approval controller implementation, I added input validation for all public methods (at least somewhere along their code paths), and unit tests to test the input validation. Since, it's impossible to pass invalid inputs in TypeScript, I had to write additional tests in JavaScript, and test against the built approval controller files. This necessitated making the build step in CI a precondition for formatting and unit tests.

### Miscellaneous

This PR includes the lint/formatting changes also introduced in #291, which should be merged first.