### PR TITLE
Add try/catch for `assetsContract.getBalanceOf`

### DIFF
--- a/src/assets/TokenBalancesController.ts
+++ b/src/assets/TokenBalancesController.ts
@@ -96,7 +96,17 @@ export class TokenBalancesController extends BaseController<TokenBalancesConfig,
     const newContractBalances: { [address: string]: typeof BN } = {};
     for (const i in tokens) {
       const { address } = tokens[i];
-      newContractBalances[address] = await assetsContract.getBalanceOf(address, selectedAddress);
+      /* istanbul ignore next */
+      try {
+        newContractBalances[address] = await assetsContract.getBalanceOf(address, selectedAddress);
+      } catch (error) {
+        /** TODO
+         * Come up with a better way of indicating `assetsContract.getBalanceOf` failed...
+         * displaying 0 (again) will likely cause some confusion, but at least it'll just be
+         * the offending token(s) vs everything after it.
+         */
+        newContractBalances[address] = 0;
+      }
     }
     this.update({ contractBalances: newContractBalances });
   }

--- a/src/assets/TokenBalancesController.ts
+++ b/src/assets/TokenBalancesController.ts
@@ -5,6 +5,7 @@ import { Token } from './TokenRatesController';
 import { AssetsContractController } from './AssetsContractController';
 
 const { BN } = require('ethereumjs-util');
+export const errorMsg = 'Failed to get balance';
 
 export { BN };
 
@@ -93,19 +94,13 @@ export class TokenBalancesController extends BaseController<TokenBalancesConfig,
     const assets = this.context.AssetsController as AssetsController;
     const { selectedAddress } = assets.config;
     const { tokens } = this.config;
-    const newContractBalances: { [address: string]: typeof BN } = {};
+    const newContractBalances: { [address: string]: typeof BN | Error } = {};
     for (const i in tokens) {
       const { address } = tokens[i];
-      /* istanbul ignore next */
       try {
         newContractBalances[address] = await assetsContract.getBalanceOf(address, selectedAddress);
       } catch (error) {
-        /** TODO
-         * Come up with a better way of indicating `assetsContract.getBalanceOf` failed...
-         * displaying 0 (again) will likely cause some confusion, but at least it'll just be
-         * the offending token(s) vs everything after it.
-         */
-        newContractBalances[address] = 0;
+        newContractBalances[address] = new Error(errorMsg);
       }
     }
     this.update({ contractBalances: newContractBalances });

--- a/src/assets/TokenBalancesController.ts
+++ b/src/assets/TokenBalancesController.ts
@@ -93,7 +93,7 @@ export class TokenBalancesController extends BaseController<TokenBalancesConfig,
     const assets = this.context.AssetsController as AssetsController;
     const { selectedAddress } = assets.config;
     const { tokens } = this.config;
-    const newContractBalances: { [address: string]: typeof BN | Error } = {};
+    const newContractBalances: { [address: string]: typeof BN } = {};
     for (const i in tokens) {
       const { address } = tokens[i];
       try {

--- a/src/assets/TokenBalancesController.ts
+++ b/src/assets/TokenBalancesController.ts
@@ -5,7 +5,6 @@ import { Token } from './TokenRatesController';
 import { AssetsContractController } from './AssetsContractController';
 
 const { BN } = require('ethereumjs-util');
-export const errorMsg = 'Failed to get balance';
 
 export { BN };
 
@@ -100,7 +99,7 @@ export class TokenBalancesController extends BaseController<TokenBalancesConfig,
       try {
         newContractBalances[address] = await assetsContract.getBalanceOf(address, selectedAddress);
       } catch (error) {
-        newContractBalances[address] = new Error(errorMsg);
+        newContractBalances[address] = error;
       }
     }
     this.update({ contractBalances: newContractBalances });

--- a/src/assets/TokenBalancesController.ts
+++ b/src/assets/TokenBalancesController.ts
@@ -99,7 +99,8 @@ export class TokenBalancesController extends BaseController<TokenBalancesConfig,
       try {
         newContractBalances[address] = await assetsContract.getBalanceOf(address, selectedAddress);
       } catch (error) {
-        newContractBalances[address] = error;
+        newContractBalances[address] = 0;
+        tokens[i].balanceError = error;
       }
     }
     this.update({ contractBalances: newContractBalances });

--- a/src/assets/TokenBalancesController.ts
+++ b/src/assets/TokenBalancesController.ts
@@ -98,6 +98,7 @@ export class TokenBalancesController extends BaseController<TokenBalancesConfig,
       const { address } = tokens[i];
       try {
         newContractBalances[address] = await assetsContract.getBalanceOf(address, selectedAddress);
+        tokens[i].balanceError = undefined;
       } catch (error) {
         newContractBalances[address] = 0;
         tokens[i].balanceError = error;

--- a/src/assets/TokenBalancesController.ts
+++ b/src/assets/TokenBalancesController.ts
@@ -98,7 +98,7 @@ export class TokenBalancesController extends BaseController<TokenBalancesConfig,
       const { address } = tokens[i];
       try {
         newContractBalances[address] = await assetsContract.getBalanceOf(address, selectedAddress);
-        tokens[i].balanceError = undefined;
+        tokens[i].balanceError = null;
       } catch (error) {
         newContractBalances[address] = 0;
         tokens[i].balanceError = error;

--- a/src/assets/TokenRatesController.ts
+++ b/src/assets/TokenRatesController.ts
@@ -31,6 +31,7 @@ export interface Token {
   decimals: number;
   symbol: string;
   image?: string;
+  balanceError?: Error;
 }
 
 /**

--- a/src/assets/TokenRatesController.ts
+++ b/src/assets/TokenRatesController.ts
@@ -31,7 +31,7 @@ export interface Token {
   decimals: number;
   symbol: string;
   image?: string;
-  balanceError?: Error | undefined;
+  balanceError?: Error | null;
 }
 
 /**

--- a/src/assets/TokenRatesController.ts
+++ b/src/assets/TokenRatesController.ts
@@ -31,7 +31,7 @@ export interface Token {
   decimals: number;
   symbol: string;
   image?: string;
-  balanceError?: Error;
+  balanceError?: Error | undefined;
 }
 
 /**

--- a/tests/TokenBalancesController.test.ts
+++ b/tests/TokenBalancesController.test.ts
@@ -89,7 +89,7 @@ describe('TokenBalancesController', () => {
     expect(tokenBalances.state.contractBalances[address].toNumber()).toBeGreaterThan(0);
   });
 
-  it('should handle error case', async () => {
+  it('should handle `getBalanceOf` error case', async () => {
     const errorMsg = 'Failed to get balance';
     const address = '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0';
     expect(tokenBalances.state.contractBalances).toEqual({});
@@ -104,6 +104,7 @@ describe('TokenBalancesController', () => {
     stub(assetsContract, 'getBalanceOf').returns(Promise.reject(new Error(errorMsg)));
     await tokenBalances.updateBalances();
     expect(Object.keys(tokenBalances.state.contractBalances)).toContain(address);
+    expect(tokenBalances.state.contractBalances[address]).toBeInstanceOf(Error);
     expect(tokenBalances.state.contractBalances[address].message).toBe(errorMsg);
   });
 

--- a/tests/TokenBalancesController.test.ts
+++ b/tests/TokenBalancesController.test.ts
@@ -16,6 +16,11 @@ describe('TokenBalancesController', () => {
   let tokenBalances: TokenBalancesController;
   const sandbox = createSandbox();
 
+  const getToken = (address: string) => {
+    const { tokens } = tokenBalances.config;
+    return tokens.find((token) => token.address === address);
+  };
+
   beforeEach(() => {
     tokenBalances = new TokenBalancesController();
   });
@@ -85,9 +90,8 @@ describe('TokenBalancesController', () => {
     assetsContract.configure({ provider: MAINNET_PROVIDER });
     stub(assetsContract, 'getBalanceOf').returns(new BN(1));
     await tokenBalances.updateBalances();
-    const { tokens } = tokenBalances.config;
-    const _token = tokens.find((token) => token.address === address);
-    expect(_token?.balanceError).toBeUndefined();
+    const mytoken = getToken(address);
+    expect(mytoken?.balanceError).toBeUndefined();
     expect(Object.keys(tokenBalances.state.contractBalances)).toContain(address);
     expect(tokenBalances.state.contractBalances[address].toNumber()).toBeGreaterThan(0);
   });
@@ -106,10 +110,9 @@ describe('TokenBalancesController', () => {
     assetsContract.configure({ provider: MAINNET_PROVIDER });
     stub(assetsContract, 'getBalanceOf').returns(Promise.reject(new Error(errorMsg)));
     await tokenBalances.updateBalances();
-    const { tokens } = tokenBalances.config;
-    const _token = tokens.find((token) => token.address === address);
-    expect(_token?.balanceError).toBeInstanceOf(Error);
-    expect(_token?.balanceError?.message).toBe(errorMsg);
+    const mytoken = getToken(address);
+    expect(mytoken?.balanceError).toBeInstanceOf(Error);
+    expect(mytoken?.balanceError?.message).toBe(errorMsg);
     expect(tokenBalances.state.contractBalances[address]).toEqual(0);
   });
 

--- a/tests/TokenBalancesController.test.ts
+++ b/tests/TokenBalancesController.test.ts
@@ -91,7 +91,7 @@ describe('TokenBalancesController', () => {
     stub(assetsContract, 'getBalanceOf').returns(new BN(1));
     await tokenBalances.updateBalances();
     const mytoken = getToken(address);
-    expect(mytoken?.balanceError).toBeUndefined();
+    expect(mytoken?.balanceError).toBeNull();
     expect(Object.keys(tokenBalances.state.contractBalances)).toContain(address);
     expect(tokenBalances.state.contractBalances[address].toNumber()).toBeGreaterThan(0);
   });

--- a/tests/TokenBalancesController.test.ts
+++ b/tests/TokenBalancesController.test.ts
@@ -85,6 +85,9 @@ describe('TokenBalancesController', () => {
     assetsContract.configure({ provider: MAINNET_PROVIDER });
     stub(assetsContract, 'getBalanceOf').returns(new BN(1));
     await tokenBalances.updateBalances();
+    const { tokens } = tokenBalances.config;
+    const token = tokens.find(token => token.address === address);
+    expect(token?.balanceError).toBe(undefined);
     expect(Object.keys(tokenBalances.state.contractBalances)).toContain(address);
     expect(tokenBalances.state.contractBalances[address].toNumber()).toBeGreaterThan(0);
   });
@@ -103,7 +106,11 @@ describe('TokenBalancesController', () => {
     assetsContract.configure({ provider: MAINNET_PROVIDER });
     stub(assetsContract, 'getBalanceOf').returns(Promise.reject(new Error(errorMsg)));
     await tokenBalances.updateBalances();
-    expect(Object.keys(tokenBalances.state.contractBalances)).toContain(address);
+    const { tokens } = tokenBalances.config;
+    const token = tokens.find(token => token.address === address);
+    expect(token?.balanceError).toBeInstanceOf(Error);
+    expect(token?.balanceError?.message).toBe(errorMsg);
+    expect(tokenBalances.state.contractBalances[address]).toEqual(0);
   });
 
   it('should subscribe to new sibling assets controllers', async () => {

--- a/tests/TokenBalancesController.test.ts
+++ b/tests/TokenBalancesController.test.ts
@@ -90,6 +90,7 @@ describe('TokenBalancesController', () => {
   });
 
   it('should handle error case', async () => {
+    const errorMsg = 'Failed to get balance';
     const address = '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0';
     expect(tokenBalances.state.contractBalances).toEqual({});
     tokenBalances.configure({ tokens: [{ address, decimals: 18, symbol: 'EOS' }] });
@@ -100,10 +101,10 @@ describe('TokenBalancesController', () => {
 
     new ComposableController([assets, assetsContract, network, preferences, tokenBalances]);
     assetsContract.configure({ provider: MAINNET_PROVIDER });
-    stub(assetsContract, 'getBalanceOf').returns(Promise.reject());
+    stub(assetsContract, 'getBalanceOf').returns(Promise.reject(new Error(errorMsg)));
     await tokenBalances.updateBalances();
     expect(Object.keys(tokenBalances.state.contractBalances)).toContain(address);
-    expect(tokenBalances.state.contractBalances[address].message).toBe('Failed to get balance');
+    expect(tokenBalances.state.contractBalances[address].message).toBe(errorMsg);
   });
 
   it('should subscribe to new sibling assets controllers', async () => {

--- a/tests/TokenBalancesController.test.ts
+++ b/tests/TokenBalancesController.test.ts
@@ -104,8 +104,6 @@ describe('TokenBalancesController', () => {
     stub(assetsContract, 'getBalanceOf').returns(Promise.reject(new Error(errorMsg)));
     await tokenBalances.updateBalances();
     expect(Object.keys(tokenBalances.state.contractBalances)).toContain(address);
-    expect(tokenBalances.state.contractBalances[address]).toBeInstanceOf(Error);
-    expect(tokenBalances.state.contractBalances[address].message).toBe(errorMsg);
   });
 
   it('should subscribe to new sibling assets controllers', async () => {

--- a/tests/TokenBalancesController.test.ts
+++ b/tests/TokenBalancesController.test.ts
@@ -89,6 +89,23 @@ describe('TokenBalancesController', () => {
     expect(tokenBalances.state.contractBalances[address].toNumber()).toBeGreaterThan(0);
   });
 
+  it('should handle error case', async () => {
+    const address = '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0';
+    expect(tokenBalances.state.contractBalances).toEqual({});
+    tokenBalances.configure({ tokens: [{ address, decimals: 18, symbol: 'EOS' }] });
+    const assets = new AssetsController();
+    const assetsContract = new AssetsContractController();
+    const network = new NetworkController();
+    const preferences = new PreferencesController();
+
+    new ComposableController([assets, assetsContract, network, preferences, tokenBalances]);
+    assetsContract.configure({ provider: MAINNET_PROVIDER });
+    stub(assetsContract, 'getBalanceOf').returns(Promise.reject());
+    await tokenBalances.updateBalances();
+    expect(Object.keys(tokenBalances.state.contractBalances)).toContain(address);
+    expect(tokenBalances.state.contractBalances[address].message).toBe('Failed to get balance');
+  });
+
   it('should subscribe to new sibling assets controllers', async () => {
     const assets = new AssetsController();
     const assetsContract = new AssetsContractController();

--- a/tests/TokenBalancesController.test.ts
+++ b/tests/TokenBalancesController.test.ts
@@ -86,8 +86,8 @@ describe('TokenBalancesController', () => {
     stub(assetsContract, 'getBalanceOf').returns(new BN(1));
     await tokenBalances.updateBalances();
     const { tokens } = tokenBalances.config;
-    const token = tokens.find(token => token.address === address);
-    expect(token?.balanceError).toBe(undefined);
+    const _token = tokens.find((token) => token.address === address);
+    expect(_token?.balanceError).toBeUndefined();
     expect(Object.keys(tokenBalances.state.contractBalances)).toContain(address);
     expect(tokenBalances.state.contractBalances[address].toNumber()).toBeGreaterThan(0);
   });
@@ -107,9 +107,9 @@ describe('TokenBalancesController', () => {
     stub(assetsContract, 'getBalanceOf').returns(Promise.reject(new Error(errorMsg)));
     await tokenBalances.updateBalances();
     const { tokens } = tokenBalances.config;
-    const token = tokens.find(token => token.address === address);
-    expect(token?.balanceError).toBeInstanceOf(Error);
-    expect(token?.balanceError?.message).toBe(errorMsg);
+    const _token = tokens.find((token) => token.address === address);
+    expect(_token?.balanceError).toBeInstanceOf(Error);
+    expect(_token?.balanceError?.message).toBe(errorMsg);
     expect(tokenBalances.state.contractBalances[address]).toEqual(0);
   });
 


### PR DESCRIPTION
this allows for tokens to have a `balanceError` property... surprisingly similar to: https://github.com/MetaMask/eth-token-tracker/pull/53/files#diff-da4ef0bd8d62fc58923ab92dc5a94b4fdaeaa2a36242311727356d7e3f1d44d0R79

re: [#2128](https://github.com/MetaMask/metamask-mobile/issues/2128)