### PR TITLE
Add approval controller count methods

### DIFF
--- a/src/approval/ApprovalController.ts
+++ b/src/approval/ApprovalController.ts
@@ -157,11 +157,11 @@ export class ApprovalController extends BaseController<ApprovalConfig, ApprovalS
    * @returns The pending approval count for the given origin and/or type.
    */
   getApprovalCount(opts: { origin?: string; type?: string | null} = {}): number {
-    const { origin } = opts;
-    const _type = opts.type === null ? NO_TYPE : opts.type;
-    if (!origin && !_type) {
+    if (!opts.origin && !opts.type && opts.type !== null) {
       throw new Error('Must specify origin, type, or both.');
     }
+    const { origin } = opts;
+    const _type = opts.type === null ? NO_TYPE : opts.type as ApprovalType;
 
     if (origin && _type) {
       return Number(Boolean(this._origins.get(origin)?.has(_type)));
@@ -173,9 +173,8 @@ export class ApprovalController extends BaseController<ApprovalConfig, ApprovalS
 
     // Only "type" was specified
     let count = 0;
-    for (const id of Object.keys(this.state[STORE_KEY])) {
-      const storeType = this.state[STORE_KEY][id].type;
-      if (storeType === _type || (storeType === undefined && _type === NO_TYPE)) {
+    for (const [_origin, types] of this._origins) {
+      if (types.has(_type)) {
         count += 1;
       }
     }

--- a/tests/ApprovalController.test.js
+++ b/tests/ApprovalController.test.js
@@ -48,12 +48,24 @@ describe('ApprovalController: Input Validation', () => {
     });
   });
 
+  describe('getApprovalCount', () => {
+    it('validates input', () => {
+      const approvalController = getApprovalController();
+
+      expect(() => approvalController.getApprovalCount()).toThrow(getApprovalCountParamsError());
+      expect(() => approvalController.getApprovalCount({})).toThrow(getApprovalCountParamsError());
+      expect(() => approvalController.getApprovalCount({ origin: null })).toThrow(getApprovalCountParamsError());
+      expect(() => approvalController.getApprovalCount({ type: false })).toThrow(getApprovalCountParamsError());
+    });
+  });
+
+
   describe('has', () => {
     it('validates input', () => {
       const approvalController = getApprovalController();
 
+      expect(() => approvalController.has()).toThrow(getMissingIdOrOriginError());
       expect(() => approvalController.has({})).toThrow(getMissingIdOrOriginError());
-
       expect(() => approvalController.has({ type: false })).toThrow(getNoFalsyTypeError());
     });
   });
@@ -137,6 +149,10 @@ function getEmptyStringTypeError(code) {
 
 function getMissingIdOrOriginError() {
   return getError('Must specify id or origin.');
+}
+
+function getApprovalCountParamsError() {
+  return getError('Must specify origin, type, or both.');
 }
 
 function getError(message, code) {

--- a/tests/ApprovalController.test.js
+++ b/tests/ApprovalController.test.js
@@ -59,7 +59,6 @@ describe('ApprovalController: Input Validation', () => {
     });
   });
 
-
   describe('has', () => {
     it('validates input', () => {
       const approvalController = getApprovalController();

--- a/tests/ApprovalController.test.ts
+++ b/tests/ApprovalController.test.ts
@@ -147,26 +147,17 @@ describe('approval controller', () => {
       addWithCatch({ id: '2', origin: 'origin1', type: 'type1' });
       addWithCatch({ id: '3', origin: 'origin2', type: 'type1' });
 
-      expect(approvalController.getApprovalCount({ origin: 'origin1', type: null }))
-        .toEqual(1);
-      expect(approvalController.getApprovalCount({ origin: 'origin1', type: 'type1' }))
-        .toEqual(1);
-      expect(approvalController.getApprovalCount({ origin: 'origin1', type: 'type2' }))
-        .toEqual(0);
+      expect(approvalController.getApprovalCount({ origin: 'origin1', type: null })).toEqual(1);
+      expect(approvalController.getApprovalCount({ origin: 'origin1', type: 'type1' })).toEqual(1);
+      expect(approvalController.getApprovalCount({ origin: 'origin1', type: 'type2' })).toEqual(0);
 
-      expect(approvalController.getApprovalCount({ origin: 'origin2', type: null }))
-        .toEqual(0);
-      expect(approvalController.getApprovalCount({ origin: 'origin2', type: 'type1' }))
-        .toEqual(1);
-      expect(approvalController.getApprovalCount({ origin: 'origin2', type: 'type2' }))
-        .toEqual(0);
+      expect(approvalController.getApprovalCount({ origin: 'origin2', type: null })).toEqual(0);
+      expect(approvalController.getApprovalCount({ origin: 'origin2', type: 'type1' })).toEqual(1);
+      expect(approvalController.getApprovalCount({ origin: 'origin2', type: 'type2' })).toEqual(0);
 
-      expect(approvalController.getApprovalCount({ origin: 'origin3', type: null }))
-        .toEqual(0);
-      expect(approvalController.getApprovalCount({ origin: 'origin3', type: 'type1' }))
-        .toEqual(0);
-      expect(approvalController.getApprovalCount({ origin: 'origin3', type: 'type2' }))
-        .toEqual(0);
+      expect(approvalController.getApprovalCount({ origin: 'origin3', type: null })).toEqual(0);
+      expect(approvalController.getApprovalCount({ origin: 'origin3', type: 'type1' })).toEqual(0);
+      expect(approvalController.getApprovalCount({ origin: 'origin3', type: 'type2' })).toEqual(0);
     });
 
     it('gets the count when specifying origin only', () => {
@@ -174,14 +165,11 @@ describe('approval controller', () => {
       addWithCatch({ id: '2', origin: 'origin1', type: 'type1' });
       addWithCatch({ id: '3', origin: 'origin2', type: 'type1' });
 
-      expect(approvalController.getApprovalCount({ origin: 'origin1' }))
-        .toEqual(2);
+      expect(approvalController.getApprovalCount({ origin: 'origin1' })).toEqual(2);
 
-      expect(approvalController.getApprovalCount({ origin: 'origin2' }))
-        .toEqual(1);
+      expect(approvalController.getApprovalCount({ origin: 'origin2' })).toEqual(1);
 
-      expect(approvalController.getApprovalCount({ origin: 'origin3' }))
-        .toEqual(0);
+      expect(approvalController.getApprovalCount({ origin: 'origin3' })).toEqual(0);
     });
 
     it('gets the count when specifying type only', () => {
@@ -190,17 +178,13 @@ describe('approval controller', () => {
       addWithCatch({ id: '3', origin: 'origin2', type: 'type1' });
       addWithCatch({ id: '4', origin: 'origin2', type: 'type2' });
 
-      expect(approvalController.getApprovalCount({ type: null }))
-        .toEqual(1);
+      expect(approvalController.getApprovalCount({ type: null })).toEqual(1);
 
-      expect(approvalController.getApprovalCount({ type: 'type1' }))
-        .toEqual(2);
+      expect(approvalController.getApprovalCount({ type: 'type1' })).toEqual(2);
 
-      expect(approvalController.getApprovalCount({ type: 'type2' }))
-        .toEqual(1);
+      expect(approvalController.getApprovalCount({ type: 'type2' })).toEqual(1);
 
-      expect(approvalController.getApprovalCount({ type: 'type3' }))
-        .toEqual(0);
+      expect(approvalController.getApprovalCount({ type: 'type3' })).toEqual(0);
     });
   });
 

--- a/tests/ApprovalController.test.ts
+++ b/tests/ApprovalController.test.ts
@@ -133,6 +133,101 @@ describe('approval controller', () => {
     });
   });
 
+  describe('getApprovalCount', () => {
+    let approvalController: ApprovalController;
+    let addWithCatch: (args: any) => void;
+
+    beforeEach(() => {
+      approvalController = new ApprovalController({ ...defaultConfig });
+      addWithCatch = (args: any) => approvalController.add(args).catch(() => undefined);
+    });
+
+    it('gets the count when specifying origin and type', () => {
+      addWithCatch({ id: '1', origin: 'origin1' });
+      addWithCatch({ id: '2', origin: 'origin1', type: 'type1' });
+      addWithCatch({ id: '3', origin: 'origin2', type: 'type1' });
+
+      expect(approvalController.getApprovalCount({ origin: 'origin1', type: null }))
+        .toEqual(1);
+      expect(approvalController.getApprovalCount({ origin: 'origin1', type: 'type1' }))
+        .toEqual(1);
+      expect(approvalController.getApprovalCount({ origin: 'origin1', type: 'type2' }))
+        .toEqual(0);
+
+      expect(approvalController.getApprovalCount({ origin: 'origin2', type: null }))
+        .toEqual(0);
+      expect(approvalController.getApprovalCount({ origin: 'origin2', type: 'type1' }))
+        .toEqual(1);
+      expect(approvalController.getApprovalCount({ origin: 'origin2', type: 'type2' }))
+        .toEqual(0);
+
+      expect(approvalController.getApprovalCount({ origin: 'origin3', type: null }))
+        .toEqual(0);
+      expect(approvalController.getApprovalCount({ origin: 'origin3', type: 'type1' }))
+        .toEqual(0);
+      expect(approvalController.getApprovalCount({ origin: 'origin3', type: 'type2' }))
+        .toEqual(0);
+    });
+
+    it('gets the count when specifying origin only', () => {
+      addWithCatch({ id: '1', origin: 'origin1' });
+      addWithCatch({ id: '2', origin: 'origin1', type: 'type1' });
+      addWithCatch({ id: '3', origin: 'origin2', type: 'type1' });
+
+      expect(approvalController.getApprovalCount({ origin: 'origin1' }))
+        .toEqual(2);
+
+      expect(approvalController.getApprovalCount({ origin: 'origin2' }))
+        .toEqual(1);
+
+      expect(approvalController.getApprovalCount({ origin: 'origin3' }))
+        .toEqual(0);
+    });
+
+    it('gets the count when specifying type only', () => {
+      addWithCatch({ id: '1', origin: 'origin1' });
+      addWithCatch({ id: '2', origin: 'origin1', type: 'type1' });
+      addWithCatch({ id: '3', origin: 'origin2', type: 'type1' });
+      addWithCatch({ id: '4', origin: 'origin2', type: 'type2' });
+
+      expect(approvalController.getApprovalCount({ type: null }))
+        .toEqual(1);
+
+      expect(approvalController.getApprovalCount({ type: 'type1' }))
+        .toEqual(2);
+
+      expect(approvalController.getApprovalCount({ type: 'type2' }))
+        .toEqual(1);
+
+      expect(approvalController.getApprovalCount({ type: 'type3' }))
+        .toEqual(0);
+    });
+  });
+
+  describe('getTotalApprovalCount', () => {
+    it('gets the total approval count', () => {
+      const approvalController = new ApprovalController({ ...defaultConfig });
+      expect(approvalController.getTotalApprovalCount()).toEqual(0);
+
+      const addWithCatch = (args: any) => approvalController.add(args).catch(() => undefined);
+
+      addWithCatch({ id: '1', origin: 'origin1' });
+      expect(approvalController.getTotalApprovalCount()).toEqual(1);
+
+      addWithCatch({ id: '2', origin: 'origin1', type: 'type1' });
+      expect(approvalController.getTotalApprovalCount()).toEqual(2);
+
+      addWithCatch({ id: '3', origin: 'origin2', type: 'type1' });
+      expect(approvalController.getTotalApprovalCount()).toEqual(3);
+
+      approvalController.reject('2', new Error('foo'));
+      expect(approvalController.getTotalApprovalCount()).toEqual(2);
+
+      approvalController.clear();
+      expect(approvalController.getTotalApprovalCount()).toEqual(0);
+    });
+  });
+
   describe('has', () => {
     let approvalController: ApprovalController;
 


### PR DESCRIPTION
Adds two methods to the approval controller:
- `getTotalApprovalCount`, for getting the total count of all approvals, regardless of origin and type
- `getApprovalCount`, for getting the count of all approvals by origin, type, or both

We need this for e.g. the the `updateBadge` functionality in the MetaMask extension. Implementing the methods on the controller itself is better than hacking it on at the consumer layer.