### PR TITLE
RFC: Redesigned controller API

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "ethjs-query": "^0.3.8",
     "human-standard-collectible-abi": "^1.0.2",
     "human-standard-token-abi": "^2.0.0",
+    "immer": "^7.0.9",
     "isomorphic-fetch": "^3.0.0",
     "jsonschema": "^1.2.4",
     "nanoid": "^3.1.12",

--- a/src/assets/CurrencyRateController.ts
+++ b/src/assets/CurrencyRateController.ts
@@ -1,102 +1,82 @@
-import BaseController, { BaseConfig, BaseState } from '../BaseController';
-import { safelyExecute, handleFetch } from '../util';
+import { Mutex } from 'await-semaphore';
 
-const { Mutex } = require('await-semaphore');
-
-/**
- * @type CurrencyRateConfig
- *
- * Currency rate controller configuration
- *
- * @property currentCurrency - Currently-active ISO 4217 currency code
- * @property interval - Polling interval used to fetch new currency rate
- * @property nativeCurrency - Symbol for the base asset used for conversion
- * @property includeUSDRate - Whether to include the usd rate in addition to the currentCurrency
- */
-export interface CurrencyRateConfig extends BaseConfig {
-  currentCurrency: string;
-  interval: number;
-  nativeCurrency: string;
-  includeUSDRate?: boolean;
-}
+import BaseController from '../base-controller-v2';
+import { safelyExecute } from '../util';
+import { fetchExchangeRate as defaultFetchExchangeRate } from '../crypto-compare';
 
 /**
  * @type CurrencyRateState
- *
- * Currency rate controller state
  *
  * @property conversionDate - Timestamp of conversion rate expressed in ms since UNIX epoch
  * @property conversionRate - Conversion rate from current base asset to the current currency
  * @property currentCurrency - Currently-active ISO 4217 currency code
  * @property nativeCurrency - Symbol for the base asset used for conversion
+ * @property pendingCurrentCurrency - The currency being switched to
+ * @property pendingNativeCurrency - The base asset currency being switched to
  * @property usdConversionRate - Conversion rate from usd to the current currency
  */
-export interface CurrencyRateState extends BaseState {
+export interface CurrencyRateState {
   conversionDate: number;
   conversionRate: number;
   currentCurrency: string;
   nativeCurrency: string;
+  pendingCurrentCurrency: string | null;
+  pendingNativeCurrency: string | null;
   usdConversionRate?: number;
 }
+
+const schema = {
+  conversionDate: { persist: true, anonymous: true },
+  conversionRate: { persist: true, anonymous: true },
+  currentCurrency: { persist: true, anonymous: true },
+  nativeCurrency: { persist: true, anonymous: true },
+  pendingCurrentCurrency: { persist: false, anonymous: true },
+  pendingNativeCurrency: { persist: false, anonymous: true },
+  usdConversionRate: { persist: false, anonymous: true },
+};
 
 /**
  * Controller that passively polls on a set interval for an exchange rate from the current base
  * asset to the current currency
  */
-export class CurrencyRateController extends BaseController<CurrencyRateConfig, CurrencyRateState> {
-  /* Optional config to include conversion to usd in all price url fetches and on state */
-  includeUSDRate?: boolean;
+export class CurrencyRateController extends BaseController<CurrencyRateState> {
 
-  private activeCurrency = '';
-
-  private activeNativeCurrency = '';
+  private static defaultState = {
+    conversionDate: 0,
+    conversionRate: 0,
+    currentCurrency: 'usd',
+    nativeCurrency: 'ETH',
+    pendingCurrentCurrency: null,
+    pendingNativeCurrency: null,
+  };
 
   private mutex = new Mutex();
 
   private handle?: NodeJS.Timer;
 
-  private getCurrentCurrencyFromState(state?: Partial<CurrencyRateState>) {
-    return state && state.currentCurrency ? state.currentCurrency : 'usd';
-  }
+  private interval = 180000;
 
-  private getPricingURL(currentCurrency: string, nativeCurrency: string, includeUSDRate?: boolean) {
-    return (
-      `https://min-api.cryptocompare.com/data/price?fsym=` +
-      `${nativeCurrency.toUpperCase()}&tsyms=${currentCurrency.toUpperCase()}` +
-      `${includeUSDRate && currentCurrency.toUpperCase() !== 'USD' ? ',USD' : ''}`
-    );
-  }
+  private fetchExchangeRate;
 
-  /**
-   * Name of this controller used during composition
-   */
-  name = 'CurrencyRateController';
+  private includeUsdRate;
 
   /**
    * Creates a CurrencyRateController instance
    *
-   * @param config - Initial options used to configure this controller
    * @param state - Initial state to set on this controller
    */
-  constructor(config?: Partial<CurrencyRateConfig>, state?: Partial<CurrencyRateState>) {
-    super(config, state);
-    this.defaultConfig = {
-      currentCurrency: this.getCurrentCurrencyFromState(state),
-      disabled: true,
-      interval: 180000,
-      nativeCurrency: 'ETH',
-      includeUSDRate: false,
-    };
-    this.defaultState = {
-      conversionDate: 0,
-      conversionRate: 0,
-      currentCurrency: this.defaultConfig.currentCurrency,
-      nativeCurrency: this.defaultConfig.nativeCurrency,
-      usdConversionRate: 0,
-    };
-    this.initialize();
-    this.configure({ disabled: false }, false, false);
+  constructor(state?: Partial<CurrencyRateState>, includeUsdRate = false, fetchExchangeRate = defaultFetchExchangeRate) {
+    super({ ...CurrencyRateController.defaultState, ...state }, schema);
+    this.includeUsdRate = includeUsdRate;
+    this.fetchExchangeRate = fetchExchangeRate;
     this.poll();
+  }
+
+  destroy() {
+    super.destroy();
+    if (this.handle) {
+      clearTimeout(this.handle);
+    }
   }
 
   /**
@@ -104,9 +84,11 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
    *
    * @param currentCurrency - ISO 4217 currency code
    */
-  set currentCurrency(currentCurrency: string) {
-    this.activeCurrency = currentCurrency;
-    safelyExecute(() => this.updateExchangeRate());
+  async setCurrentCurrency(currentCurrency: string) {
+    this.update((state) => {
+      state.pendingCurrentCurrency = currentCurrency;
+    });
+    await safelyExecute(() => this.updateExchangeRate());
   }
 
   /**
@@ -114,79 +96,52 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
    *
    * @param symbol - Symbol for the base asset
    */
-  set nativeCurrency(symbol: string) {
-    this.activeNativeCurrency = symbol;
-    safelyExecute(() => this.updateExchangeRate());
+  async setNativeCurrency(symbol: string) {
+    this.update((state) => {
+      state.pendingNativeCurrency = symbol;
+    });
+    await safelyExecute(() => this.updateExchangeRate());
   }
 
   /**
    * Starts a new polling interval
-   *
-   * @param interval - Polling interval used to fetch new exchange rate
    */
-  async poll(interval?: number): Promise<void> {
-    interval && this.configure({ interval }, false, false);
+  async poll(): Promise<void> {
     this.handle && clearTimeout(this.handle);
     await safelyExecute(() => this.updateExchangeRate());
     this.handle = setTimeout(() => {
-      this.poll(this.config.interval);
-    }, this.config.interval);
-  }
-
-  /**
-   * Fetches the exchange rate for a given currency
-   *
-   * @param currency - ISO 4217 currency code
-   * @param nativeCurrency - Symbol for base asset
-   * @param includeUSDRate - Whether to add the USD rate to the fetch
-   * @returns - Promise resolving to exchange rate for given currency
-   */
-  async fetchExchangeRate(currency: string, nativeCurrency = this.activeNativeCurrency, includeUSDRate?: boolean): Promise<CurrencyRateState> {
-    const json = await handleFetch(this.getPricingURL(currency, nativeCurrency, includeUSDRate));
-    const conversionRate = Number(json[currency.toUpperCase()]);
-    const usdConversionRate = Number(json.USD);
-    if (!Number.isFinite(conversionRate)) {
-      throw new Error(`Invalid response for ${currency.toUpperCase()}: ${json[currency.toUpperCase()]}`);
-    }
-    if (includeUSDRate && !Number.isFinite(usdConversionRate)) {
-      throw new Error(`Invalid response for usdConversionRate: ${json.USD}`);
-    }
-
-    return {
-      conversionDate: Date.now() / 1000,
-      conversionRate,
-      currentCurrency: currency,
-      nativeCurrency,
-      usdConversionRate,
-    };
+      this.poll();
+    }, this.interval);
   }
 
   /**
    * Updates exchange rate for the current currency
-   *
-   * @returns Promise resolving to currency data or undefined if disabled
    */
   async updateExchangeRate(): Promise<CurrencyRateState | void> {
-    if (this.disabled || !this.activeCurrency || !this.activeNativeCurrency) {
-      return;
-    }
     const releaseLock = await this.mutex.acquire();
+    const {
+      currentCurrency,
+      nativeCurrency,
+      pendingCurrentCurrency,
+      pendingNativeCurrency,
+    } = this.state;
     try {
       const { conversionDate, conversionRate, usdConversionRate } = await this.fetchExchangeRate(
-        this.activeCurrency,
-        this.activeNativeCurrency,
-        this.includeUSDRate,
+        pendingCurrentCurrency || currentCurrency,
+        pendingNativeCurrency || nativeCurrency,
+        this.includeUsdRate,
       );
-      const newState: CurrencyRateState = {
-        conversionDate,
-        conversionRate,
-        currentCurrency: this.activeCurrency,
-        nativeCurrency: this.activeNativeCurrency,
-        usdConversionRate: this.includeUSDRate ? usdConversionRate : this.defaultState.usdConversionRate,
-      };
-      this.update(newState);
-
-      return this.state;
+      this.update(() => {
+        return {
+          conversionDate,
+          conversionRate,
+          currentCurrency: pendingCurrentCurrency || currentCurrency,
+          nativeCurrency: pendingNativeCurrency || nativeCurrency,
+          pendingCurrentCurrency: null,
+          pendingNativeCurrency: null,
+          usdConversionRate,
+        };
+      });
     } finally {
       releaseLock();
     }

--- a/src/assets/TokenRatesController.ts
+++ b/src/assets/TokenRatesController.ts
@@ -1,8 +1,6 @@
 import { toChecksumAddress } from 'ethereumjs-util';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import { safelyExecute, handleFetch } from '../util';
-import AssetsController from './AssetsController';
-import CurrencyRateController from './CurrencyRateController';
 
 /**
  * @type CoinGeckoResponse
@@ -133,22 +131,6 @@ export class TokenRatesController extends BaseController<TokenRatesConfig, Token
    */
   async fetchExchangeRate(query: string): Promise<CoinGeckoResponse> {
     return handleFetch(this.getPricingURL(query));
-  }
-
-  /**
-   * Extension point called if and when this controller is composed
-   * with other controllers using a ComposableController
-   */
-  onComposed() {
-    super.onComposed();
-    const assets = this.context.AssetsController as AssetsController;
-    const currencyRate = this.context.CurrencyRateController as CurrencyRateController;
-    assets.subscribe(() => {
-      this.configure({ tokens: assets.state.tokens });
-    });
-    currencyRate.subscribe(() => {
-      this.configure({ nativeCurrency: currencyRate.state.nativeCurrency });
-    });
   }
 
   /**

--- a/src/base-controller-v2.ts
+++ b/src/base-controller-v2.ts
@@ -1,0 +1,98 @@
+// 'Draft' is a type, and import/named apparently doesn't like it when you
+// import a type: https://github.com/benmosher/eslint-plugin-import/issues/1699
+// eslint-disable-next-line import/named
+import { Draft, produce } from 'immer';
+
+/**
+ * State change callbacks
+ */
+export type Listener<T> = (state: T) => void;
+
+type Anonymizer<T> = (value: T) => T;
+
+export type Schema<T> = {
+  [P in keyof T]: {
+    persist: boolean;
+    anonymous: boolean | Anonymizer<T[P]>;
+  };
+};
+
+/**
+ * Controller class that provides state management and subscriptions
+ */
+export class BaseController<S extends Record<string, any>> {
+  private internalState: S;
+
+  private internalListeners: Listener<S>[] = [];
+
+  public readonly schema: Schema<S>;
+
+  /**
+   * Creates a BaseController instance.
+   *
+   * @param state - Initial controller state
+   * @param schema - State schema, describing how to "anonymize" the state,
+   *   and which parts should be persisted.
+   */
+  constructor(state: S, schema: Schema<S>) {
+    this.internalState = state;
+    this.schema = schema;
+  }
+
+  /**
+   * Retrieves current controller state
+   *
+   * @returns - Current state
+   */
+  get state() {
+    return this.internalState;
+  }
+
+  /**
+   * Adds new listener to be notified of state changes
+   *
+   * @param listener - Callback triggered when state changes
+   */
+  subscribe(listener: Listener<S>) {
+    this.internalListeners.push(listener);
+  }
+
+  /**
+   * Removes existing listener from receiving state changes
+   *
+   * @param listener - Callback to remove
+   * @returns - True if a listener is found and unsubscribed
+   */
+  unsubscribe(listener: Listener<S>) {
+    const index = this.internalListeners.findIndex((cb) => listener === cb);
+    index > -1 && this.internalListeners.splice(index, 1);
+    return index > -1;
+  }
+
+  /**
+   * Updates controller state. Accepts a callback that is passed a draft copy
+   * of the controller state. If a value is returned, it is set as the new
+   * state. Otherwise, any changes made within that callback to the draft are
+   * applied to the controller state.
+   *
+   * @param callback - Callback for updating state, passed a draft state
+   *   object. Return a new state object or mutate the draft to update state.
+   */
+  protected update(callback: (state: Draft<S>) => void | S) {
+    this.internalState = produce(this.internalState, callback) as S;
+  }
+
+  /**
+   * Prepares the controller for garbage collection. This should be extended
+   * by any subclasses to clean up any additional connections or events.
+   *
+   * The only cleanup performed here is to remove listeners. While technically
+   * this is not required for garbage collection, it at least ensures this
+   * instance won't be responsible for keeping the listeners in memory.
+   */
+  protected destroy() {
+    this.internalListeners = [];
+  }
+}
+
+export default BaseController;

--- a/src/crypto-compare.ts
+++ b/src/crypto-compare.ts
@@ -1,0 +1,39 @@
+import { handleFetch } from './util';
+
+function getPricingURL(currentCurrency: string, nativeCurrency: string, includeUsdRate?: boolean) {
+  return (
+    `https://min-api.cryptocompare.com/data/price?fsym=` +
+    `${nativeCurrency.toUpperCase()}&tsyms=${currentCurrency.toUpperCase()}` +
+    `${includeUsdRate && currentCurrency.toUpperCase() !== 'USD' ? ',USD' : ''}`
+  );
+}
+
+/**
+ * Fetches the exchange rate for a given currency
+ *
+ * @param currency - ISO 4217 currency code
+ * @param nativeCurrency - Symbol for base asset
+ * @param includeUSDRate - Whether to add the USD rate to the fetch
+ * @returns Promise resolving to exchange rate for given currency
+ */
+export async function fetchExchangeRate(
+  currency: string,
+  nativeCurrency: string,
+  includeUsdRate?: boolean,
+): Promise<{ conversionDate: number; conversionRate: number; usdConversionRate?: number }> {
+  const json = await handleFetch(getPricingURL(currency, nativeCurrency, includeUsdRate));
+  const conversionRate = Number(json[currency.toUpperCase()]);
+  const usdConversionRate = Number(json.USD);
+  if (!Number.isFinite(conversionRate)) {
+    throw new Error(`Invalid response for ${currency.toUpperCase()}: ${json[currency.toUpperCase()]}`);
+  }
+  if (includeUsdRate && !Number.isFinite(usdConversionRate)) {
+    throw new Error(`Invalid response for usdConversionRate: ${json.USD}`);
+  }
+
+  return {
+    conversionDate: Date.now() / 1000,
+    conversionRate,
+    usdConversionRate: includeUsdRate ? usdConversionRate : undefined,
+  };
+}

--- a/src/schema-transform.ts
+++ b/src/schema-transform.ts
@@ -1,0 +1,36 @@
+type Anonymizer<T> = (value: T) => T;
+
+export type Schema<T> = {
+  [P in keyof T]: {
+    persist: boolean;
+    anonymous: boolean | Anonymizer<T[P]>;
+  };
+};
+
+// This function acts as a type guard. Using a `typeof` conditional didn't seem to work.
+function isAnonymizingFunction<T>(x: boolean | Anonymizer<T>): x is Anonymizer<T> {
+  return typeof x === 'function';
+}
+
+export function getPersistedState<S extends Record<string, any>>(state: S, schema: Schema<S>) {
+  return Object.keys(state).reduce((persistedState, _key) => {
+    const key: keyof S = _key; // https://stackoverflow.com/questions/63893394/string-cannot-be-used-to-index-type-t
+    if (schema[key].persist) {
+      persistedState[key] = state[key];
+    }
+    return persistedState;
+  }, {} as Partial<S>);
+}
+
+export function getAnonymizedState<S extends Record<string, any>>(state: S, schema: Schema<S>) {
+  return Object.keys(state).reduce((anonymizedState, _key) => {
+    const key: keyof S = _key; // https://stackoverflow.com/questions/63893394/string-cannot-be-used-to-index-type-t
+    const schemaValue = schema[key].anonymous;
+    if (isAnonymizingFunction(schemaValue)) {
+      anonymizedState[key] = schemaValue(state[key]);
+    } else if (schemaValue) {
+      anonymizedState[key] = state[key];
+    }
+    return anonymizedState;
+  }, {} as Partial<S>);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3463,6 +3463,11 @@ immediate@^3.2.3:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.2.3.tgz#d140fa8f614659bd6541233097ddaac25cdd991c"
   integrity sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=
 
+immer@^7.0.9:
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-7.0.9.tgz#28e7552c21d39dd76feccd2b800b7bc86ee4a62e"
+  integrity sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A==
+
 import-fresh@^3.0.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"


### PR DESCRIPTION
This represents a prototype implementation of a new controller API design. The motivations for this are written about in this document: https://docs.google.com/document/d/1DjtFfNB0JuziijGqs4h3vW8PL8zCI6zuaovqvSHbJ2o/edit#heading=h.mtvpfhpuzjof

A new base controller has been introduced (`base-controller-v2.ts`), and the `CurrencyRateController` has been updated to use it. All other controllers remain unchanged.

Note that the `CurrencyRateController` no longer works correctly with the `ComposableController` - I didn't think that was worth the effort to get working.