### PR TITLE
Add BaseControllerV2 state metadata

### DIFF
--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -219,6 +219,67 @@ describe('getAnonymizedState', () => {
 
     expect(anonymizedState).toEqual({ transactionHash: '4321x0' });
   });
+
+  it('should allow returning a partial object from an anonymizing function', () => {
+    const anonymizeTransactionHash = (txMeta: { hash: string; value: number }) => {
+      return { value: txMeta.value };
+    };
+
+    const anonymizedState = getAnonymizedState(
+      {
+        txMeta: {
+          hash: '0x123',
+          value: 10,
+        },
+      },
+      {
+        txMeta: {
+          anonymous: anonymizeTransactionHash,
+          persist: false,
+        },
+      },
+    );
+
+    expect(anonymizedState).toEqual({ txMeta: { value: 10 } });
+  });
+
+  it('should allow returning a ntested partial object from an anonymizing function', () => {
+    const anonymizeTransactionHash = (txMeta: {
+      hash: string;
+      value: number;
+      history: { hash: string; value: number }[];
+    }) => {
+      return {
+        history: txMeta.history.map((entry) => {
+          return { value: entry.value };
+        }),
+        value: txMeta.value,
+      };
+    };
+
+    const anonymizedState = getAnonymizedState(
+      {
+        txMeta: {
+          hash: '0x123',
+          history: [
+            {
+              hash: '0x123',
+              value: 9,
+            },
+          ],
+          value: 10,
+        },
+      },
+      {
+        txMeta: {
+          anonymous: anonymizeTransactionHash,
+          persist: false,
+        },
+      },
+    );
+
+    expect(anonymizedState).toEqual({ txMeta: { history: [{ value: 9 }], value: 10 } });
+  });
 });
 
 describe('getPersistentState', () => {

--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -243,7 +243,7 @@ describe('getAnonymizedState', () => {
     expect(anonymizedState).toEqual({ txMeta: { value: 10 } });
   });
 
-  it('should allow returning a ntested partial object from an anonymizing function', () => {
+  it('should allow returning a nested partial object from an anonymizing function', () => {
     const anonymizeTransactionHash = (txMeta: {
       hash: string;
       value: number;

--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -7,7 +7,7 @@ type MockControllerState = {
   count: number;
 };
 
-const mockControllerSchema = {
+const mockControllerStateMetadata = {
   count: {
     persist: true,
     anonymous: true,
@@ -26,19 +26,19 @@ class MockController extends BaseController<MockControllerState> {
 
 describe('BaseController', () => {
   it('should set initial state', () => {
-    const controller = new MockController({ count: 0 }, mockControllerSchema);
+    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
 
     expect(controller.state).toEqual({ count: 0 });
   });
 
   it('should set initial schema', () => {
-    const controller = new MockController({ count: 0 }, mockControllerSchema);
+    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
 
-    expect(controller.schema).toEqual(mockControllerSchema);
+    expect(controller.metadata).toEqual(mockControllerStateMetadata);
   });
 
   it('should not allow mutating state directly', () => {
-    const controller = new MockController({ count: 0 }, mockControllerSchema);
+    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
 
     expect(() => {
       controller.state = { count: 1 };
@@ -46,7 +46,7 @@ describe('BaseController', () => {
   });
 
   it('should allow updating state by modifying draft', () => {
-    const controller = new MockController({ count: 0 }, mockControllerSchema);
+    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
 
     controller.update((draft) => {
       draft.count += 1;
@@ -56,7 +56,7 @@ describe('BaseController', () => {
   });
 
   it('should allow updating state by return a value', () => {
-    const controller = new MockController({ count: 0 }, mockControllerSchema);
+    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
 
     controller.update(() => {
       return { count: 1 };
@@ -66,7 +66,7 @@ describe('BaseController', () => {
   });
 
   it('should throw an error if update callback modifies draft and returns value', () => {
-    const controller = new MockController({ count: 0 }, mockControllerSchema);
+    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
 
     expect(() => {
       controller.update((draft) => {
@@ -77,7 +77,7 @@ describe('BaseController', () => {
   });
 
   it('should inform subscribers of state changes', () => {
-    const controller = new MockController({ count: 0 }, mockControllerSchema);
+    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
     const listener1 = sinon.stub();
     const listener2 = sinon.stub();
 
@@ -94,7 +94,7 @@ describe('BaseController', () => {
   });
 
   it('should inform a subscriber of each state change once even after multiple subscriptions', () => {
-    const controller = new MockController({ count: 0 }, mockControllerSchema);
+    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
     const listener1 = sinon.stub();
 
     controller.subscribe(listener1);
@@ -108,7 +108,7 @@ describe('BaseController', () => {
   });
 
   it('should no longer inform a subscriber about state changes after unsubscribing', () => {
-    const controller = new MockController({ count: 0 }, mockControllerSchema);
+    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
     const listener1 = sinon.stub();
 
     controller.subscribe(listener1);
@@ -121,7 +121,7 @@ describe('BaseController', () => {
   });
 
   it('should no longer inform a subscriber about state changes after unsubscribing once, even if they subscribed many times', () => {
-    const controller = new MockController({ count: 0 }, mockControllerSchema);
+    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
     const listener1 = sinon.stub();
 
     controller.subscribe(listener1);
@@ -135,7 +135,7 @@ describe('BaseController', () => {
   });
 
   it('should allow unsubscribing listeners who were never subscribed', () => {
-    const controller = new MockController({ count: 0 }, mockControllerSchema);
+    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
     const listener1 = sinon.stub();
 
     expect(() => {
@@ -144,7 +144,7 @@ describe('BaseController', () => {
   });
 
   it('should no longer update subscribers after being destroyed', () => {
-    const controller = new MockController({ count: 0 }, mockControllerSchema);
+    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
     const listener1 = sinon.stub();
     const listener2 = sinon.stub();
 

--- a/src/BaseControllerV2.ts
+++ b/src/BaseControllerV2.ts
@@ -63,9 +63,9 @@ export type StateMetadata<T> = {
  *   identifiable), or is set to a function that returns an anonymized
  *   representation of this state.
  */
-export interface StatePropertyMetadata<P> {
+export interface StatePropertyMetadata<T> {
   persist: boolean;
-  anonymous: boolean | Anonymizer<P>;
+  anonymous: boolean | Anonymizer<T>;
 }
 
 /**

--- a/src/BaseControllerV2.ts
+++ b/src/BaseControllerV2.ts
@@ -11,6 +11,15 @@ enablePatches();
  */
 export type Listener<T> = (state: T, patches: Patch[]) => void;
 
+export type Anonymizer<T> = (value: T) => T;
+
+export type Schema<T> = {
+  [P in keyof T]: {
+    persist: boolean;
+    anonymous: boolean | Anonymizer<T[P]>;
+  };
+};
+
 /**
  * Controller class that provides state management and subscriptions
  */
@@ -19,13 +28,18 @@ export class BaseController<S extends Record<string, unknown>> {
 
   private internalListeners: Set<Listener<S>> = new Set();
 
+  public readonly schema: Schema<S>;
+
   /**
    * Creates a BaseController instance.
    *
    * @param state - Initial controller state
+   * @param schema - State schema, describing how to "anonymize" the state,
+   *   and which parts should be persisted.
    */
-  constructor(state: S) {
+  constructor(state: S, schema: Schema<S>) {
     this.internalState = state;
+    this.schema = schema;
   }
 
   /**
@@ -88,4 +102,32 @@ export class BaseController<S extends Record<string, unknown>> {
   protected destroy() {
     this.internalListeners.clear();
   }
+}
+
+// This function acts as a type guard. Using a `typeof` conditional didn't seem to work.
+function isAnonymizingFunction<T>(x: boolean | Anonymizer<T>): x is Anonymizer<T> {
+  return typeof x === 'function';
+}
+
+export function getAnonymizedState<S extends Record<string, any>>(state: S, schema: Schema<S>) {
+  return Object.keys(state).reduce((anonymizedState, _key) => {
+    const key: keyof S = _key; // https://stackoverflow.com/questions/63893394/string-cannot-be-used-to-index-type-t
+    const schemaValue = schema[key].anonymous;
+    if (isAnonymizingFunction(schemaValue)) {
+      anonymizedState[key] = schemaValue(state[key]);
+    } else if (schemaValue) {
+      anonymizedState[key] = state[key];
+    }
+    return anonymizedState;
+  }, {} as Partial<S>);
+}
+
+export function getPersistentState<S extends Record<string, any>>(state: S, schema: Schema<S>) {
+  return Object.keys(state).reduce((persistedState, _key) => {
+    const key: keyof S = _key; // https://stackoverflow.com/questions/63893394/string-cannot-be-used-to-index-type-t
+    if (schema[key].persist) {
+      persistedState[key] = state[key];
+    }
+    return persistedState;
+  }, {} as Partial<S>);
 }

--- a/src/BaseControllerV2.ts
+++ b/src/BaseControllerV2.ts
@@ -191,15 +191,12 @@ export function getAnonymizedState<S extends Record<string, any>>(
  * @param metadata - The controller state metadata, which describes which pieces of state should be persisted
  * @returns The subset of controller state that should be persisted
  */
-export function getPersistentState<S extends Record<string, any>>(
-  state: S,
-  metadata: StateMetadata<S>,
-): RecursivePartial<S> {
+export function getPersistentState<S extends Record<string, any>>(state: S, metadata: StateMetadata<S>): Partial<S> {
   return Object.keys(state).reduce((persistedState, _key) => {
     const key: keyof S = _key; // https://stackoverflow.com/questions/63893394/string-cannot-be-used-to-index-type-t
     if (metadata[key].persist) {
       persistedState[key] = state[key];
     }
     return persistedState;
-  }, {} as RecursivePartial<S>);
+  }, {} as Partial<S>);
 }

--- a/src/BaseControllerV2.ts
+++ b/src/BaseControllerV2.ts
@@ -27,7 +27,7 @@ type RecursivePartial<T> = {
     ? RecursivePartial<U>[]
     : T[P] extends Primitive
     ? T[P]
-    : RecursivePartial<T>;
+    : RecursivePartial<T[P]>;
 };
 
 /**


### PR DESCRIPTION
State metadata has been added to the new BaseController class as a required constructor parameter. The state metadata describes which pieces of state should be persisted, and how to get an 'anonymized' snapshot of the controller state.

This is part of the controller redesign (#337).