### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "@metamask/*"
+    versioning-strategy: "increase"


### PR DESCRIPTION
This config will direct Dependabot to update the minimum version of any internal dependencies to match the latest publish version.

Since this is a library, there's no particular need for us to update our dependencies when new versions are released that are within the current range. However, it is still convenient. We often want to require updates because they bring in bug fixes or other improvements, and this makes updating lockfiles in each product easier (as Yarn will keep the old version of the library in the lockfile if it can, which requires manual intervention to prevent).