### PR TITLE
Add the controller for what's new notification for feature announcements 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,4 +20,5 @@ export * from './assets/TokenRatesController';
 export * from './transaction/TransactionController';
 export * from './message-manager/PersonalMessageManager';
 export * from './message-manager/TypedMessageManager';
+export * from './notification/NotificationController';
 export { util };

--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -1,81 +1,85 @@
-import BaseController, { BaseConfig, BaseState } from "../BaseController";
+import BaseController, { BaseConfig, BaseState } from '../BaseController';
 
-type viewedNotification = {[id:number]: boolean};
+interface viewedNotification {
+[id: number]: boolean;
+}
 
 export interface Notification{
     id: number;
-	title: string;
-	description: string;
+    title: string;
+    description: string;
     date: string;
-	image?: string;
+    image?: string;
     actionText: string;
-    isShown?: Boolean;
+    isShown?: boolean;
 }
 
-//NotitificationConfig will hold the notifications from JSON file read from `metamask-extension`
+// NotitificationConfig will hold the notifications from JSON file read from `metamask-extension`
 export interface NotificationConfig extends BaseConfig{
     notificationsFromFile: { [whatsnew: string]: Notification[]};
 }
 
-//Notification state will hold all the seen and unseen notifications 
+// Notification state will hold all the seen and unseen notifications
 // that are still active
 export interface NotificationState extends BaseState{
-    notifications: Notification[]
+    notifications: Notification[];
 }
 
-const defaultState = { notifications: [] }
+const defaultState = { notifications: [] };
 
 /**
- * Controller for managing the notifications for new features introducesd into the applications 
+ * Controller for managing the notifications for new features introducesd into the applications
  */
-export class NotificationController extends BaseController<NotificationConfig, NotificationState>{
+export class NotificationController extends BaseController<NotificationConfig, NotificationState> {
 
-    constructor(config: NotificationConfig, state?: NotificationState){
+    constructor(config: NotificationConfig, state?: NotificationState) {
         const { notificationsFromFile } = config;
         super(config, state || defaultState);
         this.initialize();
-        this.addNotifications(notificationsFromFile.whatsnew)
+        this.addNotifications(notificationsFromFile.whatsnew);
     }
 
     /**
      * Compares the notifications in teh states with the notifications from the files to check if there is any new notitifcations/announcements
      * if yes, the new notification will be added to the state with a flag indicating that the notification is not seen by the user.
-     * @param filedNotifications 
+     * @param filedNotifications
      */
     private addNotifications(filedNotifications: Notification[]): void{
-        let stateNotifications = this.state.notifications;
+        const stateNotifications = this.state.notifications;
         let exists: boolean;
-        if(this.state.notifications.length > 0){
-            for(let fromFile of filedNotifications){
+        if (this.state.notifications.length > 0) {
+            for (const fromFile of filedNotifications) {
                 exists = false;
-                for(let fromState of this.state.notifications){
-                    if(fromFile.id == fromState.id){
+                for (const fromState of this.state.notifications) {
+                    if (fromFile.id === fromState.id) {
                         exists = true;
                         break;
                     }
                 }
-                if(!exists){
+                if (!exists) {
                     fromFile.isShown = false;
                     stateNotifications.push(fromFile);
                 }
             }
-       }else{
-            for(let fromfile of filedNotifications){
+       } else {
+            for (const fromfile of filedNotifications) {
                 fromfile.isShown = false;
                 stateNotifications.push(fromfile);
             }
         }
-        this.update({ notifications: stateNotifications }, true)
+        this.update({ notifications: stateNotifications }, true);
     }
 
     /**
      * Updates the status of the status of the specified notifications once it is read by the user.
-     * @param viewedIds 
+     * @param viewedIds
      */
-    updateViewed(viewedIds: viewedNotification):void {
-        const stateNotifications = this.state.notifications
-        for(let index=0; index< stateNotifications.length; index++){
-            stateNotifications[index].isShown = viewedIds[stateNotifications[index].id]
+    updateViewed(viewedIds: viewedNotification): void {
+        const stateNotifications = this.state.notifications;
+        let index = 0;
+        for (const fromState of stateNotifications) {
+            stateNotifications[index].isShown = viewedIds[fromState.id];
+            index += 1;
         }
         this.update({ notifications: stateNotifications }, true);
     }

--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -76,8 +76,8 @@ export class NotificationController extends BaseController<NotificationConfig, N
         if (newNotification.action === undefined) {
           throw new Error('Must have an actionText and actionFunction.');
         }
-        const { action, ...stateNotification } = newNotification;
-        const { actionFunction, ...modifiedAction } = action;
+        const { action: { actionFunction, ...modifiedAction }, ...stateNotification } = newNotification;
+
         return { ...stateNotification, action: modifiedAction, isShown: false };
       });
 

--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -76,17 +76,9 @@ export class NotificationController extends BaseController<NotificationConfig, N
         if (newNotification.action === undefined) {
           throw new Error('Must have an actionText and actionFunction.');
         }
-        return {
-          'id': newNotification.id,
-          'title': newNotification.title,
-          'description': newNotification.description,
-          'date': newNotification.date,
-          'image': newNotification.image ? newNotification.image as string : '',
-          'action': {
-            'actionText': (newNotification.action as action).actionText,
-          },
-          'isShown': false,
-        };
+        const { action, ...stateNotification } = newNotification;
+        const { actionFunction, ...modifiedAction } = action;
+        return  { ...stateNotification, action: modifiedAction, isShown: false };
       });
 
     const stateNotifications: Record<number, Notification> = newNotifications

--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -6,8 +6,6 @@ interface viewedNotification {
 
 interface Notification {
   id: number;
-  date: string;
-  image?: string;
 }
 
 interface StateNotification extends Notification {

--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -1,28 +1,33 @@
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 
 interface viewedNotification {
-[id: number]: boolean;
+  [id: number]: boolean;
 }
 
 export interface Notification{
-    id: number;
-    title: string;
-    description: string;
-    date: string;
-    image?: string;
-    actionText: string;
-    isShown?: boolean;
+  id: number;
+  title: string;
+  description: string;
+  date: string;
+  image?: string;
+  actionText: string;
+  isShown?: boolean;
 }
 
-// NotitificationConfig will hold the notifications from JSON file read from `metamask-extension`
+/**
+ * NotitificationConfig will hold the notifications from JSON file read
+ * from `metamask-extension`
+ */
 export interface NotificationConfig extends BaseConfig{
-    notificationsFromFile: { [whatsnew: string]: Notification[]};
+  notificationsFromFile: { [whatsnew: string]: Notification[]};
 }
 
-// Notification state will hold all the seen and unseen notifications
-// that are still active
+/**
+ * Notification state will hold all the seen and unseen notifications
+ * that are still active
+ */
 export interface NotificationState extends BaseState{
-    notifications: Notification[];
+  notifications: Notification[];
 }
 
 const defaultState = { notifications: [] };
@@ -32,55 +37,66 @@ const defaultState = { notifications: [] };
  */
 export class NotificationController extends BaseController<NotificationConfig, NotificationState> {
 
-    constructor(config: NotificationConfig, state?: NotificationState) {
-        const { notificationsFromFile } = config;
-        super(config, state || defaultState);
-        this.initialize();
-        this.addNotifications(notificationsFromFile.whatsnew);
-    }
-
     /**
-     * Compares the notifications in teh states with the notifications from the files to check if there is any new notitifcations/announcements
-     * if yes, the new notification will be added to the state with a flag indicating that the notification is not seen by the user.
-     * @param filedNotifications
-     */
-    private addNotifications(filedNotifications: Notification[]): void{
-        const stateNotifications = this.state.notifications;
-        let exists: boolean;
-        if (this.state.notifications.length > 0) {
-            for (const fromFile of filedNotifications) {
-                exists = false;
-                for (const fromState of this.state.notifications) {
-                    if (fromFile.id === fromState.id) {
-                        exists = true;
-                        break;
-                    }
-                }
-                if (!exists) {
-                    fromFile.isShown = false;
-                    stateNotifications.push(fromFile);
-                }
-            }
-       } else {
-            for (const fromfile of filedNotifications) {
-                fromfile.isShown = false;
-                stateNotifications.push(fromfile);
-            }
-        }
-        this.update({ notifications: stateNotifications }, true);
-    }
+   * Creates a NotificationController instance
+   *
+   * @param config - Initial options used to configure this controller
+   * @param state - Initial state to set on this controller
+   */
+  constructor(config: NotificationConfig, state?: NotificationState) {
+    const { notificationsFromFile } = config;
+    super(config, state || defaultState);
+    this.initialize();
+    this._addNotifications(notificationsFromFile.whatsnew);
+  }
 
-    /**
-     * Updates the status of the status of the specified notifications once it is read by the user.
-     * @param viewedIds
-     */
-    updateViewed(viewedIds: viewedNotification): void {
-        const stateNotifications = this.state.notifications;
-        let index = 0;
-        for (const fromState of stateNotifications) {
-            stateNotifications[index].isShown = viewedIds[fromState.id];
-            index += 1;
+  /**
+   * Compares the notifications in teh states with the notifications from the files
+   * to check if there is any new notitifcations/announcements
+   * if yes, the new notification will be added to the state with a flag indicating
+   * that the notification is not seen by the user.
+   *
+   *  @param filedNotifications
+   */
+  private _addNotifications(filedNotifications: Notification[]): void{
+    const stateNotifications = this.state.notifications;
+    let exists: boolean;
+    if (this.state.notifications.length > 0) {
+      for (const fromFile of filedNotifications) {
+        exists = false;
+        for (const fromState of this.state.notifications) {
+          if (fromFile.id === fromState.id) {
+            exists = true;
+            break;
+          }
         }
-        this.update({ notifications: stateNotifications }, true);
+        if (!exists) {
+          fromFile.isShown = false;
+          stateNotifications.push(fromFile);
+        }
+      }
+    } else {
+      for (const fromfile of filedNotifications) {
+        fromfile.isShown = false;
+        stateNotifications.push(fromfile);
+      }
     }
+    this.update({ notifications: stateNotifications }, true);
+  }
+
+  /**
+   * Updates the status of the status of the specified notifications
+   * once it is read by the user.
+   *
+   * @param viewedIds
+   */
+  updateViewed(viewedIds: viewedNotification): void {
+    const stateNotifications = this.state.notifications;
+    let index = 0;
+    for (const fromState of stateNotifications) {
+      stateNotifications[index].isShown = viewedIds[fromState.id];
+      index += 1;
+    }
+    this.update({ notifications: stateNotifications }, true);
+  }
 }

--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -6,6 +6,7 @@ interface viewedNotification {
 
 interface Notification {
   id: number;
+  date: string;
 }
 
 interface StateNotification extends Notification {

--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -15,7 +15,7 @@ export interface Notification{
   description: string;
   date: string;
   image?: string;
-  actionText: string;
+  action?: Partial<action>;
   isShown?: boolean;
 }
 
@@ -24,7 +24,7 @@ export interface Notification{
  * from `metamask-extension`
  */
 export interface NotificationConfig extends BaseConfig{
-  allNotifications: Record<string, string | number | action>[];
+  allNotifications: Notification[];
 }
 
 /**
@@ -42,7 +42,7 @@ const defaultState = {};
  */
 export class NotificationController extends BaseController<NotificationConfig, NotificationState> {
 
-  private readonly allNotifications: Record<string, string | number | action>[];
+  private readonly allNotifications: Notification[];
 
   /**
    * Creates a NotificationController instance
@@ -77,12 +77,14 @@ export class NotificationController extends BaseController<NotificationConfig, N
           throw new Error('Must have an actionText and actionFunction.');
         }
         return {
-          'id': newNotification.id as number,
-          'title': newNotification.title as string,
-          'description': newNotification.description as string,
-          'date': newNotification.date as string,
+          'id': newNotification.id,
+          'title': newNotification.title,
+          'description': newNotification.description,
+          'date': newNotification.date,
           'image': newNotification.image ? newNotification.image as string : '',
-          'actionText': (newNotification.action as action).actionText,
+          'action': {
+            'actionText': (newNotification.action as action).actionText,
+          },
           'isShown': false,
         };
       });
@@ -118,7 +120,7 @@ export class NotificationController extends BaseController<NotificationConfig, N
    */
   actionCall(id: number): void {
     try {
-      const notification: Record<string, string | number | action> | undefined = this.allNotifications.find((notify) => notify.id === id);
+      const notification: Notification | undefined = this.allNotifications.find((notify) => notify.id === id);
       (notification?.action as action).actionFunction();
     } catch (error) {
       throw new Error('Incomplete notification.');

--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -78,7 +78,7 @@ export class NotificationController extends BaseController<NotificationConfig, N
         }
         const { action, ...stateNotification } = newNotification;
         const { actionFunction, ...modifiedAction } = action;
-        return  { ...stateNotification, action: modifiedAction, isShown: false };
+        return { ...stateNotification, action: modifiedAction, isShown: false };
       });
 
     const stateNotifications: Record<number, Notification> = newNotifications

--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -6,11 +6,8 @@ interface viewedNotification {
 
 interface Notification {
   id: number;
-  title: string;
-  description: string;
   date: string;
   image?: string;
-  actionText?: string;
 }
 
 interface StateNotification extends Notification {

--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -2,7 +2,7 @@ import BaseController, { BaseConfig, BaseState } from '../BaseController';
 
 interface action {
   actionText: string;
-  actionFunction: () => void;
+  actionFunction: VoidFunction;
 }
 
 interface viewedNotification {

--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -1,22 +1,34 @@
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 
-interface action {
-  actionText: string;
-  actionFunction: VoidFunction;
-}
-
 interface viewedNotification {
   [id: number]: boolean;
 }
 
-export interface Notification{
+interface Notification {
   id: number;
   title: string;
   description: string;
   date: string;
   image?: string;
-  action?: Partial<action>;
-  isShown?: boolean;
+  actionText?: string;
+}
+
+interface StateNotification extends Notification {
+  isShown: boolean;
+}
+
+/**
+  * A map of notification ids to Notification objects
+  */
+interface NotificationMap {
+  [id: number]: Notification;
+}
+
+/**
+  * A map of notification ids to StateNotification objects
+  */
+export interface StateNotificationMap {
+  [id: number]: StateNotification;
 }
 
 /**
@@ -24,7 +36,7 @@ export interface Notification{
  * from `metamask-extension`
  */
 export interface NotificationConfig extends BaseConfig{
-  allNotifications: Notification[];
+  allNotifications: NotificationMap;
 }
 
 /**
@@ -32,17 +44,19 @@ export interface NotificationConfig extends BaseConfig{
  * that are still active
  */
 export interface NotificationState extends BaseState{
-  notifications: { [id: number]: Notification};
+  notifications: StateNotificationMap;
 }
 
-const defaultState = {};
+const defaultState = {
+  notifications: {},
+};
 
 /**
  * Controller for managing in-app announcement notifications.
  */
 export class NotificationController extends BaseController<NotificationConfig, NotificationState> {
 
-  private readonly allNotifications: Notification[];
+  private readonly allNotifications: NotificationMap;
 
   /**
    * Creates a NotificationController instance
@@ -53,7 +67,7 @@ export class NotificationController extends BaseController<NotificationConfig, N
   constructor(config: NotificationConfig, state?: NotificationState) {
     const { allNotifications } = config;
     super(config, state || defaultState);
-    this.allNotifications = [...allNotifications];
+    this.allNotifications = { ...allNotifications };
     this.initialize();
     this._addNotifications();
   }
@@ -67,27 +81,17 @@ export class NotificationController extends BaseController<NotificationConfig, N
    *  @param allNotifications
    */
   private _addNotifications(): void{
-    const existingNotificationIds: number[] = this.state.notifications ? Object.keys(this.state.notifications).map(Number) : [];
+    const newNotifications: StateNotificationMap = {};
 
-    const newNotifications: Notification[] = this.allNotifications
-      .filter((notification) => !existingNotificationIds
-      .some((existingId) => (existingId === notification.id)))
-      .map((newNotification) => {
-        if (newNotification.action === undefined) {
-          throw new Error('Must have an actionText and actionFunction.');
-        }
-        const { action: { actionFunction, ...modifiedAction }, ...stateNotification } = newNotification;
-
-        return { ...stateNotification, action: modifiedAction, isShown: false };
-      });
-
-    const stateNotifications: Record<number, Notification> = newNotifications
-      .reduce((object: Record<number, Notification>, notification: Notification) => {
-        object[notification.id] = notification;
-        return object;
-      }, {});
-
-    this.update({ notifications: { ...this.state.notifications, ...stateNotifications } }, true);
+    Object.values(this.allNotifications).forEach((notification: StateNotification) => {
+      newNotifications[notification.id] = this.state.notifications[notification.id]
+        ? this.state.notifications[notification.id]
+        : {
+          ...notification,
+          isShown: false,
+        };
+    });
+    this.update({ notifications: newNotifications });
   }
 
   /**
@@ -99,23 +103,9 @@ export class NotificationController extends BaseController<NotificationConfig, N
   updateViewed(viewedIds: viewedNotification): void {
     const stateNotifications = this.state.notifications;
 
-    for (const id of Object.keys(stateNotifications)) {
+    for (const id of Object.keys(viewedIds)) {
       stateNotifications[(id as unknown) as number].isShown = viewedIds[(id as unknown) as number];
     }
-
     this.update({ notifications: stateNotifications }, true);
-  }
-
-  /**
-   * retuns the actionFucntion
-   * @param id
-   */
-  actionCall(id: number): void {
-    try {
-      const notification: Notification | undefined = this.allNotifications.find((notify) => notify.id === id);
-      (notification?.action as action).actionFunction();
-    } catch (error) {
-      throw new Error('Incomplete notification.');
-    }
   }
 }

--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -11,6 +11,7 @@ export interface Notification{
   date: string;
   image?: string;
   actionText: string;
+  actionURL: string;
   isShown?: boolean;
 }
 

--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -18,15 +18,15 @@ interface StateNotification extends Notification {
 }
 
 /**
-  * A map of notification ids to Notification objects
-  */
+ * A map of notification ids to Notification objects
+ */
 interface NotificationMap {
   [id: number]: Notification;
 }
 
 /**
-  * A map of notification ids to StateNotification objects
-  */
+ * A map of notification ids to StateNotification objects
+ */
 export interface StateNotificationMap {
   [id: number]: StateNotification;
 }
@@ -54,7 +54,6 @@ const defaultState = {
  * Controller for managing in-app announcement notifications.
  */
 export class NotificationController extends BaseController<NotificationConfig, NotificationState> {
-
   /**
    * Creates a NotificationController instance
    *
@@ -82,9 +81,9 @@ export class NotificationController extends BaseController<NotificationConfig, N
       newNotifications[notification.id] = this.state.notifications[notification.id]
         ? this.state.notifications[notification.id]
         : {
-          ...notification,
-          isShown: false,
-        };
+            ...notification,
+            isShown: false,
+          };
     });
     this.update({ notifications: newNotifications });
   }

--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -32,10 +32,9 @@ export interface StateNotificationMap {
 }
 
 /**
- * NotitificationConfig will hold the notifications from JSON file read
- * from `metamask-extension`
+ * NotitificationConfig will hold the active notifications
  */
-export interface NotificationConfig extends BaseConfig{
+export interface NotificationConfig extends BaseConfig {
   allNotifications: NotificationMap;
 }
 
@@ -43,7 +42,7 @@ export interface NotificationConfig extends BaseConfig{
  * Notification state will hold all the seen and unseen notifications
  * that are still active
  */
-export interface NotificationState extends BaseState{
+export interface NotificationState extends BaseState {
   notifications: StateNotificationMap;
 }
 
@@ -56,8 +55,6 @@ const defaultState = {
  */
 export class NotificationController extends BaseController<NotificationConfig, NotificationState> {
 
-  private readonly allNotifications: NotificationMap;
-
   /**
    * Creates a NotificationController instance
    *
@@ -65,9 +62,7 @@ export class NotificationController extends BaseController<NotificationConfig, N
    * @param state - Initial state to set on this controller
    */
   constructor(config: NotificationConfig, state?: NotificationState) {
-    const { allNotifications } = config;
     super(config, state || defaultState);
-    this.allNotifications = { ...allNotifications };
     this.initialize();
     this._addNotifications();
   }
@@ -80,10 +75,10 @@ export class NotificationController extends BaseController<NotificationConfig, N
    *
    *  @param allNotifications
    */
-  private _addNotifications(): void{
+  private _addNotifications(): void {
     const newNotifications: StateNotificationMap = {};
-
-    Object.values(this.allNotifications).forEach((notification: StateNotification) => {
+    const { allNotifications } = this.config;
+    Object.values(allNotifications).forEach((notification: StateNotification) => {
       newNotifications[notification.id] = this.state.notifications[notification.id]
         ? this.state.notifications[notification.id]
         : {
@@ -103,8 +98,8 @@ export class NotificationController extends BaseController<NotificationConfig, N
   updateViewed(viewedIds: viewedNotification): void {
     const stateNotifications = this.state.notifications;
 
-    for (const id of Object.keys(viewedIds)) {
-      stateNotifications[(id as unknown) as number].isShown = viewedIds[(id as unknown) as number];
+    for (const id of Object.keys(viewedIds).map(Number)) {
+      stateNotifications[id].isShown = viewedIds[id];
     }
     this.update({ notifications: stateNotifications }, true);
   }

--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -74,16 +74,15 @@ export class NotificationController extends BaseController<NotificationConfig, N
           throw new Error('Must have an actionFunction for an actionText.');
         }
         return {
-                  'id': notification.id as number,
-                  'title': notification.title as string,
-                  'description': notification.description as string,
-                  'date': notification.date as string,
-                  'image': notification.image ? notification.image as string : '',
-                  'actionText': notification.actionText as string,
-                  'isShown': false,
-              };
-        }
-      );
+          'id': notification.id as number,
+          'title': notification.title as string,
+          'description': notification.description as string,
+          'date': notification.date as string,
+          'image': notification.image ? notification.image as string : '',
+          'actionText': notification.actionText as string,
+          'isShown': false,
+        };
+      });
 
     const stateNotifications: Record<number, Notification> = newNotifications
       .reduce((object: Record<number, Notification>, notification: Notification) => {
@@ -114,7 +113,8 @@ export class NotificationController extends BaseController<NotificationConfig, N
    * retuns the actionFucntion
    * @param id
    */
-  actionCall(id: number): action {
-    return this.allNotifications.find((notification) => notification.id === id)?.actionFunction as action;
+  actionCall(id: number): action | null {
+    const notification = this.allNotifications.find((notify) => notify.id === id);
+    return notification ? notification.actionFunction as action : null;
   }
 }

--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -1,0 +1,82 @@
+import BaseController, { BaseConfig, BaseState } from "../BaseController";
+
+type viewedNotification = {[id:number]: boolean};
+
+export interface Notification{
+    id: number;
+	title: string;
+	description: string;
+    date: string;
+	image?: string;
+    actionText: string;
+    isShown?: Boolean;
+}
+
+//NotitificationConfig will hold the notifications from JSON file read from `metamask-extension`
+export interface NotificationConfig extends BaseConfig{
+    notificationsFromFile: { [whatsnew: string]: Notification[]};
+}
+
+//Notification state will hold all the seen and unseen notifications 
+// that are still active
+export interface NotificationState extends BaseState{
+    notifications: Notification[]
+}
+
+const defaultState = { notifications: [] }
+
+/**
+ * Controller for managing the notifications for new features introducesd into the applications 
+ */
+export class NotificationController extends BaseController<NotificationConfig, NotificationState>{
+
+    constructor(config: NotificationConfig, state?: NotificationState){
+        const { notificationsFromFile } = config;
+        super(config, state || defaultState);
+        this.initialize();
+        this.addNotifications(notificationsFromFile.whatsnew)
+    }
+
+    /**
+     * Compares the notifications in teh states with the notifications from the files to check if there is any new notitifcations/announcements
+     * if yes, the new notification will be added to the state with a flag indicating that the notification is not seen by the user.
+     * @param filedNotifications 
+     */
+    private addNotifications(filedNotifications: Notification[]): void{
+        let stateNotifications = this.state.notifications;
+        let exists: boolean;
+        if(this.state.notifications.length > 0){
+            for(let fromFile of filedNotifications){
+                exists = false;
+                for(let fromState of this.state.notifications){
+                    if(fromFile.id == fromState.id){
+                        exists = true;
+                        break;
+                    }
+                }
+                if(!exists){
+                    fromFile.isShown = false;
+                    stateNotifications.push(fromFile);
+                }
+            }
+       }else{
+            for(let fromfile of filedNotifications){
+                fromfile.isShown = false;
+                stateNotifications.push(fromfile);
+            }
+        }
+        this.update({ notifications: stateNotifications }, true)
+    }
+
+    /**
+     * Updates the status of the status of the specified notifications once it is read by the user.
+     * @param viewedIds 
+     */
+    updateViewed(viewedIds: viewedNotification):void {
+        const stateNotifications = this.state.notifications
+        for(let index=0; index< stateNotifications.length; index++){
+            stateNotifications[index].isShown = viewedIds[stateNotifications[index].id]
+        }
+        this.update({ notifications: stateNotifications }, true);
+    }
+}

--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -33,7 +33,7 @@ export interface NotificationState extends BaseState{
 const defaultState = { notifications: [] };
 
 /**
- * Controller for managing the notifications for new features introducesd into the applications
+ * Controller for managing in-app announcement notifications.
  */
 export class NotificationController extends BaseController<NotificationConfig, NotificationState> {
 

--- a/tests/NotificationController.test.ts
+++ b/tests/NotificationController.test.ts
@@ -15,6 +15,7 @@ const config1: NotificationConfig = {
       description:
         'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
       date: '12/8/2020',
+      image: 'image url',
       actionText: 'Start swapping',
       actionFunction: swapsHandler,
     },
@@ -46,6 +47,7 @@ const config2: NotificationConfig = {
       description:
         'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
       date: '12/8/2020',
+      image: 'image url',
       actionText: 'Get the mobile app',
     },
   ],
@@ -59,6 +61,7 @@ const config3: NotificationConfig = {
       description:
         'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
       date: '12/8/2020',
+      image: 'image url',
       actionText: 'Start swapping',
       actionFunction: swapsHandler,
     },
@@ -108,6 +111,7 @@ describe('notification controller', () => {
       expect(controller.actionCall(1)).toEqual(swapsHandler);
       expect(controller.actionCall(2)).toEqual(mobileHandler);
       expect(controller.actionCall(3)).toEqual(npsHandler);
+      expect(controller.actionCall(4)).toBeNull();
     });
   });
   describe('update viewed notifications', () => {

--- a/tests/NotificationController.test.ts
+++ b/tests/NotificationController.test.ts
@@ -4,6 +4,9 @@ import {
   NotificationState,
 } from '../src/notification/NotificationController';
 
+const swapsHandler = () => console.log('swaps');
+const mobileHandler = () => console.log('mobile');
+const npsHandler = () => console.log('NPS survey');
 const config1: NotificationConfig = {
   allNotifications: [
     {
@@ -13,7 +16,7 @@ const config1: NotificationConfig = {
         'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
       date: '12/8/2020',
       actionText: 'Start swapping',
-      actionURL: '/swaps',
+      actionFunction: swapsHandler,
     },
     {
       id: 2,
@@ -22,7 +25,7 @@ const config1: NotificationConfig = {
         'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
       date: '12/8/2020',
       actionText: 'Get the mobile app',
-      actionURL: 'https://metamask.io/download.html',
+      actionFunction: mobileHandler,
     },
   ],
 };
@@ -36,7 +39,6 @@ const config2: NotificationConfig = {
         'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
       date: '12/8/2020',
       actionText: 'Start swapping',
-      actionURL: '/swaps',
     },
     {
       id: 2,
@@ -45,7 +47,29 @@ const config2: NotificationConfig = {
         'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
       date: '12/8/2020',
       actionText: 'Get the mobile app',
-      actionURL: 'https://metamask.io/download.html',
+    },
+  ],
+};
+
+const config3: NotificationConfig = {
+  allNotifications: [
+    {
+      id: 1,
+      title: 'Now Swap tokens directly in your wallet!',
+      description:
+        'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
+      date: '12/8/2020',
+      actionText: 'Start swapping',
+      actionFunction: swapsHandler,
+    },
+    {
+      id: 2,
+      title: 'MetaMask Mobile is here!',
+      description:
+        'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
+      date: '12/8/2020',
+      actionText: 'Get the mobile app',
+      actionFunction: mobileHandler,
     },
     {
       id: 3,
@@ -53,7 +77,7 @@ const config2: NotificationConfig = {
       description: 'Take NPS survey here',
       date: '12/8/2020',
       actionText: 'Take the Survey',
-      actionURL: 'survey url',
+      actionFunction: npsHandler,
     },
   ],
 };
@@ -65,12 +89,27 @@ describe('notification controller', () => {
     expect(Object.keys(controller.state.notifications)).toHaveLength(2);
     state = controller.state;
   });
+  it('should not add new notifcation to state when actiontion is not present', () => {
+    try {
+      new NotificationController(config2);
+    } catch (error) {
+      expect(error.message).toEqual('Must have an actionFunction for an actionText.');
+    }
+  });
+
   let controller: NotificationController;
   it('should add new notifcation to state', () => {
-    controller = new NotificationController(config2, state);
+    controller = new NotificationController(config3, state);
     expect(Object.keys(controller.state.notifications)).toHaveLength(3);
   });
 
+  describe('calling the actionFunction', () => {
+    it('should return the actionFunction corresponding to the id', () => {
+      expect(controller.actionCall(1)).toEqual(swapsHandler);
+      expect(controller.actionCall(2)).toEqual(mobileHandler);
+      expect(controller.actionCall(3)).toEqual(npsHandler);
+    });
+  });
   describe('update viewed notifications', () => {
     it('should update isshown status', () => {
       controller.updateViewed({ 1: true });

--- a/tests/NotificationController.test.ts
+++ b/tests/NotificationController.test.ts
@@ -1,144 +1,125 @@
 import {
   NotificationConfig,
-  NotificationController,
   NotificationState,
+  NotificationController,
+  StateNotificationMap,
 } from '../src/notification/NotificationController';
 
-const swapsHandler = jest.fn();
-const mobileHandler = jest.fn();
-const npsHandler = jest.fn();
 const config1: NotificationConfig = {
-  allNotifications: [
-    {
+  allNotifications: {
+    1: {
       id: 1,
       title: 'Now Swap tokens directly in your wallet!',
       description:
         'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
       date: '12/8/2020',
       image: 'image url',
-      action: {
-        actionText: 'Start swapping',
-        actionFunction: swapsHandler,
-      },
+      actionText: 'Start swapping',
     },
-    {
+    2: {
       id: 2,
       title: 'MetaMask Mobile is here!',
       description:
         'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
       date: '12/8/2020',
-      action: {
-        actionText: 'Get the mobile app',
-        actionFunction: mobileHandler,
-      },
+      actionText: 'Get the mobile app',
     },
-  ],
+  },
 };
 
 const config2: NotificationConfig = {
-  allNotifications: [
-    {
-      id: 1,
-      title: 'Now Swap tokens directly in your wallet!',
-      description:
-        'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
-      date: '12/8/2020',
-    },
-    {
-      id: 2,
-      title: 'MetaMask Mobile is here!',
-      description:
-        'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
-      date: '12/8/2020',
-      image: 'image url',
-    },
-  ],
-};
-
-const config3: NotificationConfig = {
-  allNotifications: [
-    {
+  allNotifications: {
+    1: {
       id: 1,
       title: 'Now Swap tokens directly in your wallet!',
       description:
         'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
       date: '12/8/2020',
       image: 'image url',
-      action: {
-        actionText: 'Start swapping',
-        actionFunction: swapsHandler,
-      },
+      actionText: 'Start swapping',
     },
-    {
+    2: {
       id: 2,
       title: 'MetaMask Mobile is here!',
       description:
         'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
       date: '12/8/2020',
-      action: {
-        actionText: 'Get the mobile app',
-        actionFunction: mobileHandler,
-      },
+      actionText: 'Get the mobile app',
     },
-    {
+    3: {
       id: 3,
       title: 'Help improve MetaMask',
       description: 'Please shae your experience in this 5 minute survey',
       date: '12/8/2020',
-      action: {
-        actionText: 'Start Survey',
-        actionFunction: npsHandler,
-      },
+      actionText: 'Start Survey',
     },
-  ],
+  },
+};
+
+const state1: NotificationState = {
+  notifications: {
+    1: {
+      id: 1,
+      title: 'Now Swap tokens directly in your wallet!',
+      description:
+        'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
+      date: '12/8/2020',
+      image: 'image url',
+      actionText: 'Start swapping',
+      isShown: true,
+    },
+    2: {
+      id: 2,
+      title: 'MetaMask Mobile is here!',
+      description:
+        'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
+      date: '12/8/2020',
+      actionText: 'Get the mobile app',
+      isShown: true,
+    },
+  },
 };
 
 describe('notification controller', () => {
-  let state: NotificationState;
   it('should add notifications to state', () => {
     const controller = new NotificationController(config1);
     expect(Object.keys(controller.state.notifications)).toHaveLength(2);
-    state = controller.state;
-  });
-  it('should not add new notifcation to state when actiontion is not present', () => {
-    try {
-      new NotificationController(config2);
-    } catch (error) {
-      expect(error.message).toEqual('Must have an actionText and actionFunction.');
-    }
+    const expectedStateNotifications: StateNotificationMap = {
+      1: {
+        ...config1.allNotifications[1],
+        isShown: false,
+      },
+      2: {
+        ...config1.allNotifications[2],
+        isShown: false,
+      },
+    };
+    expect(controller.state.notifications).toEqual(expectedStateNotifications);
   });
 
-  let controller: NotificationController;
   it('should add new notifcation to state', () => {
-    controller = new NotificationController(config3, state);
+    const controller = new NotificationController(config2, state1);
     expect(Object.keys(controller.state.notifications)).toHaveLength(3);
+    expect(controller.state.notifications[1].isShown).toBe(true);
+    expect(controller.state.notifications[2].isShown).toBe(true);
+    expect(controller.state.notifications[3].isShown).toBe(false);
   });
 
-  describe('calling the actionFunction', () => {
-    it('should return the actionFunction corresponding to the id', () => {
-      controller.actionCall(1);
-      expect(swapsHandler).toHaveBeenCalled();
-      controller.actionCall(2);
-      expect(mobileHandler).toHaveBeenCalled();
-      controller.actionCall(3);
-      expect(npsHandler).toHaveBeenCalled();
-      try {
-        expect(controller.actionCall(4)).toBeUndefined();
-      } catch (error) {
-        expect(error.message).toEqual('Incomplete notification.');
-      }
-    });
-  });
   describe('update viewed notifications', () => {
-    it('should update isshown status', () => {
+    it('should update isShown status', () => {
+      const controller = new NotificationController(config2);
       controller.updateViewed({ 1: true });
-      expect(controller.state.notifications[1].isShown).toBeTruthy();
-      expect(controller.state.notifications[2].isShown).toBeFalsy();
+      expect(controller.state.notifications[1].isShown).toBe(true);
+      expect(controller.state.notifications[2].isShown).toBe(false);
+      expect(controller.state.notifications[3].isShown).toBe(false);
     });
-    it('should update isshown of more than one notifications', () => {
+
+    it('should update isShown of more than one notifications', () => {
+      const controller = new NotificationController(config2);
       controller.updateViewed({ 2: true, 3: true });
-      expect(controller.state.notifications[2].isShown).toBeTruthy();
-      expect(controller.state.notifications[3].isShown).toBeTruthy();
+      expect(controller.state.notifications[1].isShown).toBe(false);
+      expect(controller.state.notifications[2].isShown).toBe(true);
+      expect(controller.state.notifications[3].isShown).toBe(true);
     });
   });
 });

--- a/tests/NotificationController.test.ts
+++ b/tests/NotificationController.test.ts
@@ -12,7 +12,8 @@ const config1: NotificationConfig = {
       description:
         'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
       date: '12/8/2020',
-      actionText: 'url',
+      actionText: 'Start swapping',
+      actionURL: '/swaps'
     },
     {
       id: 2,
@@ -20,7 +21,8 @@ const config1: NotificationConfig = {
       description:
         'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
       date: '12/8/2020',
-      actionText: 'url',
+      actionText: 'Get the mobile app',
+      actionURL: 'https://metamask.io/download.html'
     },
   ],
 };
@@ -33,7 +35,8 @@ const config2: NotificationConfig = {
       description:
         'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
       date: '12/8/2020',
-      actionText: 'url',
+      actionText: 'Start swapping',
+      actionURL: '/swaps'
     },
     {
       id: 2,
@@ -41,14 +44,16 @@ const config2: NotificationConfig = {
       description:
         'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
       date: '12/8/2020',
-      actionText: 'url',
+      actionText: 'Get the mobile app',
+      actionURL: 'https://metamask.io/download.html'
     },
     {
       id: 3,
-      title: 'NSS Survey',
-      description: 'Take NSS survey here',
+      title: 'NPS Survey',
+      description: 'Take NPS survey here',
       date: '12/8/2020',
-      actionText: 'url',
+      actionText: 'Take the Survey',
+      actionURL: 'survey url'
     },
   ],
 };

--- a/tests/NotificationController.test.ts
+++ b/tests/NotificationController.test.ts
@@ -1,75 +1,83 @@
-import { NotificationConfig, NotificationController, NotificationState } from '../dist/notification/NotificationController';
+import {
+  NotificationConfig,
+  NotificationController,
+  NotificationState,
+} from '../dist/notification/NotificationController';
 
 const config1: NotificationConfig = {
-    notificationsFromFile: {
-        whatsnew: [
-            {
-                id: 1,
-                title: 'Now Swao tokens dirsctly in your wallet!',
-                description: 'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
-                date: '12/8/2020',
-                actionText: 'url',
-            },
-            {
-                id: 2,
-                title: 'MetaMask Mobile is here!',
-                description: 'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
-                date: '12/8/2020',
-                actionText: 'url',
-            },
-        ],
-    },
+  notificationsFromFile: {
+    whatsnew: [
+      {
+        id: 1,
+        title: 'Now Swao tokens dirsctly in your wallet!',
+        description:
+          'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
+        date: '12/8/2020',
+        actionText: 'url',
+      },
+      {
+        id: 2,
+        title: 'MetaMask Mobile is here!',
+        description:
+          'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
+        date: '12/8/2020',
+        actionText: 'url',
+      },
+    ],
+  },
 };
 const config2: NotificationConfig = {
-    notificationsFromFile: {
-        whatsnew: [
-            {
-                id: 1,
-                title: 'Now Swao tokens dirsctly in your wallet!',
-                description: 'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
-                date: '12/8/2020',
-                actionText: 'url',
-            },
-            {
-                id: 2,
-                title: 'MetaMask Mobile is here!',
-                description: 'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
-                date: '12/8/2020',
-                actionText: 'url',
-            },
-            {
-                id: 3,
-                title: 'NSS Survey',
-                description: 'Take NSS survey here',
-                date: '12/8/2020',
-                actionText: 'url',
-            },
-        ],
-    },
+  notificationsFromFile: {
+    whatsnew: [
+      {
+        id: 1,
+        title: 'Now Swao tokens dirsctly in your wallet!',
+        description:
+          'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
+        date: '12/8/2020',
+        actionText: 'url',
+      },
+      {
+        id: 2,
+        title: 'MetaMask Mobile is here!',
+        description:
+          'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
+        date: '12/8/2020',
+        actionText: 'url',
+      },
+      {
+        id: 3,
+        title: 'NSS Survey',
+        description: 'Take NSS survey here',
+        date: '12/8/2020',
+        actionText: 'url',
+      },
+    ],
+  },
 };
 
 describe('notification controller', () => {
-    let state: NotificationState;
-    it('should add notifications to state', () => {
-        const controller = new NotificationController(config1);
-        expect(controller.state.notifications).toHaveLength(2);
-        state = controller.state;
+  let state: NotificationState;
+  it('should add notifications to state', () => {
+    const controller = new NotificationController(config1);
+    expect(controller.state.notifications).toHaveLength(2);
+    state = controller.state;
+  });
+  let controller: NotificationController;
+  it('should add new notifcation to state', () => {
+    controller = new NotificationController(config2, state);
+    expect(controller.state.notifications).toHaveLength(3);
+  });
+  describe('update viewed notifications', () => {
+    it('should update isshown status', () => {
+      controller.updateViewed({ 1: true });
+      expect(controller.state.notifications[0].isShown).toBeTruthy();
+      expect(controller.state.notifications[1].isShown).toBeFalsy();
     });
-    let controller: NotificationController;
-    it('should add new notifcation to state', () => {
-        controller = new NotificationController(config2, state);
-        expect(controller.state.notifications).toHaveLength(3);
+    it('should update isshown of more than one notifications', () => {
+      controller.updateViewed({ 2: true, 3: true });
+      expect(controller.state.notifications[1].isShown).toBeTruthy();
+      expect(controller.state.notifications[2].isShown).toBeTruthy();
     });
-    describe('update viewed notifications', () => {
-        it('should update isshown status', () => {
-            controller.updateViewed({ 1: true });
-            expect(controller.state.notifications[0].isShown).toBeTruthy();
-            expect(controller.state.notifications[1].isShown).toBeFalsy();
-        });
-        it('should update isshown of more than one notifications', () => {
-            controller.updateViewed({ 2: true, 3: true });
-            expect(controller.state.notifications[1].isShown).toBeTruthy();
-            expect(controller.state.notifications[2].isShown).toBeTruthy();
-        });
-    });
+  });
 });

--- a/tests/NotificationController.test.ts
+++ b/tests/NotificationController.test.ts
@@ -13,7 +13,7 @@ const config1: NotificationConfig = {
         'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
       date: '12/8/2020',
       actionText: 'Start swapping',
-      actionURL: '/swaps'
+      actionURL: '/swaps',
     },
     {
       id: 2,
@@ -22,7 +22,7 @@ const config1: NotificationConfig = {
         'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
       date: '12/8/2020',
       actionText: 'Get the mobile app',
-      actionURL: 'https://metamask.io/download.html'
+      actionURL: 'https://metamask.io/download.html',
     },
   ],
 };
@@ -36,7 +36,7 @@ const config2: NotificationConfig = {
         'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
       date: '12/8/2020',
       actionText: 'Start swapping',
-      actionURL: '/swaps'
+      actionURL: '/swaps',
     },
     {
       id: 2,
@@ -45,7 +45,7 @@ const config2: NotificationConfig = {
         'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
       date: '12/8/2020',
       actionText: 'Get the mobile app',
-      actionURL: 'https://metamask.io/download.html'
+      actionURL: 'https://metamask.io/download.html',
     },
     {
       id: 3,
@@ -53,7 +53,7 @@ const config2: NotificationConfig = {
       description: 'Take NPS survey here',
       date: '12/8/2020',
       actionText: 'Take the Survey',
-      actionURL: 'survey url'
+      actionURL: 'survey url',
     },
   ],
 };

--- a/tests/NotificationController.test.ts
+++ b/tests/NotificationController.test.ts
@@ -4,9 +4,9 @@ import {
   NotificationState,
 } from '../src/notification/NotificationController';
 
-const swapsHandler = () => console.log('swaps');
-const mobileHandler = () => console.log('mobile');
-const npsHandler = () => console.log('NPS survey');
+const swapsHandler = jest.fn();
+const mobileHandler = jest.fn();
+const npsHandler = jest.fn();
 const config1: NotificationConfig = {
   allNotifications: [
     {
@@ -16,8 +16,10 @@ const config1: NotificationConfig = {
         'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
       date: '12/8/2020',
       image: 'image url',
-      actionText: 'Start swapping',
-      actionFunction: swapsHandler,
+      action: {
+        actionText: 'Start swapping',
+        actionFunction: swapsHandler,
+      },
     },
     {
       id: 2,
@@ -25,8 +27,10 @@ const config1: NotificationConfig = {
       description:
         'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
       date: '12/8/2020',
-      actionText: 'Get the mobile app',
-      actionFunction: mobileHandler,
+      action: {
+        actionText: 'Get the mobile app',
+        actionFunction: mobileHandler,
+      },
     },
   ],
 };
@@ -39,7 +43,6 @@ const config2: NotificationConfig = {
       description:
         'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
       date: '12/8/2020',
-      actionText: 'Start swapping',
     },
     {
       id: 2,
@@ -48,7 +51,6 @@ const config2: NotificationConfig = {
         'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
       date: '12/8/2020',
       image: 'image url',
-      actionText: 'Get the mobile app',
     },
   ],
 };
@@ -62,8 +64,10 @@ const config3: NotificationConfig = {
         'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
       date: '12/8/2020',
       image: 'image url',
-      actionText: 'Start swapping',
-      actionFunction: swapsHandler,
+      action: {
+        actionText: 'Start swapping',
+        actionFunction: swapsHandler,
+      },
     },
     {
       id: 2,
@@ -71,16 +75,20 @@ const config3: NotificationConfig = {
       description:
         'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
       date: '12/8/2020',
-      actionText: 'Get the mobile app',
-      actionFunction: mobileHandler,
+      action: {
+        actionText: 'Get the mobile app',
+        actionFunction: mobileHandler,
+      },
     },
     {
       id: 3,
-      title: 'NPS Survey',
-      description: 'Take NPS survey here',
+      title: 'Help improve MetaMask',
+      description: 'Please shae your experience in this 5 minute survey',
       date: '12/8/2020',
-      actionText: 'Take the Survey',
-      actionFunction: npsHandler,
+      action: {
+        actionText: 'Start Survey',
+        actionFunction: npsHandler,
+      },
     },
   ],
 };
@@ -96,7 +104,7 @@ describe('notification controller', () => {
     try {
       new NotificationController(config2);
     } catch (error) {
-      expect(error.message).toEqual('Must have an actionFunction for an actionText.');
+      expect(error.message).toEqual('Must have an actionText and actionFunction.');
     }
   });
 
@@ -108,10 +116,17 @@ describe('notification controller', () => {
 
   describe('calling the actionFunction', () => {
     it('should return the actionFunction corresponding to the id', () => {
-      expect(controller.actionCall(1)).toEqual(swapsHandler);
-      expect(controller.actionCall(2)).toEqual(mobileHandler);
-      expect(controller.actionCall(3)).toEqual(npsHandler);
-      expect(controller.actionCall(4)).toBeNull();
+      controller.actionCall(1);
+      expect(swapsHandler).toHaveBeenCalled();
+      controller.actionCall(2);
+      expect(mobileHandler).toHaveBeenCalled();
+      controller.actionCall(3);
+      expect(npsHandler).toHaveBeenCalled();
+      try {
+        expect(controller.actionCall(4)).toBeUndefined();
+      } catch (error) {
+        expect(error.message).toEqual('Incomplete notification.');
+      }
     });
   });
   describe('update viewed notifications', () => {

--- a/tests/NotificationController.test.ts
+++ b/tests/NotificationController.test.ts
@@ -9,12 +9,9 @@ const config1: NotificationConfig = {
   allNotifications: {
     1: {
       id: 1,
-      date: '12/8/2020',
-      image: 'image url',
     },
     2: {
       id: 2,
-      date: '12/8/2020',
     },
   },
 };
@@ -23,16 +20,12 @@ const config2: NotificationConfig = {
   allNotifications: {
     1: {
       id: 1,
-      date: '12/8/2020',
-      image: 'image url',
     },
     2: {
       id: 2,
-      date: '12/8/2020',
     },
     3: {
       id: 3,
-      date: '12/8/2020',
     },
   },
 };
@@ -41,13 +34,10 @@ const state1: NotificationState = {
   notifications: {
     1: {
       id: 1,
-      date: '12/8/2020',
-      image: 'image url',
       isShown: true,
     },
     2: {
       id: 2,
-      date: '12/8/2020',
       isShown: true,
     },
   },

--- a/tests/NotificationController.test.ts
+++ b/tests/NotificationController.test.ts
@@ -9,20 +9,12 @@ const config1: NotificationConfig = {
   allNotifications: {
     1: {
       id: 1,
-      title: 'Now Swap tokens directly in your wallet!',
-      description:
-        'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
       date: '12/8/2020',
       image: 'image url',
-      actionText: 'Start swapping',
     },
     2: {
       id: 2,
-      title: 'MetaMask Mobile is here!',
-      description:
-        'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
       date: '12/8/2020',
-      actionText: 'Get the mobile app',
     },
   },
 };
@@ -31,27 +23,16 @@ const config2: NotificationConfig = {
   allNotifications: {
     1: {
       id: 1,
-      title: 'Now Swap tokens directly in your wallet!',
-      description:
-        'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
       date: '12/8/2020',
       image: 'image url',
-      actionText: 'Start swapping',
     },
     2: {
       id: 2,
-      title: 'MetaMask Mobile is here!',
-      description:
-        'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
       date: '12/8/2020',
-      actionText: 'Get the mobile app',
     },
     3: {
       id: 3,
-      title: 'Help improve MetaMask',
-      description: 'Please shae your experience in this 5 minute survey',
       date: '12/8/2020',
-      actionText: 'Start Survey',
     },
   },
 };
@@ -60,21 +41,13 @@ const state1: NotificationState = {
   notifications: {
     1: {
       id: 1,
-      title: 'Now Swap tokens directly in your wallet!',
-      description:
-        'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
       date: '12/8/2020',
       image: 'image url',
-      actionText: 'Start swapping',
       isShown: true,
     },
     2: {
       id: 2,
-      title: 'MetaMask Mobile is here!',
-      description:
-        'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
       date: '12/8/2020',
-      actionText: 'Get the mobile app',
       isShown: true,
     },
   },

--- a/tests/NotificationController.test.ts
+++ b/tests/NotificationController.test.ts
@@ -9,9 +9,11 @@ const config1: NotificationConfig = {
   allNotifications: {
     1: {
       id: 1,
+      date: '12/8/2020',
     },
     2: {
       id: 2,
+      date: '12/8/2020',
     },
   },
 };
@@ -20,12 +22,15 @@ const config2: NotificationConfig = {
   allNotifications: {
     1: {
       id: 1,
+      date: '12/8/2020',
     },
     2: {
       id: 2,
+      date: '12/8/2020',
     },
     3: {
       id: 3,
+      date: '12/8/2020',
     },
   },
 };
@@ -34,10 +39,12 @@ const state1: NotificationState = {
   notifications: {
     1: {
       id: 1,
+      date: '12/8/2020',
       isShown: true,
     },
     2: {
       id: 2,
+      date: '12/8/2020',
       isShown: true,
     },
   },

--- a/tests/NotificationController.test.ts
+++ b/tests/NotificationController.test.ts
@@ -2,82 +2,80 @@ import {
   NotificationConfig,
   NotificationController,
   NotificationState,
-} from '../dist/notification/NotificationController';
+} from '../src/notification/NotificationController';
 
 const config1: NotificationConfig = {
-  notificationsFromFile: {
-    whatsnew: [
-      {
-        id: 1,
-        title: 'Now Swao tokens dirsctly in your wallet!',
-        description:
-          'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
-        date: '12/8/2020',
-        actionText: 'url',
-      },
-      {
-        id: 2,
-        title: 'MetaMask Mobile is here!',
-        description:
-          'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
-        date: '12/8/2020',
-        actionText: 'url',
-      },
-    ],
-  },
+  allNotifications: [
+    {
+      id: 1,
+      title: 'Now Swap tokens directly in your wallet!',
+      description:
+        'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
+      date: '12/8/2020',
+      actionText: 'url',
+    },
+    {
+      id: 2,
+      title: 'MetaMask Mobile is here!',
+      description:
+        'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
+      date: '12/8/2020',
+      actionText: 'url',
+    },
+  ],
 };
+
 const config2: NotificationConfig = {
-  notificationsFromFile: {
-    whatsnew: [
-      {
-        id: 1,
-        title: 'Now Swao tokens dirsctly in your wallet!',
-        description:
-          'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
-        date: '12/8/2020',
-        actionText: 'url',
-      },
-      {
-        id: 2,
-        title: 'MetaMask Mobile is here!',
-        description:
-          'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
-        date: '12/8/2020',
-        actionText: 'url',
-      },
-      {
-        id: 3,
-        title: 'NSS Survey',
-        description: 'Take NSS survey here',
-        date: '12/8/2020',
-        actionText: 'url',
-      },
-    ],
-  },
+  allNotifications: [
+    {
+      id: 1,
+      title: 'Now Swap tokens directly in your wallet!',
+      description:
+        'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
+      date: '12/8/2020',
+      actionText: 'url',
+    },
+    {
+      id: 2,
+      title: 'MetaMask Mobile is here!',
+      description:
+        'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
+      date: '12/8/2020',
+      actionText: 'url',
+    },
+    {
+      id: 3,
+      title: 'NSS Survey',
+      description: 'Take NSS survey here',
+      date: '12/8/2020',
+      actionText: 'url',
+    },
+  ],
 };
 
 describe('notification controller', () => {
   let state: NotificationState;
   it('should add notifications to state', () => {
     const controller = new NotificationController(config1);
-    expect(controller.state.notifications).toHaveLength(2);
+    expect(Object.keys(controller.state.notifications)).toHaveLength(2);
     state = controller.state;
   });
   let controller: NotificationController;
   it('should add new notifcation to state', () => {
     controller = new NotificationController(config2, state);
-    expect(controller.state.notifications).toHaveLength(3);
+    expect(Object.keys(controller.state.notifications)).toHaveLength(3);
   });
+
   describe('update viewed notifications', () => {
     it('should update isshown status', () => {
       controller.updateViewed({ 1: true });
-      expect(controller.state.notifications[0].isShown).toBeTruthy();
-      expect(controller.state.notifications[1].isShown).toBeFalsy();
+      expect(controller.state.notifications[1].isShown).toBeTruthy();
+      expect(controller.state.notifications[2].isShown).toBeFalsy();
     });
     it('should update isshown of more than one notifications', () => {
       controller.updateViewed({ 2: true, 3: true });
-      expect(controller.state.notifications[1].isShown).toBeTruthy();
       expect(controller.state.notifications[2].isShown).toBeTruthy();
+      expect(controller.state.notifications[3].isShown).toBeTruthy();
     });
   });
 });

--- a/tests/NotificationController.test.ts
+++ b/tests/NotificationController.test.ts
@@ -1,0 +1,82 @@
+import { NotificationConfig, NotificationController, NotificationState } from '../dist/notification/NotificationController';
+
+const config1: NotificationConfig = {
+    notificationsFromFile:{
+        whatsnew:[
+            {
+                id: 1,
+                title: 'Now Swao tokens dirsctly in your wallet!',
+                description: 'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
+                date: '12/8/2020',
+                actionText: 'url'
+            },
+            {
+                id: 2,
+                title: 'MetaMask Mobile is here!',
+                description: 'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
+                date: '12/8/2020',
+                actionText: 'url',
+            }
+        ]
+    }
+}
+const config2: NotificationConfig = {
+    notificationsFromFile:{
+        whatsnew:[
+            {
+                id: 1,
+                title: 'Now Swao tokens dirsctly in your wallet!',
+                description: 'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
+                date: '12/8/2020',
+                actionText: 'url'
+            },
+            {
+                id: 2,
+                title: 'MetaMask Mobile is here!',
+                description: 'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
+                date: '12/8/2020',
+                actionText: 'url',
+            },
+            {
+                id: 3,
+                title: 'NSS Survey',
+                description: 'Take NSS survey here',
+                date: '12/8/2020',
+                actionText: 'url',
+            }
+        ]
+    }
+}
+
+describe('notification controller', ()=>{
+    let state: NotificationState;
+    it('should add notifications to state',()=>{
+        const controller = new NotificationController(config1)
+        expect(controller.state.notifications).toHaveLength(2);
+        state = controller.state;
+    })
+    let controller : NotificationController;
+    it('should add new notifcation to state',()=>{
+        controller = new NotificationController(config2, state)
+        expect(controller.state.notifications).toHaveLength(3);
+    })
+    describe('update viewed notifications', ()=>{
+        it('should update isshown status',()=>{
+            controller.updateViewed({1: true});
+            expect(controller.state.notifications[0].isShown).toBeTruthy();
+            expect(controller.state.notifications[1].isShown).toBeFalsy()
+        })
+        it('should update isshown of more than one notifications',()=>{
+            controller.updateViewed({2: true, 3:true});
+            expect(controller.state.notifications[1].isShown).toBeTruthy();
+            expect(controller.state.notifications[2].isShown).toBeTruthy()
+            state = controller.state;
+        })
+    })
+    describe('remove outdated notifications', ()=>{
+        it('should remove outdated notifications from state',()=>{
+            controller = new NotificationController(config1, state)
+            expect(controller.state.notifications).toHaveLength(2);
+        })
+    })
+})

--- a/tests/NotificationController.test.ts
+++ b/tests/NotificationController.test.ts
@@ -1,14 +1,14 @@
 import { NotificationConfig, NotificationController, NotificationState } from '../dist/notification/NotificationController';
 
 const config1: NotificationConfig = {
-    notificationsFromFile:{
-        whatsnew:[
+    notificationsFromFile: {
+        whatsnew: [
             {
                 id: 1,
                 title: 'Now Swao tokens dirsctly in your wallet!',
                 description: 'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
                 date: '12/8/2020',
-                actionText: 'url'
+                actionText: 'url',
             },
             {
                 id: 2,
@@ -16,19 +16,19 @@ const config1: NotificationConfig = {
                 description: 'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
                 date: '12/8/2020',
                 actionText: 'url',
-            }
-        ]
-    }
-}
+            },
+        ],
+    },
+};
 const config2: NotificationConfig = {
-    notificationsFromFile:{
-        whatsnew:[
+    notificationsFromFile: {
+        whatsnew: [
             {
                 id: 1,
                 title: 'Now Swao tokens dirsctly in your wallet!',
                 description: 'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
                 date: '12/8/2020',
-                actionText: 'url'
+                actionText: 'url',
             },
             {
                 id: 2,
@@ -43,40 +43,33 @@ const config2: NotificationConfig = {
                 description: 'Take NSS survey here',
                 date: '12/8/2020',
                 actionText: 'url',
-            }
-        ]
-    }
-}
+            },
+        ],
+    },
+};
 
-describe('notification controller', ()=>{
+describe('notification controller', () => {
     let state: NotificationState;
-    it('should add notifications to state',()=>{
-        const controller = new NotificationController(config1)
+    it('should add notifications to state', () => {
+        const controller = new NotificationController(config1);
         expect(controller.state.notifications).toHaveLength(2);
         state = controller.state;
-    })
-    let controller : NotificationController;
-    it('should add new notifcation to state',()=>{
-        controller = new NotificationController(config2, state)
+    });
+    let controller: NotificationController;
+    it('should add new notifcation to state', () => {
+        controller = new NotificationController(config2, state);
         expect(controller.state.notifications).toHaveLength(3);
-    })
-    describe('update viewed notifications', ()=>{
-        it('should update isshown status',()=>{
-            controller.updateViewed({1: true});
+    });
+    describe('update viewed notifications', () => {
+        it('should update isshown status', () => {
+            controller.updateViewed({ 1: true });
             expect(controller.state.notifications[0].isShown).toBeTruthy();
-            expect(controller.state.notifications[1].isShown).toBeFalsy()
-        })
-        it('should update isshown of more than one notifications',()=>{
-            controller.updateViewed({2: true, 3:true});
+            expect(controller.state.notifications[1].isShown).toBeFalsy();
+        });
+        it('should update isshown of more than one notifications', () => {
+            controller.updateViewed({ 2: true, 3: true });
             expect(controller.state.notifications[1].isShown).toBeTruthy();
-            expect(controller.state.notifications[2].isShown).toBeTruthy()
-            state = controller.state;
-        })
-    })
-    describe('remove outdated notifications', ()=>{
-        it('should remove outdated notifications from state',()=>{
-            controller = new NotificationController(config1, state)
-            expect(controller.state.notifications).toHaveLength(2);
-        })
-    })
-})
+            expect(controller.state.notifications[2].isShown).toBeTruthy();
+        });
+    });
+});


### PR DESCRIPTION
The controller adds the notifications to the state and keeps and updates the status of whether it is seen by the user or not. 
Associated to issue [#23](https://github.com/MetaMask/MetaMask-planning/issues/23)