### PR TITLE
Update `uuid` from `v3.3.3` to `v8.3.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "jsonschema": "^1.2.4",
     "nanoid": "^3.1.12",
     "single-call-balance-checker-abi": "^1.0.0",
-    "uuid": "^3.3.2",
+    "uuid": "^8.3.2",
     "web3": "^0.20.7",
     "web3-provider-engine": "^16.0.1"
   },

--- a/src/assets/AssetsController.ts
+++ b/src/assets/AssetsController.ts
@@ -9,7 +9,7 @@ import { AssetsContractController } from './AssetsContractController';
 import { ApiCollectibleResponse } from './AssetsDetectionController';
 
 const { Mutex } = require('async-mutex');
-const random = require('uuid/v1');
+const random = require('uuid').v1;
 
 /**
  * @type Collectible

--- a/src/message-manager/MessageManager.ts
+++ b/src/message-manager/MessageManager.ts
@@ -6,7 +6,7 @@ import AbstractMessageManager, {
   OriginalRequest,
 } from './AbstractMessageManager';
 
-const random = require('uuid/v1');
+const random = require('uuid').v1;
 
 /**
  * @type Message

--- a/src/message-manager/PersonalMessageManager.ts
+++ b/src/message-manager/PersonalMessageManager.ts
@@ -6,7 +6,7 @@ import AbstractMessageManager, {
   OriginalRequest,
 } from './AbstractMessageManager';
 
-const random = require('uuid/v1');
+const random = require('uuid').v1;
 
 /**
  * @type Message

--- a/src/message-manager/TypedMessageManager.ts
+++ b/src/message-manager/TypedMessageManager.ts
@@ -6,7 +6,7 @@ import AbstractMessageManager, {
   OriginalRequest,
 } from './AbstractMessageManager';
 
-const random = require('uuid/v1');
+const random = require('uuid').v1;
 
 /**
  * @type TypedMessage

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -19,7 +19,7 @@ import {
 const MethodRegistry = require('eth-method-registry');
 const EthQuery = require('eth-query');
 const Transaction = require('ethereumjs-tx');
-const random = require('uuid/v1');
+const random = require('uuid').v1;
 const { BN } = require('ethereumjs-util');
 const { Mutex } = require('async-mutex');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7124,7 +7124,7 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
-uuid@^8.3.0:
+uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
This update includes changes to the package export. The various different versions of `uuid` that used to be provided by path are now named exports, and the default export has been removed.

Our imports have been updated to use the new named export, [as per the migration guide](https://github.com/uuidjs/uuid#upgrading-from-uuid3x).