### PR TITLE
Enforce chainId

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/controllers",
-  "version": "5.1.0",
+  "version": "5.1.2",
   "description": "Collection of platform-agnostic modules for creating secure data models for cryptocurrency wallets",
   "license": "MIT",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/controllers",
-  "version": "5.1.2",
+  "version": "5.1.0",
   "description": "Collection of platform-agnostic modules for creating secure data models for cryptocurrency wallets",
   "license": "MIT",
   "files": [

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -11,6 +11,16 @@ const { Mutex } = require('await-semaphore');
  */
 export type NetworkType = 'kovan' | 'localhost' | 'mainnet' | 'rinkeby' | 'goerli' | 'ropsten' | 'rpc';
 
+export enum NetworksChainId {
+  mainnet = '1',
+  kovan = '42',
+  rinkeby = '4',
+  goerli = '5',
+  ropsten = '3',
+  localhost = '',
+  rpc = '',
+}
+
 /**
  * @type ProviderConfig
  *
@@ -25,7 +35,7 @@ export type NetworkType = 'kovan' | 'localhost' | 'mainnet' | 'rinkeby' | 'goerl
 export interface ProviderConfig {
   rpcTarget?: string;
   type: NetworkType;
-  chainId?: string;
+  chainId: string;
   ticker?: string;
   nickname?: string;
 }
@@ -170,7 +180,7 @@ export class NetworkController extends BaseController<NetworkConfig, NetworkStat
     super(config, state);
     this.defaultState = {
       network: 'loading',
-      provider: { type: 'mainnet' },
+      provider: { type: 'mainnet', chainId: '1' },
     };
     this.initialize();
   }
@@ -213,7 +223,7 @@ export class NetworkController extends BaseController<NetworkConfig, NetworkStat
     this.update({
       provider: {
         ...providerState,
-        ...{ type, ticker: 'ETH' },
+        ...{ type, ticker: 'ETH', chainId: NetworksChainId[type] },
       },
     });
     this.refreshNetwork();
@@ -223,11 +233,11 @@ export class NetworkController extends BaseController<NetworkConfig, NetworkStat
    * Convenience method to update provider RPC settings
    *
    * @param rpcTarget - RPC endpoint URL
-   * @param chainId? - Network ID as per EIP-155
+   * @param chainId - Network ID as per EIP-155
    * @param ticker? - Currency ticker
    * @param nickname? - Personalized network name
    */
-  setRpcTarget(rpcTarget: string, chainId?: string, ticker?: string, nickname?: string) {
+  setRpcTarget(rpcTarget: string, chainId: string, ticker?: string, nickname?: string) {
     this.update({
       provider: {
         ...this.state.provider,

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -180,7 +180,7 @@ export class NetworkController extends BaseController<NetworkConfig, NetworkStat
     super(config, state);
     this.defaultState = {
       network: 'loading',
-      provider: { type: 'mainnet', chainId: '1' },
+      provider: { type: 'mainnet', chainId: NetworksChainId.mainnet },
     };
     this.initialize();
   }

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -3,6 +3,7 @@ import { addHexPrefix, bufferToHex } from 'ethereumjs-util';
 import { ethErrors } from 'eth-rpc-errors';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import NetworkController from '../network/NetworkController';
+
 import {
   BNToHex,
   fractionBN,
@@ -470,7 +471,6 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
    * @returns - Promise resolving when this operation completes
    */
   async approveTransaction(transactionID: string) {
-    const releaseLock = await this.mutex.acquire();
     const { transactions } = this.state;
     const network = this.context.NetworkController as NetworkController;
     /* istanbul ignore next */
@@ -481,11 +481,9 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 
     if (!this.sign) {
       this.failTransaction(transactionMeta, new Error('No sign method defined.'));
-      releaseLock();
       return;
     } else if (!currentChainId) {
       this.failTransaction(transactionMeta, new Error('No chainId defined.'));
-      releaseLock();
       return;
     }
 
@@ -507,9 +505,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
       transactionMeta.status = 'submitted';
       this.updateTransaction(transactionMeta);
       this.hub.emit(`${transactionMeta.id}:finished`, transactionMeta);
-      releaseLock();
     } catch (error) {
-      releaseLock();
       this.failTransaction(transactionMeta, error);
     }
   }

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -417,6 +417,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
     transaction = normalizeTransaction(transaction);
     validateTransaction(transaction);
 
+    /* istanbul ignore next */
     const networkID = network?.state?.provider?.chainId;
 
     const transactionMeta = {

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -419,7 +419,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
 
     const transactionMeta = {
       id: random(),
-      networkID: network ? network.state.network : /* istanbul ignore next */ '1',
+      networkID: network ? network.state.provider.chainId : /* istanbul ignore next */ '1',
       origin,
       status: 'unapproved',
       time: Date.now(),
@@ -472,7 +472,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
     const { transactions } = this.state;
     const network = this.context.NetworkController as NetworkController;
     /* istanbul ignore next */
-    const currentNetworkID = network ? network.state.network : '1';
+    const currentNetworkID = network ? network.state.provider.chainId : '1';
     const index = transactions.findIndex(({ id }) => transactionID === id);
     const transactionMeta = transactions[index];
     const { from } = transactionMeta.transaction;
@@ -674,7 +674,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
   async queryTransactionStatuses() {
     const { transactions } = this.state;
     const network = this.context.NetworkController;
-    const currentNetworkID = network.state.network;
+    const currentNetworkID = network.state.provider.chainId;
     let gotUpdates = false;
     await safelyExecute(() =>
       Promise.all(
@@ -726,7 +726,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
     if (!network) {
       return;
     }
-    const currentNetworkID = network.state.network;
+    const currentNetworkID = network.state.provider.chainId;
     const newTransactions = this.state.transactions.filter(({ networkID }) => networkID !== currentNetworkID);
     this.update({ transactions: newTransactions });
   }

--- a/tests/AssetsController.test.ts
+++ b/tests/AssetsController.test.ts
@@ -3,7 +3,7 @@ import { getOnce } from 'fetch-mock';
 import AssetsController from '../src/assets/AssetsController';
 import ComposableController from '../src/ComposableController';
 import PreferencesController from '../src/user/PreferencesController';
-import { NetworkController } from '../src/network/NetworkController';
+import { NetworkController, NetworksChainId } from '../src/network/NetworkController';
 import { AssetsContractController } from '../src/assets/AssetsContractController';
 
 const HttpProvider = require('ethjs-provider-http');
@@ -166,11 +166,11 @@ describe('AssetsController', () => {
   it('should add token by provider type', async () => {
     const firstNetworkType = 'rinkeby';
     const secondNetworkType = 'ropsten';
-    network.update({ provider: { type: firstNetworkType } });
+    network.update({ provider: { type: firstNetworkType, chainId: NetworksChainId[firstNetworkType] } });
     await assetsController.addToken('foo', 'bar', 2);
-    network.update({ provider: { type: secondNetworkType } });
+    network.update({ provider: { type: secondNetworkType, chainId: NetworksChainId[secondNetworkType] } });
     expect(assetsController.state.tokens).toHaveLength(0);
-    network.update({ provider: { type: firstNetworkType } });
+    network.update({ provider: { type: firstNetworkType, chainId: NetworksChainId[firstNetworkType] } });
     expect(assetsController.state.tokens[0]).toEqual({
       address: '0xfoO',
       decimals: 2,
@@ -204,13 +204,13 @@ describe('AssetsController', () => {
   it('should remove token by provider type', async () => {
     const firstNetworkType = 'rinkeby';
     const secondNetworkType = 'ropsten';
-    network.update({ provider: { type: firstNetworkType } });
+    network.update({ provider: { type: firstNetworkType, chainId: NetworksChainId[firstNetworkType] } });
     await assetsController.addToken('fou', 'baz', 2);
-    network.update({ provider: { type: secondNetworkType } });
+    network.update({ provider: { type: secondNetworkType, chainId: NetworksChainId[secondNetworkType] } });
     await assetsController.addToken('foo', 'bar', 2);
     assetsController.removeToken('0xfoO');
     expect(assetsController.state.tokens).toHaveLength(0);
-    network.update({ provider: { type: firstNetworkType } });
+    network.update({ provider: { type: firstNetworkType, chainId: NetworksChainId[firstNetworkType] } });
     expect(assetsController.state.tokens[0]).toEqual({
       address: '0xFOu',
       decimals: 2,
@@ -310,11 +310,11 @@ describe('AssetsController', () => {
     sandbox
       .stub(assetsController, 'getCollectibleInformation' as any)
       .returns({ name: 'name', image: 'url', description: 'description' });
-    network.update({ provider: { type: firstNetworkType } });
+    network.update({ provider: { type: firstNetworkType, chainId: NetworksChainId[firstNetworkType] } });
     await assetsController.addCollectible('foo', 1234);
-    network.update({ provider: { type: secondNetworkType } });
+    network.update({ provider: { type: secondNetworkType, chainId: NetworksChainId[secondNetworkType] } });
     expect(assetsController.state.collectibles).toHaveLength(0);
-    network.update({ provider: { type: firstNetworkType } });
+    network.update({ provider: { type: firstNetworkType, chainId: NetworksChainId[firstNetworkType] } });
     expect(assetsController.state.collectibles[0]).toEqual({
       address: '0xfoO',
       description: 'description',
@@ -393,14 +393,14 @@ describe('AssetsController', () => {
       .returns({ name: 'name', image: 'url', description: 'description' });
     const firstNetworkType = 'rinkeby';
     const secondNetworkType = 'ropsten';
-    network.update({ provider: { type: firstNetworkType } });
+    network.update({ provider: { type: firstNetworkType, chainId: NetworksChainId[firstNetworkType] } });
     await assetsController.addCollectible('fou', 4321);
-    network.update({ provider: { type: secondNetworkType } });
+    network.update({ provider: { type: secondNetworkType, chainId: NetworksChainId[secondNetworkType] } });
     await assetsController.addCollectible('foo', 1234);
     assetsController.removeToken('0xfoO');
     assetsController.removeCollectible('0xfoO', 1234);
     expect(assetsController.state.collectibles).toHaveLength(0);
-    network.update({ provider: { type: firstNetworkType } });
+    network.update({ provider: { type: firstNetworkType, chainId: NetworksChainId[firstNetworkType] } });
     expect(assetsController.state.collectibles[0]).toEqual({
       address: '0xFOu',
       description: 'description',
@@ -415,7 +415,7 @@ describe('AssetsController', () => {
     const address = '0x123';
     preferences.update({ selectedAddress: address });
     expect(assetsController.context.PreferencesController.state.selectedAddress).toEqual(address);
-    network.update({ provider: { type: networkType } });
+    network.update({ provider: { type: networkType, chainId: NetworksChainId[networkType] } });
     expect(assetsController.context.NetworkController.state.provider.type).toEqual(networkType);
   });
 
@@ -445,7 +445,7 @@ describe('AssetsController', () => {
         )
         .catch((error) => {
           expect(error.message).toContain('Asset of type ERC721 not supported');
-          resolve();
+          resolve('');
         });
     });
   });
@@ -467,7 +467,7 @@ describe('AssetsController', () => {
       });
       result.catch((error) => {
         expect(error.message).toContain('User rejected to watch the asset.');
-        resolve();
+        resolve('');
       });
     });
   });
@@ -485,7 +485,7 @@ describe('AssetsController', () => {
       result.then((res) => {
         expect(assetsController.state.suggestedAssets).toHaveLength(0);
         expect(res).toBe('0xe9f786dfdd9ae4d57e830acb52296837765f0e5b');
-        resolve();
+        resolve('');
       });
       await assetsController.acceptWatchAsset(suggestedAssetMeta.id);
     });
@@ -509,7 +509,7 @@ describe('AssetsController', () => {
       await assetsController.acceptWatchAsset(suggestedAssetMeta.id);
       result.catch((error) => {
         expect(error.message).toContain('Asset of type ERC721 not supported');
-        resolve();
+        resolve('');
       });
     });
   });

--- a/tests/AssetsDetectionController.test.ts
+++ b/tests/AssetsDetectionController.test.ts
@@ -1,7 +1,7 @@
 import { createSandbox, stub } from 'sinon';
 import { getOnce, get } from 'fetch-mock';
 import { AssetsDetectionController } from '../src/assets/AssetsDetectionController';
-import { NetworkController } from '../src/network/NetworkController';
+import { NetworkController, NetworksChainId } from '../src/network/NetworkController';
 import { PreferencesController } from '../src/user/PreferencesController';
 import { ComposableController } from '../src/ComposableController';
 import { AssetsController } from '../src/assets/AssetsController';
@@ -189,7 +189,7 @@ describe('AssetsDetectionController', () => {
         expect(mockCollectibles.calledTwice).toBe(true);
         mockTokens.restore();
         mockCollectibles.restore();
-        resolve();
+        resolve('');
       }, 15);
     });
   });
@@ -210,7 +210,7 @@ describe('AssetsDetectionController', () => {
       expect(mockCollectibles.called).toBe(false);
       mockTokens.restore();
       mockCollectibles.restore();
-      resolve();
+      resolve('');
     });
   });
 
@@ -444,9 +444,9 @@ describe('AssetsDetectionController', () => {
     expect(detectAssets.calledTwice).toBe(false);
     preferences.update({ selectedAddress: firstAddress });
     expect(assetsDetection.context.PreferencesController.state.selectedAddress).toEqual(firstAddress);
-    network.update({ provider: { type: secondNetworkType } });
+    network.update({ provider: { type: secondNetworkType, chainId: NetworksChainId[secondNetworkType] } });
     expect(assetsDetection.context.NetworkController.state.provider.type).toEqual(secondNetworkType);
-    network.update({ provider: { type: firstNetworkType } });
+    network.update({ provider: { type: firstNetworkType, chainId: NetworksChainId[firstNetworkType] } });
     expect(assetsDetection.context.NetworkController.state.provider.type).toEqual(firstNetworkType);
     assets.update({ tokens: TOKENS });
     expect(assetsDetection.config.tokens).toEqual(TOKENS);

--- a/tests/ComposableController.test.ts
+++ b/tests/ComposableController.test.ts
@@ -5,7 +5,7 @@ import ComposableController from '../src/ComposableController';
 import PreferencesController from '../src/user/PreferencesController';
 import TokenRatesController from '../src/assets/TokenRatesController';
 import { AssetsController } from '../src/assets/AssetsController';
-import { NetworkController } from '../src/network/NetworkController';
+import { NetworkController, NetworksChainId } from '../src/network/NetworkController';
 import { AssetsContractController } from '../src/assets/AssetsContractController';
 import CurrencyRateController from '../src/assets/CurrencyRateController';
 
@@ -47,7 +47,7 @@ describe('ComposableController', () => {
       },
       NetworkController: {
         network: 'loading',
-        provider: { type: 'mainnet' },
+        provider: { type: 'mainnet', chainId: NetworksChainId.mainnet },
       },
       PreferencesController: {
         featureFlags: {},
@@ -93,7 +93,7 @@ describe('ComposableController', () => {
       lostIdentities: {},
       nativeCurrency: 'ETH',
       network: 'loading',
-      provider: { type: 'mainnet' },
+      provider: { type: 'mainnet', chainId: NetworksChainId.mainnet },
       selectedAddress: '',
       suggestedAssets: [],
       tokens: [],
@@ -147,7 +147,7 @@ describe('ComposableController', () => {
       lostIdentities: {},
       nativeCurrency: 'ETH',
       network: 'loading',
-      provider: { type: 'mainnet' },
+      provider: { type: 'mainnet', chainId: NetworksChainId.mainnet },
       selectedAddress: '',
       suggestedAssets: [],
       tokens: [],

--- a/tests/NetworkController.test.ts
+++ b/tests/NetworkController.test.ts
@@ -1,5 +1,5 @@
 import { stub } from 'sinon';
-import NetworkController, { ProviderConfig } from '../src/network/NetworkController';
+import NetworkController, { NetworksChainId, ProviderConfig } from '../src/network/NetworkController';
 
 const Web3ProviderEngine = require('web3-provider-engine');
 
@@ -12,6 +12,7 @@ describe('NetworkController', () => {
       network: 'loading',
       provider: {
         type: 'mainnet',
+        chainId: '1',
       },
     });
   });
@@ -30,7 +31,7 @@ describe('NetworkController', () => {
     const testConfig = {
       infuraProjectId: 'foo',
     };
-    const controller = new NetworkController(testConfig, { network: '0', provider: { type: 'kovan' } });
+    const controller = new NetworkController(testConfig, { network: '0', provider: { type: 'kovan', chainId: NetworksChainId.kovan } });
     controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
   });
@@ -39,7 +40,7 @@ describe('NetworkController', () => {
     const testConfig = {
       infuraProjectId: 'foo',
     };
-    const controller = new NetworkController(testConfig, { network: '0', provider: { type: 'rinkeby' } });
+    const controller = new NetworkController(testConfig, { network: '0', provider: { type: 'rinkeby', chainId: NetworksChainId.rinkeby } });
     controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
   });
@@ -48,7 +49,7 @@ describe('NetworkController', () => {
     const testConfig = {
       infuraProjectId: 'foo',
     };
-    const controller = new NetworkController(testConfig, { network: '0', provider: { type: 'ropsten' } });
+    const controller = new NetworkController(testConfig, { network: '0', provider: { type: 'ropsten', chainId: NetworksChainId.ropsten } });
     controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
   });
@@ -57,13 +58,13 @@ describe('NetworkController', () => {
     const testConfig = {
       infuraProjectId: 'foo',
     };
-    const controller = new NetworkController(testConfig, { network: '0', provider: { type: 'mainnet' } });
+    const controller = new NetworkController(testConfig, { network: '0', provider: { type: 'mainnet', chainId: NetworksChainId.mainnet } });
     controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
   });
 
   it('should create a provider instance for local network', () => {
-    const controller = new NetworkController(undefined, { network: '0', provider: { type: 'localhost' } });
+    const controller = new NetworkController(undefined, { network: '0', provider: { type: 'localhost', chainId: NetworksChainId.rpc } });
     controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
   });
@@ -74,6 +75,7 @@ describe('NetworkController', () => {
       provider: {
         rpcTarget: RPC_TARGET,
         type: 'rpc',
+        chainId: NetworksChainId.mainnet,
       },
     });
     controller.providerConfig = {} as ProviderConfig;
@@ -82,7 +84,7 @@ describe('NetworkController', () => {
 
   it('should set new RPC target', () => {
     const controller = new NetworkController();
-    controller.setRpcTarget(RPC_TARGET);
+    controller.setRpcTarget(RPC_TARGET, NetworksChainId.rpc);
     expect(controller.state.provider.rpcTarget).toBe(RPC_TARGET);
   });
 
@@ -114,7 +116,7 @@ describe('NetworkController', () => {
       controller.providerConfig = {} as ProviderConfig;
       setTimeout(() => {
         expect(controller.state.network !== 'loading').toBe(true);
-        resolve();
+        resolve('');
       }, 4500);
     });
   });

--- a/tests/NetworkController.test.ts
+++ b/tests/NetworkController.test.ts
@@ -31,7 +31,10 @@ describe('NetworkController', () => {
     const testConfig = {
       infuraProjectId: 'foo',
     };
-    const controller = new NetworkController(testConfig, { network: '0', provider: { type: 'kovan', chainId: NetworksChainId.kovan } });
+    const controller = new NetworkController(testConfig, {
+      network: '0',
+      provider: { type: 'kovan', chainId: NetworksChainId.kovan },
+    });
     controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
   });
@@ -40,7 +43,10 @@ describe('NetworkController', () => {
     const testConfig = {
       infuraProjectId: 'foo',
     };
-    const controller = new NetworkController(testConfig, { network: '0', provider: { type: 'rinkeby', chainId: NetworksChainId.rinkeby } });
+    const controller = new NetworkController(testConfig, {
+      network: '0',
+      provider: { type: 'rinkeby', chainId: NetworksChainId.rinkeby },
+    });
     controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
   });
@@ -49,7 +55,10 @@ describe('NetworkController', () => {
     const testConfig = {
       infuraProjectId: 'foo',
     };
-    const controller = new NetworkController(testConfig, { network: '0', provider: { type: 'ropsten', chainId: NetworksChainId.ropsten } });
+    const controller = new NetworkController(testConfig, {
+      network: '0',
+      provider: { type: 'ropsten', chainId: NetworksChainId.ropsten },
+    });
     controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
   });
@@ -58,13 +67,19 @@ describe('NetworkController', () => {
     const testConfig = {
       infuraProjectId: 'foo',
     };
-    const controller = new NetworkController(testConfig, { network: '0', provider: { type: 'mainnet', chainId: NetworksChainId.mainnet } });
+    const controller = new NetworkController(testConfig, {
+      network: '0',
+      provider: { type: 'mainnet', chainId: NetworksChainId.mainnet },
+    });
     controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
   });
 
   it('should create a provider instance for local network', () => {
-    const controller = new NetworkController(undefined, { network: '0', provider: { type: 'localhost', chainId: NetworksChainId.rpc } });
+    const controller = new NetworkController(undefined, {
+      network: '0',
+      provider: { type: 'localhost', chainId: NetworksChainId.rpc },
+    });
     controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
   });

--- a/tests/TransactionController.test.ts
+++ b/tests/TransactionController.test.ts
@@ -66,23 +66,17 @@ const MAINNET_PROVIDER = new HttpProvider('https://mainnet.infura.io/v3/341eacb5
 const MOCK_NETWORK = {
   provider: PROVIDER,
   state: { network: '3', provider: { type: 'ropsten', chainId: NetworksChainId.ropsten } },
-  subscribe: () => {
-    /* eslint-disable-line no-empty */
-  },
+  subscribe: () => undefined,
 };
 const MOCK_NETWORK_WITHOUT_CHAIN_ID = {
   provider: PROVIDER,
   state: { network: '3', provider: { type: 'ropsten' } },
-  subscribe: () => {
-    /* eslint-disable-line no-empty */
-  },
+  subscribe: () => undefined,
 };
 const MOCK_MAINNET_NETWORK = {
   provider: MAINNET_PROVIDER,
   state: { network: '1', provider: { type: 'mainnet', chainId: NetworksChainId.mainnet } },
-  subscribe: () => {
-    /* eslint-disable-line no-empty */
-  },
+  subscribe: () => undefined,
 };
 
 const ETH_TRANSACTIONS = [

--- a/tests/TransactionController.test.ts
+++ b/tests/TransactionController.test.ts
@@ -1,4 +1,5 @@
 import { stub } from 'sinon';
+import { NetworksChainId } from '../src/network/NetworkController';
 import TransactionController from '../src/transaction/TransactionController';
 
 const globalAny: any = global;
@@ -64,14 +65,14 @@ const PROVIDER = new HttpProvider('https://ropsten.infura.io/v3/341eacb578dd44a1
 const MAINNET_PROVIDER = new HttpProvider('https://mainnet.infura.io/v3/341eacb578dd44a1a049cbc5f6fd4035');
 const MOCK_NETWORK = {
   provider: PROVIDER,
-  state: { network: '3', provider: { type: 'ropsten' } },
+  state: { network: '3', provider: { type: 'ropsten', chainId: NetworksChainId.ropsten } },
   subscribe: () => {
     /* eslint-disable-line no-empty */
   },
 };
 const MOCK_MAINNET_NETWORK = {
   provider: MAINNET_PROVIDER,
-  state: { network: '1', provider: { type: 'mainnet' } },
+  state: { network: '1', provider: { type: 'mainnet', chainId: NetworksChainId.mainnet } },
   subscribe: () => {
     /* eslint-disable-line no-empty */
   },
@@ -385,7 +386,7 @@ describe('TransactionController', () => {
       setTimeout(() => {
         expect(mock.calledTwice).toBe(true);
         mock.restore();
-        resolve();
+        resolve('');
       }, 15);
     });
   });
@@ -398,7 +399,7 @@ describe('TransactionController', () => {
         controller.poll(1338);
         expect(mock.called).toBe(true);
         mock.restore();
-        resolve();
+        resolve('');
       }, 100);
     });
   });
@@ -410,7 +411,7 @@ describe('TransactionController', () => {
       setTimeout(() => {
         expect(func.called).toBe(false);
         func.restore();
-        resolve();
+        resolve('');
       }, 20);
     });
   });
@@ -422,7 +423,7 @@ describe('TransactionController', () => {
         await controller.addTransaction({ from: 'foo' } as any);
       } catch (error) {
         expect(error.message).toContain('Invalid "from" address');
-        resolve();
+        resolve('');
       }
     });
   });
@@ -463,7 +464,7 @@ describe('TransactionController', () => {
       controller.cancelTransaction(controller.state.transactions[0].id);
       result.catch((error) => {
         expect(error.message).toContain('User rejected the transaction');
-        resolve();
+        resolve('');
       });
     });
   });
@@ -505,7 +506,7 @@ describe('TransactionController', () => {
         expect(transaction.to).toBe(to);
         expect(status).toBe('failed');
         expect(error.message).toContain('foo');
-        resolve();
+        resolve('');
       });
       await controller.approveTransaction(controller.state.transactions[0].id);
     });
@@ -527,7 +528,7 @@ describe('TransactionController', () => {
         });
       } catch (error) {
         expect(error.message).toContain('Uh oh');
-        resolve();
+        resolve('');
       }
     });
   });
@@ -550,7 +551,7 @@ describe('TransactionController', () => {
         expect(transaction.to).toBe(to);
         expect(status).toBe('failed');
         expect(error.message).toContain('No sign method defined');
-        resolve();
+        resolve('');
       });
       await controller.approveTransaction(controller.state.transactions[0].id);
     });
@@ -578,7 +579,7 @@ describe('TransactionController', () => {
         const { transaction, status } = controller.state.transactions[0];
         expect(transaction.from).toBe(from);
         expect(status).toBe('submitted');
-        resolve();
+        resolve('');
       });
       controller.approveTransaction(controller.state.transactions[0].id);
     });
@@ -605,7 +606,7 @@ describe('TransactionController', () => {
 
       controller.hub.once(`${controller.state.transactions[0].id}:confirmed`, () => {
         expect(controller.state.transactions[0].status).toBe('confirmed');
-        resolve();
+        resolve('');
       });
       controller.queryTransactionStatuses();
     });
@@ -727,7 +728,7 @@ describe('TransactionController', () => {
       });
       result.catch((error) => {
         expect(error.message).toContain('User cancelled the transaction');
-        resolve();
+        resolve('');
       });
       controller.stopTransaction(controller.state.transactions[0].id);
     });
@@ -750,7 +751,7 @@ describe('TransactionController', () => {
         await controller.stopTransaction(controller.state.transactions[0].id);
       } catch (error) {
         expect(error.message).toContain('No sign method defined');
-        resolve();
+        resolve('');
       }
     });
   });
@@ -777,7 +778,7 @@ describe('TransactionController', () => {
 
       expect(controller.state.transactions).toHaveLength(2);
       expect(controller.state.transactions[1].transaction.gasPrice).toBe('0x5916a6d6');
-      resolve();
+      resolve('');
     });
   });
 });

--- a/tests/TransactionController.test.ts
+++ b/tests/TransactionController.test.ts
@@ -70,6 +70,13 @@ const MOCK_NETWORK = {
     /* eslint-disable-line no-empty */
   },
 };
+const MOCK_NETWORK_WITHOUT_CHAIN_ID = {
+  provider: PROVIDER,
+  state: { network: '3', provider: { type: 'ropsten' } },
+  subscribe: () => {
+    /* eslint-disable-line no-empty */
+  },
+};
 const MOCK_MAINNET_NETWORK = {
   provider: MAINNET_PROVIDER,
   state: { network: '1', provider: { type: 'mainnet', chainId: NetworksChainId.mainnet } },
@@ -551,6 +558,31 @@ describe('TransactionController', () => {
         expect(transaction.to).toBe(to);
         expect(status).toBe('failed');
         expect(error.message).toContain('No sign method defined');
+        resolve('');
+      });
+      await controller.approveTransaction(controller.state.transactions[0].id);
+    });
+  });
+
+  it('should fail if no chainId defined', () => {
+    return new Promise(async (resolve) => {
+      const controller = new TransactionController({
+        provider: PROVIDER,
+        sign: async (transaction: any) => transaction,
+      });
+      controller.context = {
+        NetworkController: MOCK_NETWORK_WITHOUT_CHAIN_ID,
+      } as any;
+      controller.onComposed();
+      const from = '0xe6509775f3f3614576c0d83f8647752f87cd6659';
+      const to = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+      const { result } = await controller.addTransaction({ from, to });
+      result.catch((error) => {
+        const { transaction, status } = controller.state.transactions[0];
+        expect(transaction.from).toBe(from);
+        expect(transaction.to).toBe(to);
+        expect(status).toBe('failed');
+        expect(error.message).toContain('No chainId defined');
         resolve('');
       });
       await controller.approveTransaction(controller.state.transactions[0].id);


### PR DESCRIPTION
This PR makes sure that all custom rpc networks have a valid chainId, and disregard the usage of networkId in favor of chainId