### PR TITLE
Use `unknown` rather than `any` for BaseController state

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,9 @@ module.exports = {
     'no-shadow': 'off',
     '@typescript-eslint/no-shadow': 'error',
     '@typescript-eslint/indent': 'off',
+    // disabled due to incompatibility with Record<string, unknown>
+    // See https://github.com/Microsoft/TypeScript/issues/15300#issuecomment-702872440
+    '@typescript-eslint/consistent-type-definitions': 'off',
 
     // TODO re-enable most of these rules
     '@typescript-eslint/no-non-null-assertion': 'off',

--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -3,9 +3,9 @@ import * as sinon from 'sinon';
 
 import { BaseController } from './BaseControllerV2';
 
-interface MockControllerState {
+type MockControllerState = {
   count: number;
-}
+};
 
 class MockController extends BaseController<MockControllerState> {
   update(callback: (state: Draft<MockControllerState>) => void | MockControllerState) {

--- a/src/BaseControllerV2.ts
+++ b/src/BaseControllerV2.ts
@@ -14,7 +14,7 @@ export type Listener<T> = (state: T, patches: Patch[]) => void;
 /**
  * Controller class that provides state management and subscriptions
  */
-export class BaseController<S extends Record<string, any>> {
+export class BaseController<S extends Record<string, unknown>> {
   private internalState: S;
 
   private internalListeners: Set<Listener<S>> = new Set();


### PR DESCRIPTION
The BaseController state now uses `unknown` rather than `any` as the type for state properties. `unknown` is more type-safe than `any` in cases like this where we don't know what type to expect. [See here for details](https://github.com/Microsoft/TypeScript/pull/24439).

This was suggested by @rekmarks during review of #362: ([comment](https://github.com/MetaMask/controllers/pull/362#discussion_r581338608))

The mock controller state in the base controller tests now uses a type alias for the controller state rather than an interface. This was required to get around [an incompatibility between `Record<string, unknown>` and interfaces](https://github.com/Microsoft/TypeScript/issues/15300#issuecomment-702872440).

The `@typescript-eslint/consistent-type-definitions` ESLint rule has been disabled, as this problem will be encountered fairly frequently.