### PR TITLE
Fix `tsconfig.json` indentation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,22 @@
 {
-	"compilerOptions": {
-		"declaration": true,
-		"declarationDir": "dist",
-		"experimentalDecorators": true,
-		"importHelpers": false,
-		"module": "commonjs",
-		"moduleResolution": "node",
-		"noImplicitAny": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"outDir": "dist",
-		"removeComments": false,
-		"sourceMap": true,
-		"inlineSources": true,
-		"strict": true,
-		"target": "es6"
-	},
-	"include": [
-		"./src/**/*.ts"
-	]
+  "compilerOptions": {
+    "declaration": true,
+    "declarationDir": "dist",
+    "experimentalDecorators": true,
+    "importHelpers": false,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "outDir": "dist",
+    "removeComments": false,
+    "sourceMap": true,
+    "inlineSources": true,
+    "strict": true,
+    "target": "es6"
+  },
+  "include": [
+    "./src/**/*.ts"
+  ]
 }


### PR DESCRIPTION
This file was the only one in the repo to use tabs for indentation. It has been updated to use spaces.