### PR TITLE
Add `docs` to list of ignored eslint patterns

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     '!jest.config.js',
     'node_modules',
     'dist',
+    'docs',
     'coverage',
     '*.d.ts',
   ],


### PR DESCRIPTION
The `docs` directory includes auto-generated JavaScript that does not follow our lint rules.