### PR TITLE
eth-sig-util@3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eth-phishing-detect": "^1.1.13",
     "eth-query": "^2.1.2",
     "eth-rpc-errors": "^4.0.0",
-    "eth-sig-util": "^2.3.0",
+    "eth-sig-util": "3.0.0",
     "ethereumjs-util": "^6.1.0",
     "ethereumjs-wallet": "0.6.0",
     "ethjs-query": "^0.3.8",

--- a/src/keyring/KeyringController.ts
+++ b/src/keyring/KeyringController.ts
@@ -1,11 +1,16 @@
 import { toChecksumAddress } from 'ethereumjs-util';
+import {
+  normalize as normalizeAddress,
+  signTypedData,
+  signTypedData_v4,
+  signTypedDataLegacy,
+} from 'eth-sig-util';
 import BaseController, { BaseConfig, BaseState, Listener } from '../BaseController';
 import PreferencesController from '../user/PreferencesController';
 import { Transaction } from '../transaction/TransactionController';
 import { PersonalMessageParams } from '../message-manager/PersonalMessageManager';
 import { TypedMessageParams } from '../message-manager/TypedMessageManager';
 
-const sigUtil = require('eth-sig-util');
 const Keyring = require('eth-keyring-controller');
 const { Mutex } = require('await-semaphore');
 const Wallet = require('ethereumjs-wallet');
@@ -347,17 +352,18 @@ export class KeyringController extends BaseController<KeyringConfig, KeyringStat
    */
   async signTypedMessage(messageParams: TypedMessageParams, version: string) {
     try {
-      const address = sigUtil.normalize(messageParams.from);
+      const address = normalizeAddress(messageParams.from);
       const { password } = privates.get(this).keyring;
       const privateKey = await this.exportAccount(password, address);
       const privateKeyBuffer = ethUtil.toBuffer(ethUtil.addHexPrefix(privateKey));
       switch (version) {
         case 'V1':
-          return sigUtil.signTypedDataLegacy(privateKeyBuffer, { data: messageParams.data });
+          // signTypedDataLegacy will throw if the data is invalid.
+          return signTypedDataLegacy(privateKeyBuffer, { data: messageParams.data as any });
         case 'V3':
-          return sigUtil.signTypedData(privateKeyBuffer, { data: JSON.parse(messageParams.data as string) });
+          return signTypedData(privateKeyBuffer, { data: JSON.parse(messageParams.data as string) });
         case 'V4':
-          return sigUtil.signTypedData_v4(privateKeyBuffer, {
+          return signTypedData_v4(privateKeyBuffer, {
             data: JSON.parse(messageParams.data as string),
           });
       }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,11 +1,11 @@
 import { addHexPrefix, isValidAddress, bufferToHex } from 'ethereumjs-util';
+import { TYPED_MESSAGE_SCHEMA, typedSignatureHash } from 'eth-sig-util';
 import { Transaction, FetchAllOptions } from './transaction/TransactionController';
 import { MessageParams } from './message-manager/MessageManager';
 import { PersonalMessageParams } from './message-manager/PersonalMessageManager';
 import { TypedMessageParams } from './message-manager/TypedMessageManager';
 import { Token } from './assets/TokenRatesController';
 
-const sigUtil = require('eth-sig-util');
 const jsonschema = require('jsonschema');
 const { BN, stripHexPrefix } = require('ethereumjs-util');
 const ensNamehash = require('eth-ens-namehash');
@@ -300,7 +300,8 @@ export function validateTypedSignMessageDataV1(messageData: TypedMessageParams) 
     throw new Error(`Invalid message "data": ${messageData.data} must be a valid array.`);
   }
   try {
-    sigUtil.typedSignatureHash(messageData.data);
+    // typedSignatureHash will throw if the data is invalid.
+    typedSignatureHash(messageData.data as any);
   } catch (e) {
     throw new Error(`Expected EIP712 typed data.`);
   }
@@ -325,7 +326,7 @@ export function validateTypedSignMessageDataV3(messageData: TypedMessageParams) 
   } catch (e) {
     throw new Error('Data must be passed as a valid JSON string.');
   }
-  const validation = jsonschema.validate(data, sigUtil.TYPED_MESSAGE_SCHEMA);
+  const validation = jsonschema.validate(data, TYPED_MESSAGE_SCHEMA);
   if (validation.errors.length > 0) {
     throw new Error('Data must conform to EIP-712 schema. See https://git.io/fNtcx.');
   }

--- a/tests/KeyringController.test.ts
+++ b/tests/KeyringController.test.ts
@@ -1,10 +1,15 @@
 import * as ethUtil from 'ethereumjs-util';
+import {
+  recoverPersonalSignature,
+  recoverTypedSignature,
+  recoverTypedSignature_v4,
+  recoverTypedSignatureLegacy,
+} from 'eth-sig-util';
 import { stub } from 'sinon';
 import KeyringController, { Keyring, KeyringConfig } from '../src/keyring/KeyringController';
 import PreferencesController from '../src/user/PreferencesController';
 import ComposableController from '../src/ComposableController';
 
-const sigUtil = require('eth-sig-util');
 const Transaction = require('ethereumjs-tx');
 const mockEncryptor: any = require('./utils/mockEncryptor');
 
@@ -152,7 +157,7 @@ describe('KeyringController', () => {
     const data = ethUtil.bufferToHex(Buffer.from('Hello from test', 'utf8'));
     const account = initialState.keyrings[0].accounts[0];
     const signature = await keyringController.signPersonalMessage({ data, from: account });
-    const recovered = sigUtil.recoverPersonalSignature({ data, sig: signature });
+    const recovered = recoverPersonalSignature({ data, sig: signature });
     expect(account).toBe(recovered);
   });
 
@@ -171,7 +176,7 @@ describe('KeyringController', () => {
     ];
     const account = initialState.keyrings[0].accounts[0];
     const signature = await keyringController.signTypedMessage({ data: typedMsgParams, from: account }, 'V1');
-    const recovered = sigUtil.recoverTypedSignatureLegacy({ data: typedMsgParams, sig: signature });
+    const recovered = recoverTypedSignatureLegacy({ data: typedMsgParams, sig: signature as string });
     expect(account).toBe(recovered);
   });
 
@@ -212,7 +217,7 @@ describe('KeyringController', () => {
       { data: JSON.stringify(msgParams), from: account },
       'V3',
     );
-    const recovered = sigUtil.recoverTypedSignature({ data: msgParams, sig: signature });
+    const recovered = recoverTypedSignature({ data: msgParams as any, sig: signature as string });
     expect(account).toBe(recovered);
   });
 
@@ -270,7 +275,7 @@ describe('KeyringController', () => {
       { data: JSON.stringify(msgParams), from: account },
       'V4',
     );
-    const recovered = sigUtil.recoverTypedSignature_v4({ data: msgParams, sig: signature });
+    const recovered = recoverTypedSignature_v4({ data: msgParams as any, sig: signature as string });
     expect(account).toBe(recovered);
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2556,18 +2556,10 @@ eth-rpc-errors@^4.0.0:
   dependencies:
     fast-safe-stringify "^2.0.6"
 
-eth-sig-util@^1.4.0, eth-sig-util@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-1.4.2.tgz#8d958202c7edbaae839707fba6f09ff327606210"
-  integrity sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=
-  dependencies:
-    ethereumjs-abi "git+https://github.com/ethereumjs/ethereumjs-abi.git"
-    ethereumjs-util "^5.1.1"
-
-eth-sig-util@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-2.3.0.tgz#c54a6ac8e8796f7e25f59cf436982a930e645231"
-  integrity sha512-ugD1AvaggvKaZDgnS19W5qOfepjGc7qHrt7TrAaL54gJw9SHvgIXJ3r2xOMW30RWJZNP+1GlTOy5oye7yXA4xA==
+eth-sig-util@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-3.0.0.tgz#75133b3d7c20a5731af0690c385e184ab942b97e"
+  integrity sha512-4eFkMOhpGbTxBQ3AMzVf0haUX2uTur7DpWiHzWyTURa28BVJJtOkcb9Ok5TV0YvEPG61DODPW7ZUATbJTslioQ==
   dependencies:
     buffer "^5.2.1"
     elliptic "^6.4.0"
@@ -2575,6 +2567,14 @@ eth-sig-util@^2.3.0:
     ethereumjs-util "^5.1.1"
     tweetnacl "^1.0.0"
     tweetnacl-util "^0.15.0"
+
+eth-sig-util@^1.4.0, eth-sig-util@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-1.4.2.tgz#8d958202c7edbaae839707fba6f09ff327606210"
+  integrity sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=
+  dependencies:
+    ethereumjs-abi "git+https://github.com/ethereumjs/ethereumjs-abi.git"
+    ethereumjs-util "^5.1.1"
 
 eth-sig-util@^2.4.4, eth-sig-util@^2.5.0:
   version "2.5.0"


### PR DESCRIPTION
- `eth-sig-util@3.0.0`
  - Because this version uses TypeScript, we had to cast variables in certain places to `any`. The package makes runtime type checks wherever we do so, and we catch any errors thrown.