### PR TITLE
Add lock and unlock events with a bump on the keyring controller

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eth-contract-metadata": "^1.11.0",
     "eth-ens-namehash": "^2.0.8",
     "eth-json-rpc-infura": "^5.1.0",
-    "eth-keyring-controller": "^5.6.1",
+    "eth-keyring-controller": "^6.1.0",
     "eth-method-registry": "1.1.0",
     "eth-phishing-detect": "^1.1.13",
     "eth-query": "^2.1.2",

--- a/src/keyring/KeyringController.ts
+++ b/src/keyring/KeyringController.ts
@@ -416,6 +416,14 @@ export class KeyringController extends BaseController<KeyringConfig, KeyringStat
     return privates.get(this).keyring.store.unsubscribe(listener);
   }
 
+  onLock(listener: Listener<KeyringState>){
+    return privates.get(this).keyring.on('lock', listener)
+  }
+
+  onUnlock(listener: Listener<KeyringState>){
+	return privates.get(this).keyring.on('unlock', listener)
+  }
+
   /**
    * Verifies the that the seed phrase restores the current keychain's accounts
    *

--- a/src/keyring/KeyringController.ts
+++ b/src/keyring/KeyringController.ts
@@ -416,11 +416,11 @@ export class KeyringController extends BaseController<KeyringConfig, KeyringStat
     return privates.get(this).keyring.store.unsubscribe(listener);
   }
 
-  onLock(listener: Listener<KeyringState>) {
+  onLock(listener: void) {
     return privates.get(this).keyring.on('lock', listener);
   }
 
-  onUnlock(listener: Listener<KeyringState>) {
+  onUnlock(listener: void) {
     return privates.get(this).keyring.on('unlock', listener);
   }
 

--- a/src/keyring/KeyringController.ts
+++ b/src/keyring/KeyringController.ts
@@ -421,7 +421,7 @@ export class KeyringController extends BaseController<KeyringConfig, KeyringStat
   }
 
   onUnlock(listener: Listener<KeyringState>){
-	return privates.get(this).keyring.on('unlock', listener)
+    return privates.get(this).keyring.on('unlock', listener)
   }
 
   /**

--- a/src/keyring/KeyringController.ts
+++ b/src/keyring/KeyringController.ts
@@ -416,12 +416,12 @@ export class KeyringController extends BaseController<KeyringConfig, KeyringStat
     return privates.get(this).keyring.store.unsubscribe(listener);
   }
 
-  onLock(listener: Listener<KeyringState>){
-    return privates.get(this).keyring.on('lock', listener)
+  onLock(listener: Listener<KeyringState>) {
+    return privates.get(this).keyring.on('lock', listener);
   }
 
-  onUnlock(listener: Listener<KeyringState>){
-    return privates.get(this).keyring.on('unlock', listener)
+  onUnlock(listener: Listener<KeyringState>) {
+    return privates.get(this).keyring.on('unlock', listener);
   }
 
   /**

--- a/src/keyring/KeyringController.ts
+++ b/src/keyring/KeyringController.ts
@@ -416,11 +416,23 @@ export class KeyringController extends BaseController<KeyringConfig, KeyringStat
     return privates.get(this).keyring.store.unsubscribe(listener);
   }
 
-  onLock(listener: void) {
+  /**
+   * Adds new listener to be notified when the wallet is locked
+   *
+   * @param listener - Callback triggered when wallet is locked
+   * @returns - EventEmitter if listener added
+   */
+  onLock(listener: () => void) {
     return privates.get(this).keyring.on('lock', listener);
   }
 
-  onUnlock(listener: void) {
+  /**
+   * Adds new listener to be notified when the wallet is unlocked
+   *
+   * @param listener - Callback triggered when wallet is unlocked
+   * @returns - EventEmitter if listener added
+   */
+  onUnlock(listener: () => void) {
     return privates.get(this).keyring.on('unlock', listener);
   }
 

--- a/tests/KeyringController.test.ts
+++ b/tests/KeyringController.test.ts
@@ -328,4 +328,15 @@ describe('KeyringController', () => {
     await keyringController.removeAccount('0x51253087e6f8358b5f10c0a94315d69db3357859');
     expect(listener.calledTwice).toBe(false);
   });
+
+  it('should receive lock and unlock events', async () => {
+    const listenerLock = stub();
+    keyringController.onLock(listenerLock);
+	await keyringController.setLocked()
+	expect(listenerLock.called).toBe(true);
+	const listenerUnlock = stub();
+	keyringController.onUnlock(listenerUnlock);
+	await keyringController.submitPassword(password);
+	expect(listenerUnlock.called).toBe(true);
+  });
 });

--- a/tests/KeyringController.test.ts
+++ b/tests/KeyringController.test.ts
@@ -332,11 +332,11 @@ describe('KeyringController', () => {
   it('should receive lock and unlock events', async () => {
     const listenerLock = stub();
     keyringController.onLock(listenerLock);
-	await keyringController.setLocked()
-	expect(listenerLock.called).toBe(true);
-	const listenerUnlock = stub();
-	keyringController.onUnlock(listenerUnlock);
-	await keyringController.submitPassword(password);
-	expect(listenerUnlock.called).toBe(true);
+    await keyringController.setLocked();
+    expect(listenerLock.called).toBe(true);
+    const listenerUnlock = stub();
+    keyringController.onUnlock(listenerUnlock);
+    await keyringController.submitPassword(password);
+    expect(listenerUnlock.called).toBe(true);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2505,10 +2505,10 @@ eth-json-rpc-middleware@^6.0.0:
     pify "^3.0.0"
     safe-event-emitter "^1.0.1"
 
-eth-keyring-controller@^5.6.1:
-  version "5.6.1"
-  resolved "https://registry.yarnpkg.com/eth-keyring-controller/-/eth-keyring-controller-5.6.1.tgz#7b7268400704c8f5ce98a055910341177dd207ca"
-  integrity sha512-sxJ87bJg7PvvPzj1sY1jJYHQL1HVUhh84Q/a4QPrcnzAAng1yibvvUfww0pCez4XJfHuMkJvUxfF8eAusJM8fQ==
+eth-keyring-controller@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/eth-keyring-controller/-/eth-keyring-controller-6.1.0.tgz#dc9313d0b793e085dc1badf84dd4f5e3004e127e"
+  integrity sha512-wPxH++98VDBcDv9YkPzxhZC0gF1ixuRbyKR2u/NOT/roBpNQDe4reqyllBRC7jhPehiKnRxzf7r6HEyirRnPxQ==
   dependencies:
     bip39 "^2.4.0"
     bluebird "^3.5.0"


### PR DESCRIPTION
Bumped the `eth-keyring-controller` to **6.1.0** to be able to access the lock/unlock events.
Also added two functions `onLock` and `onUnlock` so that we can add listeners for those events.