### PR TITLE
Prevent `ApprovalController` counting mismatch

### DIFF
--- a/src/approval/ApprovalController.ts
+++ b/src/approval/ApprovalController.ts
@@ -395,12 +395,14 @@ export class ApprovalController extends BaseController<ApprovalConfig, ApprovalS
       approval.requestData = requestData;
     }
 
+    const approvals = {
+      ...this.state[APPROVALS_STORE_KEY],
+      [id]: approval,
+    };
+
     this.update({
-      [APPROVALS_STORE_KEY]: {
-        ...this.state[APPROVALS_STORE_KEY],
-        [id]: approval,
-      },
-      [APPROVAL_COUNT_STORE_KEY]: this.state[APPROVAL_COUNT_STORE_KEY] + 1,
+      [APPROVALS_STORE_KEY]: approvals,
+      [APPROVAL_COUNT_STORE_KEY]: Object.keys(approvals).length,
     }, true);
   }
 
@@ -427,7 +429,7 @@ export class ApprovalController extends BaseController<ApprovalConfig, ApprovalS
     delete newApprovals[id];
     this.update({
       [APPROVALS_STORE_KEY]: newApprovals,
-      [APPROVAL_COUNT_STORE_KEY]: this.state[APPROVAL_COUNT_STORE_KEY] - 1,
+      [APPROVAL_COUNT_STORE_KEY]: Object.keys(newApprovals).length,
     }, true);
   }
 


### PR DESCRIPTION
The `ApprovalController` was not great at counting. If you tried to delete an approval that didn't exist, or if you tried to add an approval that already existed, it would miscount the current number of pending approvals.

Validation was in place already to prevent both scenarios, so in practice this shouldn't be possible without calling private functions. But still, preventing it entirely was trivial, so here it is.