### PR TITLE
Replace `await-semaphore` with `async-mutex`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@metamask/contract-metadata": "^1.22.0",
-    "await-semaphore": "^0.1.3",
+    "async-mutex": "^0.2.6",
     "eth-ens-namehash": "^2.0.8",
     "eth-json-rpc-infura": "^5.1.0",
     "eth-keyring-controller": "^6.1.0",

--- a/src/assets/AccountTrackerController.ts
+++ b/src/assets/AccountTrackerController.ts
@@ -3,7 +3,7 @@ import PreferencesController from '../user/PreferencesController';
 import { BNToHex, query, safelyExecuteWithTimeout } from '../util';
 
 const EthQuery = require('eth-query');
-const { Mutex } = require('await-semaphore');
+const { Mutex } = require('async-mutex');
 
 /**
  * @type AccountInformation

--- a/src/assets/AssetsController.ts
+++ b/src/assets/AssetsController.ts
@@ -8,7 +8,7 @@ import { Token } from './TokenRatesController';
 import { AssetsContractController } from './AssetsContractController';
 import { ApiCollectibleResponse } from './AssetsDetectionController';
 
-const { Mutex } = require('await-semaphore');
+const { Mutex } = require('async-mutex');
 const random = require('uuid/v1');
 
 /**

--- a/src/assets/CurrencyRateController.ts
+++ b/src/assets/CurrencyRateController.ts
@@ -1,7 +1,7 @@
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import { safelyExecute, handleFetch } from '../util';
 
-const { Mutex } = require('await-semaphore');
+const { Mutex } = require('async-mutex');
 
 /**
  * @type CurrencyRateConfig

--- a/src/keyring/KeyringController.ts
+++ b/src/keyring/KeyringController.ts
@@ -12,7 +12,7 @@ import { PersonalMessageParams } from '../message-manager/PersonalMessageManager
 import { TypedMessageParams } from '../message-manager/TypedMessageManager';
 
 const Keyring = require('eth-keyring-controller');
-const { Mutex } = require('await-semaphore');
+const { Mutex } = require('async-mutex');
 const Wallet = require('ethereumjs-wallet');
 const ethUtil = require('ethereumjs-util');
 const importers = require('ethereumjs-wallet/thirdparty');

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -4,7 +4,7 @@ const EthQuery = require('eth-query');
 const Subprovider = require('web3-provider-engine/subproviders/provider.js');
 const createInfuraProvider = require('eth-json-rpc-infura/src/createProvider');
 const createMetamaskProvider = require('web3-provider-engine//zero.js');
-const { Mutex } = require('await-semaphore');
+const { Mutex } = require('async-mutex');
 
 /**
  * Human-readable network name

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -21,7 +21,7 @@ const EthQuery = require('eth-query');
 const Transaction = require('ethereumjs-tx');
 const random = require('uuid/v1');
 const { BN } = require('ethereumjs-util');
-const { Mutex } = require('await-semaphore');
+const { Mutex } = require('async-mutex');
 
 /**
  * @type Result

--- a/yarn.lock
+++ b/yarn.lock
@@ -1268,11 +1268,6 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-await-semaphore@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/await-semaphore/-/await-semaphore-0.1.3.tgz#2b88018cc8c28e06167ae1cdff02504f1f9688d3"
-  integrity sha512-d1W2aNSYcz/sxYO4pMGX9vq65qOTu0P800epMud+6cYYX0QcT7zyqcxec3VWzpgvdXo57UWmVbZpLMjX2m1I7Q==
-
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"


### PR DESCRIPTION
We've had issues with `await-semaphore` causing TypeScript errors due to mistakes in how it is packaged. It generally seems to be abandoned.

`async-mutex` is more actively maintained, has better documentation and test coverage, and is API-compatible for our usage.