### PR TITLE
Update to TypeScript 4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@metamask/eslint-config": "^5.0.0",
     "@types/jest": "^22.2.3",
-    "@types/node": "^10.1.4",
+    "@types/node": "^14.14.31",
     "@types/sinon": "^9.0.10",
     "@types/web3": "^1.0.6",
     "@typescript-eslint/eslint-plugin": "^4.15.2",
@@ -78,9 +78,9 @@
     "nock": "^13.0.7",
     "prettier": "^2.1.1",
     "sinon": "^9.2.4",
-    "ts-jest": "^26.3.0",
-    "typedoc": "^0.20.24",
-    "typescript": "^4.0.3"
+    "ts-jest": "^26.5.2",
+    "typedoc": "^0.20.28",
+    "typescript": "~4.1.5"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/src/assets/AccountTrackerController.test.ts
+++ b/src/assets/AccountTrackerController.test.ts
@@ -49,7 +49,7 @@ describe('AccountTrackerController', () => {
   });
 
   it('should call refresh every ten seconds', () => {
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
       const preferences = new PreferencesController();
       const controller = new AccountTrackerController({ provider, interval: 100 });
       stub(controller, 'refresh');

--- a/src/assets/CurrencyRateController.test.ts
+++ b/src/assets/CurrencyRateController.test.ts
@@ -50,10 +50,10 @@ describe('CurrencyRateController', () => {
     const fetchExchangeRateStub = stub();
     const controller = new CurrencyRateController({ interval: 100 }, {}, fetchExchangeRateStub);
 
-    await new Promise((resolve) => setTimeout(() => resolve(), 1));
+    await new Promise<void>((resolve) => setTimeout(() => resolve(), 1));
     expect(fetchExchangeRateStub.called).toBe(true);
     expect(fetchExchangeRateStub.calledTwice).toBe(false);
-    await new Promise((resolve) => setTimeout(() => resolve(), 150));
+    await new Promise<void>((resolve) => setTimeout(() => resolve(), 150));
     expect(fetchExchangeRateStub.calledTwice).toBe(true);
 
     controller.disabled = true;
@@ -72,7 +72,7 @@ describe('CurrencyRateController', () => {
     const fetchExchangeRateStub = stub();
     const mock = stub(global, 'clearTimeout');
     const controller = new CurrencyRateController({ interval: 1337 }, {}, fetchExchangeRateStub);
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
       setTimeout(() => {
         controller.poll(1338);
         expect(mock.called).toBe(true);

--- a/src/assets/TokenBalancesController.test.ts
+++ b/src/assets/TokenBalancesController.test.ts
@@ -41,7 +41,7 @@ describe('TokenBalancesController', () => {
   });
 
   it('should poll and update balances in the right interval', () => {
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
       const mock = stub(TokenBalancesController.prototype, 'updateBalances');
       new TokenBalancesController({ interval: 10 });
       expect(mock.called).toBe(true);
@@ -67,7 +67,7 @@ describe('TokenBalancesController', () => {
   it('should clear previous interval', () => {
     const mock = stub(global, 'clearTimeout');
     const controller = new TokenBalancesController({ interval: 1337 });
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
       setTimeout(() => {
         controller.poll(1338);
         expect(mock.called).toBe(true);

--- a/src/assets/TokenRatesController.test.ts
+++ b/src/assets/TokenRatesController.test.ts
@@ -50,7 +50,7 @@ describe('TokenRatesController', () => {
   });
 
   it('should poll and update rate in the right interval', () => {
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
       const mock = stub(TokenRatesController.prototype, 'fetchExchangeRate');
       new TokenRatesController({
         interval: 10,
@@ -79,7 +79,7 @@ describe('TokenRatesController', () => {
   it('should clear previous interval', () => {
     const mock = stub(global, 'clearTimeout');
     const controller = new TokenRatesController({ interval: 1337 });
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
       setTimeout(() => {
         controller.poll(1338);
         expect(mock.called).toBe(true);

--- a/src/message-manager/MessageManager.test.ts
+++ b/src/message-manager/MessageManager.test.ts
@@ -42,7 +42,7 @@ describe('PersonalMessageManager', () => {
   });
 
   it('should reject a message', () => {
-    return new Promise(async (resolve) => {
+    return new Promise<void>(async (resolve) => {
       const controller = new MessageManager();
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
@@ -65,7 +65,7 @@ describe('PersonalMessageManager', () => {
   });
 
   it('should sign a message', () => {
-    return new Promise(async (resolve) => {
+    return new Promise<void>(async (resolve) => {
       const controller = new MessageManager();
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
@@ -89,7 +89,7 @@ describe('PersonalMessageManager', () => {
   });
 
   it('should throw when unapproved finishes', () => {
-    return new Promise(async (resolve) => {
+    return new Promise<void>(async (resolve) => {
       const controller = new MessageManager();
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
@@ -131,7 +131,7 @@ describe('PersonalMessageManager', () => {
   it('should throw when adding invalid message', () => {
     const from = 'foo';
     const messageData = '0x123';
-    return new Promise(async (resolve) => {
+    return new Promise<void>(async (resolve) => {
       const controller = new MessageManager();
       try {
         await controller.addUnapprovedMessageAsync({

--- a/src/message-manager/MessageManager.ts
+++ b/src/message-manager/MessageManager.ts
@@ -76,7 +76,7 @@ export class MessageManager extends AbstractMessageManager<Message, MessageParam
       this.hub.once(`${messageId}:finished`, (data: Message) => {
         switch (data.status) {
           case 'signed':
-            return resolve(data.rawSig);
+            return resolve(data.rawSig as string);
           case 'rejected':
             return reject(new Error('MetaMask Message Signature: User denied message signature.'));
           default:

--- a/src/message-manager/PersonalMessageManager.test.ts
+++ b/src/message-manager/PersonalMessageManager.test.ts
@@ -42,7 +42,7 @@ describe('PersonalMessageManager', () => {
   });
 
   it('should reject a message', () => {
-    return new Promise(async (resolve) => {
+    return new Promise<void>(async (resolve) => {
       const controller = new PersonalMessageManager();
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
@@ -65,7 +65,7 @@ describe('PersonalMessageManager', () => {
   });
 
   it('should sign a message', () => {
-    return new Promise(async (resolve) => {
+    return new Promise<void>(async (resolve) => {
       const controller = new PersonalMessageManager();
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
@@ -89,7 +89,7 @@ describe('PersonalMessageManager', () => {
   });
 
   it('should throw when unapproved finishes', () => {
-    return new Promise(async (resolve) => {
+    return new Promise<void>(async (resolve) => {
       const controller = new PersonalMessageManager();
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
@@ -131,7 +131,7 @@ describe('PersonalMessageManager', () => {
   it('should throw when adding invalid message', () => {
     const from = 'foo';
     const messageData = '0x123';
-    return new Promise(async (resolve) => {
+    return new Promise<void>(async (resolve) => {
       const controller = new PersonalMessageManager();
       try {
         await controller.addUnapprovedMessageAsync({

--- a/src/message-manager/PersonalMessageManager.ts
+++ b/src/message-manager/PersonalMessageManager.ts
@@ -80,7 +80,7 @@ export class PersonalMessageManager extends AbstractMessageManager<
       this.hub.once(`${messageId}:finished`, (data: PersonalMessage) => {
         switch (data.status) {
           case 'signed':
-            return resolve(data.rawSig);
+            return resolve(data.rawSig as string);
           case 'rejected':
             return reject(new Error('MetaMask Personal Message Signature: User denied message signature.'));
           default:

--- a/src/message-manager/TypedMessageManager.test.ts
+++ b/src/message-manager/TypedMessageManager.test.ts
@@ -54,7 +54,7 @@ describe('TypedMessageManager', () => {
   });
 
   it('should reject a message', () => {
-    return new Promise(async (resolve) => {
+    return new Promise<void>(async (resolve) => {
       const controller = new TypedMessageManager();
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       const version = 'V1';
@@ -81,7 +81,7 @@ describe('TypedMessageManager', () => {
   });
 
   it('should sign a message', () => {
-    return new Promise(async (resolve) => {
+    return new Promise<void>(async (resolve) => {
       const controller = new TypedMessageManager();
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       const version = 'V1';
@@ -109,7 +109,7 @@ describe('TypedMessageManager', () => {
   });
 
   it("should set message status as 'errored'", () => {
-    return new Promise(async (resolve) => {
+    return new Promise<void>(async (resolve) => {
       const controller = new TypedMessageManager();
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       const version = 'V1';
@@ -136,7 +136,7 @@ describe('TypedMessageManager', () => {
   });
 
   it('should throw when unapproved finishes', () => {
-    return new Promise(async (resolve) => {
+    return new Promise<void>(async (resolve) => {
       const controller = new TypedMessageManager();
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       const version = 'V1';
@@ -185,7 +185,7 @@ describe('TypedMessageManager', () => {
     const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
     const messageData = '0x879';
     const version = 'V1';
-    return new Promise(async (resolve) => {
+    return new Promise<void>(async (resolve) => {
       const controller = new TypedMessageManager();
       try {
         await controller.addUnapprovedMessageAsync(
@@ -206,7 +206,7 @@ describe('TypedMessageManager', () => {
     const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
     const messageData = typedMessage;
     const version = 'V3';
-    return new Promise(async (resolve) => {
+    return new Promise<void>(async (resolve) => {
       const controller = new TypedMessageManager();
       try {
         await controller.addUnapprovedMessageAsync(

--- a/src/message-manager/TypedMessageManager.ts
+++ b/src/message-manager/TypedMessageManager.ts
@@ -109,7 +109,7 @@ export class TypedMessageManager extends AbstractMessageManager<
       this.hub.once(`${messageId}:finished`, (data: TypedMessage) => {
         switch (data.status) {
           case 'signed':
-            return resolve(data.rawSig);
+            return resolve(data.rawSig as string);
           case 'rejected':
             return reject(new Error('MetaMask Typed Message Signature: User denied message signature.'));
           case 'errored':

--- a/src/third-party/PhishingController.test.ts
+++ b/src/third-party/PhishingController.test.ts
@@ -21,7 +21,7 @@ describe('PhishingController', () => {
   });
 
   it('should poll and update rate in the right interval', () => {
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
       const mock = stub(PhishingController.prototype, 'updatePhishingLists');
       new PhishingController({ interval: 10 });
       expect(mock.called).toBe(true);
@@ -37,7 +37,7 @@ describe('PhishingController', () => {
   it('should clear previous interval', () => {
     const mock = stub(global, 'clearTimeout');
     const controller = new PhishingController({ interval: 1337 });
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
       setTimeout(() => {
         controller.poll(1338);
         expect(mock.called).toBe(true);

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -394,7 +394,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
       this.hub.once(`${transactionMeta.id}:finished`, (meta: TransactionMeta) => {
         switch (meta.status) {
           case 'submitted':
-            return resolve(meta.transactionHash);
+            return resolve(meta.transactionHash as string);
           case 'rejected':
             return reject(ethErrors.provider.userRejectedRequest('User rejected the transaction'));
           case 'cancelled':

--- a/yarn.lock
+++ b/yarn.lock
@@ -648,6 +648,17 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
+  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
 "@metamask/contract-metadata@^1.23.0":
   version "1.23.0"
   resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.23.0.tgz#c70be7f3eaeeb791651ce793b7cdc230e9780b18"
@@ -828,10 +839,15 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/node@*", "@types/node@^10.1.4":
+"@types/node@*":
   version "10.14.15"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.15.tgz#e8f7729b631be1b02ae130ff0b61f3e018000640"
   integrity sha512-CBR5avlLcu0YCILJiDIXeU2pTw7UK/NIxfC63m7d7CVamho1qDEzXKkOtEauQRPMy6MI8mLozth+JJkas7HY6g==
+
+"@types/node@^14.14.31":
+  version "14.14.31"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.31.tgz#72286bd33d137aa0d152d47ec7c1762563d34055"
+  integrity sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -3384,10 +3400,10 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@^4.7.6:
-  version "4.7.6"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
-  integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
+handlebars@^4.7.7:
+  version "4.7.7"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
+  integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
   dependencies:
     minimist "^1.2.5"
     neo-async "^2.6.0"
@@ -4369,18 +4385,6 @@ jest-snapshot@^26.4.2:
     pretty-format "^26.4.2"
     semver "^7.3.2"
 
-jest-util@26.x, jest-util@^26.3.0:
-  version "26.3.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.3.0.tgz#a8974b191df30e2bf523ebbfdbaeb8efca535b3e"
-  integrity sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==
-  dependencies:
-    "@jest/types" "^26.3.0"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    graceful-fs "^4.2.4"
-    is-ci "^2.0.0"
-    micromatch "^4.0.2"
-
 jest-util@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-25.5.0.tgz#31c63b5d6e901274d264a4fec849230aa3fa35b0"
@@ -4391,6 +4395,30 @@ jest-util@^25.5.0:
     graceful-fs "^4.2.4"
     is-ci "^2.0.0"
     make-dir "^3.0.0"
+
+jest-util@^26.1.0:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.2.tgz#907535dbe4d5a6cb4c47ac9b926f6af29576cbc1"
+  integrity sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    is-ci "^2.0.0"
+    micromatch "^4.0.2"
+
+jest-util@^26.3.0:
+  version "26.3.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.3.0.tgz#a8974b191df30e2bf523ebbfdbaeb8efca535b3e"
+  integrity sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==
+  dependencies:
+    "@jest/types" "^26.3.0"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    is-ci "^2.0.0"
+    micromatch "^4.0.2"
 
 jest-validate@^21.1.0:
   version "21.2.1"
@@ -4895,11 +4923,6 @@ lodash.get@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
-lodash.memoize@4.x:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
-  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
-
 lodash.set@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
@@ -4909,6 +4932,11 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
+
+lodash@4.x, lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
   version "4.17.19"
@@ -6890,22 +6918,22 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-ts-jest@^26.3.0:
-  version "26.3.0"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.3.0.tgz#6b2845045347dce394f069bb59358253bc1338a9"
-  integrity sha512-Jq2uKfx6bPd9+JDpZNMBJMdMQUC3sJ08acISj8NXlVgR2d5OqslEHOR2KHMgwymu8h50+lKIm0m0xj/ioYdW2Q==
+ts-jest@^26.5.2:
+  version "26.5.2"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.2.tgz#5281d6b44c2f94f71205728a389edc3d7995b0c4"
+  integrity sha512-bwyJ2zJieSugf7RB+o8fgkMeoMVMM2KPDE0UklRLuACxjwJsOrZNo6chrcScmK33YavPSwhARffy8dZx5LJdUQ==
   dependencies:
     "@types/jest" "26.x"
     bs-logger "0.x"
     buffer-from "1.x"
     fast-json-stable-stringify "2.x"
-    jest-util "26.x"
+    jest-util "^26.1.0"
     json5 "2.x"
-    lodash.memoize "4.x"
+    lodash "4.x"
     make-error "1.x"
     mkdirp "1.x"
     semver "7.x"
-    yargs-parser "18.x"
+    yargs-parser "20.x"
 
 tsconfig-paths@^3.9.0:
   version "3.9.0"
@@ -7002,15 +7030,15 @@ typedoc-default-themes@^0.12.7:
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.12.7.tgz#d44f68d40a3e90a19b5ea7be4cc6ed949afe768d"
   integrity sha512-0XAuGEqID+gon1+fhi4LycOEFM+5Mvm2PjwaiVZNAzU7pn3G2DEpsoXnFOPlLDnHY6ZW0BY0nO7ur9fHOFkBLQ==
 
-typedoc@^0.20.24:
-  version "0.20.24"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.20.24.tgz#9dd1cb32e44823a5ebbeb54c9b84af85286c5941"
-  integrity sha512-TadOYtcw8agrk7WTZlXUcct4jLZZcGcYe3xbmARkI+rBpXI6Mw+0P8oUo13+9oFreQvK5zZgMem4YEi7lCXLIw==
+typedoc@^0.20.28:
+  version "0.20.28"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.20.28.tgz#6c454904d864dd43a2de9228c44b91e3c53d98ce"
+  integrity sha512-8j0T8u9FuyDkoe+M/3cyoaGJSVgXCY9KwVoo7TLUnmQuzXwqH+wkScY530ZEdK6G39UZ2LFTYPIrL5eykWjx6A==
   dependencies:
     colors "^1.4.0"
     fs-extra "^9.1.0"
-    handlebars "^4.7.6"
-    lodash "^4.17.20"
+    handlebars "^4.7.7"
+    lodash "^4.17.21"
     lunr "^2.3.9"
     marked "^2.0.0"
     minimatch "^3.0.0"
@@ -7019,10 +7047,10 @@ typedoc@^0.20.24:
     shiki "^0.9.2"
     typedoc-default-themes "^0.12.7"
 
-typescript@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
-  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
+typescript@~4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
+  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
 
 uglify-js@^3.1.4:
   version "3.6.5"
@@ -7396,7 +7424,12 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yargs-parser@18.x, yargs-parser@^18.1.2:
+yargs-parser@20.x:
+  version "20.2.6"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.6.tgz#69f920addf61aafc0b8b89002f5d66e28f2d8b20"
+  integrity sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA==
+
+yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==


### PR DESCRIPTION
TypeScript [has been updated to v4.1](https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/). I'm not aware of any changes that impact our code, but the update did highlight a few new minor errors in our code for some reason. These have all been fixed. There was also a breaking change that affected us: `resolve` parameters for Promises are no longer optional. We're not required to use `Promise<void>` for any Promises not returning a value.