### PR TITLE
Fix AbstractMessageManager error

### DIFF
--- a/src/message-manager/AbstractMessageManager.test.ts
+++ b/src/message-manager/AbstractMessageManager.test.ts
@@ -11,6 +11,10 @@ class AbstractTestManager extends AbstractMessageManager<TypedMessage, TypedMess
     delete messageParams.version;
     return Promise.resolve(messageParams);
   }
+
+  setMessageStatus(messageId: string, status: string) {
+    return super.setMessageStatus(messageId, status);
+  }
 }
 const typedMessage = [
   {
@@ -174,5 +178,30 @@ describe('AbstractTestManager', () => {
     if (message) {
       expect(message.status).toEqual('approved');
     }
+  });
+
+  describe('setMessageStatus', () => {
+    it('should set the given message status', () => {
+      const controller = new AbstractTestManager();
+      controller.addMessage({
+        id: messageId,
+        messageParams: { from: '0x1234', data: 'test' },
+        status: 'status',
+        time: 10,
+        type: 'type',
+      });
+      const messageBefore = controller.getMessage(messageId);
+      expect(messageBefore && messageBefore.status).toEqual('status');
+
+      controller.setMessageStatus(messageId, 'newstatus');
+      const messageAfter = controller.getMessage(messageId);
+      expect(messageAfter && messageAfter.status).toEqual('newstatus');
+    });
+
+    it('should throw an error if message is not found', () => {
+      const controller = new AbstractTestManager();
+
+      expect(() => controller.setMessageStatus(messageId, 'newstatus')).toThrow('AbstractMessageManager: Message not found for id: 1.');
+    });
   });
 });

--- a/src/message-manager/AbstractMessageManager.ts
+++ b/src/message-manager/AbstractMessageManager.ts
@@ -99,9 +99,8 @@ export abstract class AbstractMessageManager<
    */
   protected setMessageStatus(messageId: string, status: string) {
     const message = this.getMessage(messageId);
-    /* istanbul ignore if */
     if (!message) {
-      throw new Error(`${this.context[name]}- Message not found for id: ${messageId}.`);
+      throw new Error(`${this.name}: Message not found for id: ${messageId}.`);
     }
     message.status = status;
     this.updateMessage(message);


### PR DESCRIPTION
The error thrown when trying to set the status of a non-existent message was broken. The first variable in the error message resolved to `undefined`. It has been updated to reference the type of the controller that threw the error.