### PR TITLE
Account tracker improvement

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "eth-sig-util": "^3.0.0",
     "ethereumjs-util": "^6.1.0",
     "ethereumjs-wallet": "^0.6.4",
-    "ethjs-query": "^0.3.8",
     "human-standard-collectible-abi": "^1.0.2",
     "human-standard-token-abi": "^2.0.0",
     "isomorphic-fetch": "^3.0.0",

--- a/src/assets/AccountTrackerController.ts
+++ b/src/assets/AccountTrackerController.ts
@@ -1,6 +1,6 @@
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import PreferencesController from '../user/PreferencesController';
-import { BNToHex, safelyExecuteWithTimeout } from '../util';
+import { BNToHex, query, safelyExecuteWithTimeout } from '../util';
 
 const EthQuery = require('eth-query');
 const { Mutex } = require('await-semaphore');
@@ -65,18 +65,6 @@ export class AccountTrackerController extends BaseController<AccountTrackerConfi
       delete accounts[address];
     });
     this.update({ accounts: { ...accounts } });
-  }
-
-  private query(method: string, args: any[] = []): Promise<any> {
-    return new Promise((resolve, reject) => {
-      this.ethQuery[method](...args, (error: Error, result: any) => {
-        if (error) {
-          reject(error);
-          return;
-        }
-        resolve(result);
-      });
-    });
   }
 
   /**
@@ -148,7 +136,7 @@ export class AccountTrackerController extends BaseController<AccountTrackerConfi
     const { accounts } = this.state;
     for (const address in accounts) {
       await safelyExecuteWithTimeout(async () => {
-        const balance = await this.query('getBalance', [address]);
+        const balance = await query(this.ethQuery, 'getBalance', [address]);
         accounts[address] = { balance: BNToHex(balance) };
         this.update({ accounts: { ...accounts } });
       });

--- a/src/assets/AccountTrackerController.ts
+++ b/src/assets/AccountTrackerController.ts
@@ -1,8 +1,9 @@
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import PreferencesController from '../user/PreferencesController';
-import { BNToHex, safelyExecute } from '../util';
+import { BNToHex, safelyExecuteWithTimeout } from '../util';
 
-const EthjsQuery = require('ethjs-query');
+const EthQuery = require('eth-query');
+const { Mutex } = require('await-semaphore');
 
 /**
  * @type AccountInformation
@@ -42,7 +43,9 @@ export interface AccountTrackerState extends BaseState {
  * Controller that tracks information for all accounts in the current keychain
  */
 export class AccountTrackerController extends BaseController<AccountTrackerConfig, AccountTrackerState> {
-  private ethjsQuery: any;
+  private ethQuery: any;
+
+  private mutex = new Mutex();
 
   private handle?: NodeJS.Timer;
 
@@ -62,6 +65,18 @@ export class AccountTrackerController extends BaseController<AccountTrackerConfi
       delete accounts[address];
     });
     this.update({ accounts: { ...accounts } });
+  }
+
+  private query(method: string, args: any[] = []): Promise<any> {
+    return new Promise((resolve, reject) => {
+      this.ethQuery[method](...args, (error: Error, result: any) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(result);
+      });
+    });
   }
 
   /**
@@ -95,7 +110,7 @@ export class AccountTrackerController extends BaseController<AccountTrackerConfi
    * @param provider - Provider used to create a new underlying EthQuery instance
    */
   set provider(provider: any) {
-    this.ethjsQuery = new EthjsQuery(provider);
+    this.ethQuery = new EthQuery(provider);
   }
 
   /**
@@ -115,10 +130,12 @@ export class AccountTrackerController extends BaseController<AccountTrackerConfi
    * @param interval - Polling interval trigger a 'refresh'
    */
   async poll(interval?: number): Promise<void> {
+    const releaseLock = await this.mutex.acquire();
     interval && this.configure({ interval }, false, false);
     this.handle && clearTimeout(this.handle);
-    await safelyExecute(() => this.refresh());
+    await this.refresh();
     this.handle = setTimeout(() => {
+      releaseLock();
       this.poll(this.config.interval);
     }, this.config.interval);
   }
@@ -130,8 +147,8 @@ export class AccountTrackerController extends BaseController<AccountTrackerConfi
     this.syncAccounts();
     const { accounts } = this.state;
     for (const address in accounts) {
-      await safelyExecute(async () => {
-        const balance = await this.ethjsQuery.getBalance(address);
+      await safelyExecuteWithTimeout(async () => {
+        const balance = await this.query('getBalance', [address]);
         accounts[address] = { balance: BNToHex(balance) };
         this.update({ accounts: { ...accounts } });
       });

--- a/src/util.ts
+++ b/src/util.ts
@@ -216,6 +216,34 @@ export async function safelyExecute(operation: () => Promise<any>, logError = fa
 }
 
 /**
+ * Execute and return an asynchronous operation with a timeout
+ *
+ * @param operation - Function returning a Promise
+ * @param logError - Determines if the error should be logged
+ * @param retry - Function called if an error is caught
+ * @param timeout - Timeout to fail the operation
+ * @returns - Promise resolving to the result of the async operation
+ */
+export async function safelyExecuteWithTimeout(operation: () => Promise<any>, logError = false, timeout = 500, retry?: (error: Error) => void) {
+  try {
+    return await Promise.race([
+      operation(),
+      new Promise<void>((_, reject) =>
+        setTimeout(() => {
+          reject(new Error('timeout'));
+        }, timeout),
+      ),
+    ]);
+  } catch (error) {
+    /* istanbul ignore next */
+    if (logError) {
+      console.error(error);
+    }
+    retry && retry(error);
+  }
+}
+
+/**
  * Validates a Transaction object for required properties and throws in
  * the event of any validation error.
  *
@@ -455,6 +483,7 @@ export default {
   isSmartContractCode,
   normalizeTransaction,
   safelyExecute,
+  safelyExecuteWithTimeout,
   successfulFetch,
   timeoutFetch,
   validateTokenToWatch,

--- a/src/util.ts
+++ b/src/util.ts
@@ -228,7 +228,6 @@ export async function safelyExecuteWithTimeout(
   operation: () => Promise<any>,
   logError = false,
   timeout = 500,
-  retry?: (error: Error) => void,
 ) {
   try {
     return await Promise.race([
@@ -244,8 +243,6 @@ export async function safelyExecuteWithTimeout(
     if (logError) {
       console.error(error);
     }
-    /* istanbul ignore next */
-    retry && retry(error);
   }
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -224,11 +224,7 @@ export async function safelyExecute(operation: () => Promise<any>, logError = fa
  * @param timeout - Timeout to fail the operation
  * @returns - Promise resolving to the result of the async operation
  */
-export async function safelyExecuteWithTimeout(
-  operation: () => Promise<any>,
-  logError = false,
-  timeout = 500,
-) {
+export async function safelyExecuteWithTimeout(operation: () => Promise<any>, logError = false, timeout = 500) {
   try {
     return await Promise.race([
       operation(),

--- a/src/util.ts
+++ b/src/util.ts
@@ -473,9 +473,31 @@ export function normalizeEnsName(ensName: string): string | null {
   return null;
 }
 
+/**
+ * Wrapper method to handle EthQuery requests
+ *
+ * @param ethQuery - EthQuery object initialized with a provider
+ * @param method - Method to request
+ * @param args - Arguments to send
+ *
+ * @returns - Promise resolving the request
+ */
+export function query(ethQuery: any, method: string, args: any[] = []): Promise<any> {
+  return new Promise((resolve, reject) => {
+    ethQuery[method](...args, (error: Error, result: any) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(result);
+    });
+  });
+}
+
 export default {
   BNToHex,
   fractionBN,
+  query,
   getBuyURL,
   handleFetch,
   hexToBN,

--- a/src/util.ts
+++ b/src/util.ts
@@ -224,7 +224,12 @@ export async function safelyExecute(operation: () => Promise<any>, logError = fa
  * @param timeout - Timeout to fail the operation
  * @returns - Promise resolving to the result of the async operation
  */
-export async function safelyExecuteWithTimeout(operation: () => Promise<any>, logError = false, timeout = 500, retry?: (error: Error) => void) {
+export async function safelyExecuteWithTimeout(
+  operation: () => Promise<any>,
+  logError = false,
+  timeout = 500,
+  retry?: (error: Error) => void,
+) {
   try {
     return await Promise.race([
       operation(),

--- a/src/util.ts
+++ b/src/util.ts
@@ -239,6 +239,7 @@ export async function safelyExecuteWithTimeout(operation: () => Promise<any>, lo
     if (logError) {
       console.error(error);
     }
+    /* istanbul ignore next */
     retry && retry(error);
   }
 }

--- a/tests/TransactionController.test.ts
+++ b/tests/TransactionController.test.ts
@@ -12,7 +12,6 @@ jest.mock('eth-query', () =>
   jest.fn().mockImplementation(() => {
     return {
       estimateGas: (_transaction: any, callback: any) => {
-        console.log('MOCK', callback);
         if (mockFlags.estimateGas) {
           callback(new Error(mockFlags.estimateGas));
           return;

--- a/tests/TransactionController.test.ts
+++ b/tests/TransactionController.test.ts
@@ -12,6 +12,7 @@ jest.mock('eth-query', () =>
   jest.fn().mockImplementation(() => {
     return {
       estimateGas: (_transaction: any, callback: any) => {
+        console.log('MOCK', callback);
         if (mockFlags.estimateGas) {
           callback(new Error(mockFlags.estimateGas));
           return;

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -127,10 +127,10 @@ describe('util', () => {
     });
 
     it('should resolve', async () => {
-        const response = await util.safelyExecuteWithTimeout(() => {
-          return new Promise((res) => setTimeout(() => res('response'), 200));
-        });
-        expect(response).toEqual('response');
+      const response = await util.safelyExecuteWithTimeout(() => {
+        return new Promise((res) => setTimeout(() => res('response'), 200));
+      });
+      expect(response).toEqual('response');
     });
 
     it('should timeout', () => {

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -629,7 +629,7 @@ describe('util', () => {
       const ethQuery = new EthQuery(PROVIDER);
       mockFlags.gasPrice = 'Uh oh';
       try {
-         await util.query(ethQuery, 'gasPrice', []);
+        await util.query(ethQuery, 'gasPrice', []);
       } catch (error) {
         expect(error.message).toContain('Uh oh');
       }

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -119,6 +119,31 @@ describe('util', () => {
     });
   });
 
+  describe('safelyExecuteWithTimeout', () => {
+    it('should swallow errors', async () => {
+      await util.safelyExecuteWithTimeout(() => {
+        throw new Error('ahh');
+      });
+    });
+
+    it('should resolve', async () => {
+        const response = await util.safelyExecuteWithTimeout(() => {
+          return new Promise((res) => setTimeout(() => res('response'), 200));
+        });
+        expect(response).toEqual('response');
+    });
+
+    it('should timeout', () => {
+      try {
+        util.safelyExecuteWithTimeout(() => {
+          return new Promise((res) => setTimeout(res, 800));
+        });
+      } catch (e) {
+        expect(e.message).toContain('timeout');
+      }
+    });
+  });
+
   describe('validateTransaction', () => {
     it('should throw if no from address', () => {
       expect(() => util.validateTransaction({} as any)).toThrow();

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -7,6 +7,46 @@ const { BN } = require('ethereumjs-util');
 
 const SOME_API = 'https://someapi.com';
 const SOME_FAILING_API = 'https://somefailingapi.com';
+const HttpProvider = require('ethjs-provider-http');
+const EthQuery = require('eth-query');
+
+const mockFlags: { [key: string]: any } = {
+  estimateGas: null,
+  gasPrice: null,
+};
+const PROVIDER = new HttpProvider('https://ropsten.infura.io/v3/341eacb578dd44a1a049cbc5f6fd4035');
+
+jest.mock('eth-query', () =>
+  jest.fn().mockImplementation(() => {
+    return {
+      estimateGas: (_transaction: any, callback: any) => {
+        callback(undefined, '0x0');
+      },
+      gasPrice: (callback: any) => {
+        if (mockFlags.gasPrice) {
+          callback(new Error(mockFlags.gasPrice));
+          return;
+        }
+        callback(undefined, '0x0');
+      },
+      getBlockByNumber: (_blocknumber: any, _fetchTxs: boolean, callback: any) => {
+        callback(undefined, { gasLimit: '0x0' });
+      },
+      getCode: (_to: any, callback: any) => {
+        callback(undefined, '0x0');
+      },
+      getTransactionByHash: (_hash: any, callback: any) => {
+        callback(undefined, { blockNumber: '0x1' });
+      },
+      getTransactionCount: (_from: any, _to: any, callback: any) => {
+        callback(undefined, '0x0');
+      },
+      sendRawTransaction: (_transaction: any, callback: any) => {
+        callback(undefined, '1337');
+      },
+    };
+  }),
+);
 
 describe('util', () => {
   beforeEach(() => {
@@ -575,6 +615,24 @@ describe('util', () => {
     it('should return null with empty string', async () => {
       const invalid = util.normalizeEnsName('');
       expect(invalid).toBeNull();
+    });
+  });
+
+  describe('query', () => {
+    it('should query and resolve', async () => {
+      const ethQuery = new EthQuery(PROVIDER);
+      const gasPrice = await util.query(ethQuery, 'gasPrice', []);
+      expect(gasPrice).toEqual('0x0');
+    });
+
+    it('should query and reject if error', async () => {
+      const ethQuery = new EthQuery(PROVIDER);
+      mockFlags.gasPrice = 'Uh oh';
+      try {
+         await util.query(ethQuery, 'gasPrice', []);
+      } catch (error) {
+        expect(error.message).toContain('Uh oh');
+      }
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2808,16 +2808,6 @@ ethjs-query@0.3.7:
     ethjs-rpc "0.2.0"
     promise-to-callback "^1.0.0"
 
-ethjs-query@^0.3.8:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/ethjs-query/-/ethjs-query-0.3.8.tgz#aa5af02887bdd5f3c78b3256d0f22ffd5d357490"
-  integrity sha512-/J5JydqrOzU8O7VBOwZKUWXxHDGr46VqNjBCJgBVNNda+tv7Xc8Y2uJc6aMHHVbeN3YOQ7YRElgIc0q1CI02lQ==
-  dependencies:
-    babel-runtime "^6.26.0"
-    ethjs-format "0.2.7"
-    ethjs-rpc "0.2.0"
-    promise-to-callback "^1.0.0"
-
 ethjs-rpc@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/ethjs-rpc/-/ethjs-rpc-0.2.0.tgz#3d0011e32cfff156ed6147818c6fb8f801701b4c"


### PR DESCRIPTION
There were 2 issues on the `AccountTrackerController`

1. For some reason we were using `ethjs-query` only on this controller, I moved to `eth-query` since it was used for other controllers, including the extension's controllers
2. We were seeing some cases where `getBalance` calls were stuck, making the polling process of this controller a heavy process. If the `getBalance` call was stuck, the controller never dropped it and since that process is every 500ms, made the mobile app behave poorly, specially on android. Now if the response doesn't get in time, the `getBalance` call will be dismissed and it will continue to the next poll iteration using `safelyExecuteWithTimeout`.

There's also a new util `query` that was on the `TransactionController` but now is used in `AccountTrackerController` too, so I made it one.