### PR TITLE
@metamask/contract-metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "url": "https://github.com/MetaMask/controllers/issues"
   },
   "dependencies": {
+    "@metamask/contract-metadata": "^1.19.0",
     "await-semaphore": "^0.1.3",
-    "eth-contract-metadata": "^1.11.0",
     "eth-ens-namehash": "^2.0.8",
     "eth-json-rpc-infura": "^5.1.0",
     "eth-keyring-controller": "^6.1.0",

--- a/src/assets/AssetsDetectionController.ts
+++ b/src/assets/AssetsDetectionController.ts
@@ -8,7 +8,7 @@ import { Token } from './TokenRatesController';
 
 import AssetsController from './AssetsController';
 
-const contractMap = require('eth-contract-metadata');
+const contractMap = require('@metamask/contract-metadata');
 
 const DEFAULT_INTERVAL = 180000;
 const MAINNET = 'mainnet';

--- a/yarn.lock
+++ b/yarn.lock
@@ -625,6 +625,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@metamask/contract-metadata@^1.19.0":
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.19.0.tgz#2f074bce7ab7ffd0d20e3905b1936da0749a0473"
+  integrity sha512-TklMuz7ZbFJ2Zc6C7I+9qL3J9J+4prs5Ok5MJzoxD/57Iq6espzArhpI275elVCFF9ci8IMvach1kH8+F04/hA==
+
 "@metamask/eslint-config@^3.0.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-3.2.0.tgz#66b9b2bea1616821506501e76de4ac991f34914f"
@@ -2428,11 +2433,6 @@ eth-block-tracker@^4.4.2:
     json-rpc-random-id "^1.0.1"
     pify "^3.0.0"
     safe-event-emitter "^1.0.1"
-
-eth-contract-metadata@^1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/eth-contract-metadata/-/eth-contract-metadata-1.11.0.tgz#4d23a8208d5d53be9d4c0696ed8492b505c6bca1"
-  integrity sha512-Bbvio71M+lH+qXd8XXddpTc8hhjL9m4fNPOxmZFIX8z0/VooUdwV8YmmDAbkU5WVioZi+Jp1XaoO7VwzXnDboA==
 
 eth-ens-namehash@^2.0.8:
   version "2.0.8"


### PR DESCRIPTION
This PR replaces `eth-contract-metadata` with `@metamask/contract-metadata`. The package was just renamed. It's also been updated.