### PR TITLE
Migrate CurrencyRateController to BaseControllerV2

### DIFF
--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -10,14 +10,12 @@ import {
   RestrictedControllerMessenger,
 } from './ControllerMessenger';
 import PreferencesController from './user/PreferencesController';
-import TokenRatesController from './assets/TokenRatesController';
 import { AssetsController } from './assets/AssetsController';
 import {
   NetworkController,
   NetworksChainId,
 } from './network/NetworkController';
 import { AssetsContractController } from './assets/AssetsContractController';
-import CurrencyRateController from './assets/CurrencyRateController';
 
 // Mock BaseControllerV2 classes
 
@@ -107,21 +105,13 @@ describe('ComposableController', () => {
           assetContractController,
         ),
       });
-      const currencyRateController = new CurrencyRateController();
       const controller = new ComposableController([
         new AddressBookController(),
         assetController,
         assetContractController,
         new EnsController(),
-        currencyRateController,
         networkController,
         preferencesController,
-        new TokenRatesController({
-          onAssetsStateChange: (listener) =>
-            assetController.subscribe(listener),
-          onCurrencyRateStateChange: (listener) =>
-            currencyRateController.subscribe(listener),
-        }),
       ]);
       expect(controller.state).toStrictEqual({
         AddressBookController: { addressBook: {} },
@@ -136,13 +126,6 @@ describe('ComposableController', () => {
           ignoredTokens: [],
           suggestedAssets: [],
           tokens: [],
-        },
-        CurrencyRateController: {
-          conversionDate: 0,
-          conversionRate: 0,
-          currentCurrency: 'usd',
-          nativeCurrency: 'ETH',
-          usdConversionRate: 0,
         },
         EnsController: {
           ensEntries: {},
@@ -159,7 +142,6 @@ describe('ComposableController', () => {
           lostIdentities: {},
           selectedAddress: '',
         },
-        TokenRatesController: { contractExchangeRates: {} },
       });
     });
 
@@ -182,21 +164,13 @@ describe('ComposableController', () => {
           assetContractController,
         ),
       });
-      const currencyRateController = new CurrencyRateController();
       const controller = new ComposableController([
         new AddressBookController(),
         assetController,
         assetContractController,
         new EnsController(),
-        currencyRateController,
         networkController,
         preferencesController,
-        new TokenRatesController({
-          onAssetsStateChange: (listener) =>
-            assetController.subscribe(listener),
-          onCurrencyRateStateChange: (listener) =>
-            currencyRateController.subscribe(listener),
-        }),
       ]);
       expect(controller.flatState).toStrictEqual({
         addressBook: {},
@@ -205,10 +179,6 @@ describe('ComposableController', () => {
         allTokens: {},
         collectibleContracts: [],
         collectibles: [],
-        contractExchangeRates: {},
-        conversionDate: 0,
-        conversionRate: 0,
-        currentCurrency: 'usd',
         ensEntries: {},
         featureFlags: {},
         frequentRpcList: [],
@@ -217,13 +187,11 @@ describe('ComposableController', () => {
         ignoredTokens: [],
         ipfsGateway: 'https://ipfs.io/ipfs/',
         lostIdentities: {},
-        nativeCurrency: 'ETH',
         network: 'loading',
         provider: { type: 'mainnet', chainId: NetworksChainId.mainnet },
         selectedAddress: '',
         suggestedAssets: [],
         tokens: [],
-        usdConversionRate: 0,
       });
     });
 

--- a/src/assets/CurrencyRateController.ts
+++ b/src/assets/CurrencyRateController.ts
@@ -65,7 +65,7 @@ export class CurrencyRateController extends BaseController<
 > {
   private mutex = new Mutex();
 
-  private handle?: NodeJS.Timer;
+  private pollTimeout?: NodeJS.Timeout;
 
   private interval;
 
@@ -162,8 +162,8 @@ export class CurrencyRateController extends BaseController<
   }
 
   private stopPolling() {
-    if (this.handle) {
-      clearInterval(this.handle);
+    if (this.pollTimeout) {
+      clearInterval(this.pollTimeout);
     }
   }
 
@@ -174,7 +174,7 @@ export class CurrencyRateController extends BaseController<
     this.stopPolling();
     // TODO: Expose polling currency rate update errors
     await safelyExecute(() => this.updateExchangeRate());
-    this.handle = setInterval(async () => {
+    this.pollTimeout = setInterval(async () => {
       await safelyExecute(() => this.updateExchangeRate());
     }, this.interval);
   }

--- a/src/assets/CurrencyRateController.ts
+++ b/src/assets/CurrencyRateController.ts
@@ -65,9 +65,9 @@ export class CurrencyRateController extends BaseController<
 > {
   private mutex = new Mutex();
 
-  private pollTimeout?: NodeJS.Timeout;
+  private intervalId?: NodeJS.Timeout;
 
-  private interval;
+  private intervalDelay;
 
   private fetchExchangeRate;
 
@@ -109,7 +109,7 @@ export class CurrencyRateController extends BaseController<
       state: { ...defaultState, ...state },
     });
     this.includeUsdRate = includeUsdRate;
-    this.interval = interval;
+    this.intervalDelay = interval;
     this.fetchExchangeRate = fetchExchangeRate;
   }
 
@@ -162,8 +162,8 @@ export class CurrencyRateController extends BaseController<
   }
 
   private stopPolling() {
-    if (this.pollTimeout) {
-      clearInterval(this.pollTimeout);
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
     }
   }
 
@@ -174,9 +174,9 @@ export class CurrencyRateController extends BaseController<
     this.stopPolling();
     // TODO: Expose polling currency rate update errors
     await safelyExecute(() => this.updateExchangeRate());
-    this.pollTimeout = setInterval(async () => {
+    this.intervalId = setInterval(async () => {
       await safelyExecute(() => this.updateExchangeRate());
-    }, this.interval);
+    }, this.intervalDelay);
   }
 
   /**

--- a/src/assets/CurrencyRateController.ts
+++ b/src/assets/CurrencyRateController.ts
@@ -1,184 +1,216 @@
 import { Mutex } from 'async-mutex';
-import BaseController, { BaseConfig, BaseState } from '../BaseController';
+import type { Patch } from 'immer';
+
+import { BaseController } from '../BaseControllerV2';
 import { safelyExecute } from '../util';
 import { fetchExchangeRate as defaultFetchExchangeRate } from '../apis/crypto-compare';
 
-/**
- * @type CurrencyRateConfig
- *
- * Currency rate controller configuration
- *
- * @property currentCurrency - Currently-active ISO 4217 currency code
- * @property interval - Polling interval used to fetch new currency rate
- * @property nativeCurrency - Symbol for the base asset used for conversion
- * @property includeUSDRate - Whether to include the usd rate in addition to the currentCurrency
- */
-export interface CurrencyRateConfig extends BaseConfig {
-  currentCurrency: string;
-  interval: number;
-  nativeCurrency: string;
-  includeUSDRate?: boolean;
-}
+import type { RestrictedControllerMessenger } from '../ControllerMessenger';
 
 /**
  * @type CurrencyRateState
- *
- * Currency rate controller state
  *
  * @property conversionDate - Timestamp of conversion rate expressed in ms since UNIX epoch
  * @property conversionRate - Conversion rate from current base asset to the current currency
  * @property currentCurrency - Currently-active ISO 4217 currency code
  * @property nativeCurrency - Symbol for the base asset used for conversion
+ * @property pendingCurrentCurrency - The currency being switched to
+ * @property pendingNativeCurrency - The base asset currency being switched to
  * @property usdConversionRate - Conversion rate from usd to the current currency
  */
-export interface CurrencyRateState extends BaseState {
+export type CurrencyRateState = {
   conversionDate: number;
   conversionRate: number;
   currentCurrency: string;
   nativeCurrency: string;
-  usdConversionRate?: number;
-}
+  pendingCurrentCurrency: string | null;
+  pendingNativeCurrency: string | null;
+  usdConversionRate: number | null;
+};
+
+const name = 'CurrencyRateController';
+
+export type CurrencyRateStateChange = {
+  type: `${typeof name}:stateChange`;
+  payload: [CurrencyRateState, Patch[]];
+};
+
+const metadata = {
+  conversionDate: { persist: true, anonymous: true },
+  conversionRate: { persist: true, anonymous: true },
+  currentCurrency: { persist: true, anonymous: true },
+  nativeCurrency: { persist: true, anonymous: true },
+  pendingCurrentCurrency: { persist: false, anonymous: true },
+  pendingNativeCurrency: { persist: false, anonymous: true },
+  usdConversionRate: { persist: true, anonymous: true },
+};
+
+const defaultState = {
+  conversionDate: 0,
+  conversionRate: 0,
+  currentCurrency: 'usd',
+  nativeCurrency: 'ETH',
+  pendingCurrentCurrency: null,
+  pendingNativeCurrency: null,
+  usdConversionRate: null,
+};
 
 /**
  * Controller that passively polls on a set interval for an exchange rate from the current base
  * asset to the current currency
  */
 export class CurrencyRateController extends BaseController<
-  CurrencyRateConfig,
+  typeof name,
   CurrencyRateState
 > {
-  /* Optional config to include conversion to usd in all price url fetches and on state */
-  includeUSDRate?: boolean;
-
-  private activeCurrency = '';
-
-  private activeNativeCurrency = '';
-
   private mutex = new Mutex();
 
   private handle?: NodeJS.Timer;
 
-  private fetchExchangeRate: typeof defaultFetchExchangeRate;
+  private interval;
 
-  private getCurrentCurrencyFromState(state?: Partial<CurrencyRateState>) {
-    return state?.currentCurrency ? state.currentCurrency : 'usd';
-  }
+  private fetchExchangeRate;
 
-  /**
-   * Name of this controller used during composition
-   */
-  name = 'CurrencyRateController';
+  private includeUsdRate;
 
   /**
    * Creates a CurrencyRateController instance
    *
-   * @param config - Initial options used to configure this controller
-   * @param state - Initial state to set on this controller
+   * @param options - Constructor options
+   * @param options.includeUsdRate - Keep track of the USD rate in addition to the current currency rate
+   * @param options.interval - The polling interval, in milliseconds
+   * @param options.messenger - A reference to the messaging system
+   * @param options.state - Initial state to set on this controller
+   * @param options.fetchExchangeRate - Fetches the exchange rate from an external API. This option is primarily meant for use in unit tests.
    */
-  constructor(
-    config?: Partial<CurrencyRateConfig>,
-    state?: Partial<CurrencyRateState>,
+  constructor({
+    includeUsdRate = false,
+    interval = 180000,
+    messenger,
+    state,
     fetchExchangeRate = defaultFetchExchangeRate,
-  ) {
-    super(config, state);
+  }: {
+    includeUsdRate?: boolean;
+    interval?: number;
+    messenger: RestrictedControllerMessenger<
+      typeof name,
+      any,
+      any,
+      never,
+      never
+    >;
+    state?: Partial<CurrencyRateState>;
+    fetchExchangeRate?: typeof defaultFetchExchangeRate;
+  }) {
+    super({
+      name,
+      metadata,
+      messenger,
+      state: { ...defaultState, ...state },
+    });
+    this.includeUsdRate = includeUsdRate;
+    this.interval = interval;
     this.fetchExchangeRate = fetchExchangeRate;
-    this.defaultConfig = {
-      currentCurrency: this.getCurrentCurrencyFromState(state),
-      disabled: true,
-      interval: 180000,
-      nativeCurrency: 'ETH',
-      includeUSDRate: false,
-    };
-    this.defaultState = {
-      conversionDate: 0,
-      conversionRate: 0,
-      currentCurrency: this.defaultConfig.currentCurrency,
-      nativeCurrency: this.defaultConfig.nativeCurrency,
-      usdConversionRate: 0,
-    };
-    this.initialize();
-    this.configure({ disabled: false }, false, false);
-    this.poll();
+  }
+
+  /**
+   * Start polling for the currency rate
+   */
+  async start() {
+    await this.startPolling();
+  }
+
+  /**
+   * Stop polling for the currency rate
+   */
+  stop() {
+    this.stopPolling();
+  }
+
+  /**
+   * Prepare to discard this controller.
+   *
+   * This stops any active polling.
+   */
+  destroy() {
+    super.destroy();
+    this.stopPolling();
   }
 
   /**
    * Sets a currency to track
    *
-   * TODO: Replace this wth a method
-   *
    * @param currentCurrency - ISO 4217 currency code
    */
-  set currentCurrency(currentCurrency: string) {
-    this.activeCurrency = currentCurrency;
-    safelyExecute(() => this.updateExchangeRate());
-  }
-
-  get currentCurrency() {
-    throw new Error('Property only used for setting');
+  async setCurrentCurrency(currentCurrency: string) {
+    this.update((state) => {
+      state.pendingCurrentCurrency = currentCurrency;
+    });
+    await this.updateExchangeRate();
   }
 
   /**
    * Sets a new native currency
    *
-   * TODO: Replace this wth a method
-   *
    * @param symbol - Symbol for the base asset
    */
-  set nativeCurrency(symbol: string) {
-    this.activeNativeCurrency = symbol;
-    safelyExecute(() => this.updateExchangeRate());
+  async setNativeCurrency(symbol: string) {
+    this.update((state) => {
+      state.pendingNativeCurrency = symbol;
+    });
+    await this.updateExchangeRate();
   }
 
-  get nativeCurrency() {
-    throw new Error('Property only used for setting');
+  private stopPolling() {
+    if (this.handle) {
+      clearInterval(this.handle);
+    }
   }
 
   /**
    * Starts a new polling interval
-   *
-   * @param interval - Polling interval used to fetch new exchange rate
    */
-  async poll(interval?: number): Promise<void> {
-    interval && this.configure({ interval }, false, false);
-    this.handle && clearTimeout(this.handle);
+  private async startPolling(): Promise<void> {
+    this.stopPolling();
+    // TODO: Expose polling currency rate update errors
     await safelyExecute(() => this.updateExchangeRate());
-    this.handle = setTimeout(() => {
-      this.poll(this.config.interval);
-    }, this.config.interval);
+    this.handle = setInterval(async () => {
+      await safelyExecute(() => this.updateExchangeRate());
+    }, this.interval);
   }
 
   /**
    * Updates exchange rate for the current currency
-   *
-   * @returns Promise resolving to currency data or undefined if disabled
    */
   async updateExchangeRate(): Promise<CurrencyRateState | void> {
-    if (this.disabled || !this.activeCurrency || !this.activeNativeCurrency) {
-      return undefined;
-    }
     const releaseLock = await this.mutex.acquire();
+    const {
+      currentCurrency,
+      nativeCurrency,
+      pendingCurrentCurrency,
+      pendingNativeCurrency,
+    } = this.state;
     try {
       const {
         conversionDate,
         conversionRate,
         usdConversionRate,
       } = await this.fetchExchangeRate(
-        this.activeCurrency,
-        this.activeNativeCurrency,
-        this.includeUSDRate,
+        pendingCurrentCurrency || currentCurrency,
+        pendingNativeCurrency || nativeCurrency,
+        this.includeUsdRate,
       );
-      const newState: CurrencyRateState = {
-        conversionDate,
-        conversionRate,
-        currentCurrency: this.activeCurrency,
-        nativeCurrency: this.activeNativeCurrency,
-        usdConversionRate: this.includeUSDRate
-          ? usdConversionRate
-          : this.defaultState.usdConversionRate,
-      };
-      this.update(newState);
-
-      return this.state;
+      this.update(() => {
+        return {
+          conversionDate,
+          conversionRate,
+          currentCurrency: pendingCurrentCurrency || currentCurrency,
+          nativeCurrency: pendingNativeCurrency || nativeCurrency,
+          pendingCurrentCurrency: null,
+          pendingNativeCurrency: null,
+          usdConversionRate,
+        };
+      });
     } finally {
       releaseLock();
     }

--- a/src/assets/TokenRatesController.test.ts
+++ b/src/assets/TokenRatesController.test.ts
@@ -2,10 +2,9 @@ import { stub } from 'sinon';
 import nock from 'nock';
 import { PreferencesController } from '../user/PreferencesController';
 import { NetworkController } from '../network/NetworkController';
-import TokenRatesController, { Token } from './TokenRatesController';
+import TokenRatesController from './TokenRatesController';
 import { AssetsController } from './AssetsController';
 import { AssetsContractController } from './AssetsContractController';
-import CurrencyRateController from './CurrencyRateController';
 
 const COINGECKO_HOST = 'https://api.coingecko.com';
 const COINGECKO_PATH = '/api/v3/simple/token_price/ethereum';
@@ -130,12 +129,10 @@ describe('TokenRatesController', () => {
         assetsContract,
       ),
     });
-    const currencyRate = new CurrencyRateController();
     const controller = new TokenRatesController(
       {
         onAssetsStateChange: (listener) => assets.subscribe(listener),
-        onCurrencyRateStateChange: (listener) =>
-          currencyRate.subscribe(listener),
+        onCurrencyRateStateChange: stub(),
       },
       { interval: 10 },
     );
@@ -173,33 +170,43 @@ describe('TokenRatesController', () => {
     expect(mock).not.toThrow();
   });
 
-  it('should subscribe to new sibling assets controllers', async () => {
-    const assetsContract = new AssetsContractController();
-    const network = new NetworkController();
-    const preferences = new PreferencesController();
-    const assets = new AssetsController({
-      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
-      onNetworkStateChange: (listener) => network.subscribe(listener),
-      getAssetName: assetsContract.getAssetName.bind(assetsContract),
-      getAssetSymbol: assetsContract.getAssetSymbol.bind(assetsContract),
-      getCollectibleTokenURI: assetsContract.getCollectibleTokenURI.bind(
-        assetsContract,
-      ),
+  it('should update exchange rates when assets change', async () => {
+    let assetStateChangeListener: (state: any) => void;
+    const onAssetsStateChange = stub().callsFake((listener) => {
+      assetStateChangeListener = listener;
     });
-    const currencyRate = new CurrencyRateController();
+    const onCurrencyRateStateChange = stub();
     const controller = new TokenRatesController(
       {
-        onAssetsStateChange: (listener) => assets.subscribe(listener),
-        onCurrencyRateStateChange: (listener) =>
-          currencyRate.subscribe(listener),
+        onAssetsStateChange,
+        onCurrencyRateStateChange,
       },
       { interval: 10 },
     );
-    await assets.addToken('0xfoO', 'FOO', 18);
-    currencyRate.update({ nativeCurrency: 'gno' });
-    const { tokens } = assets.state;
-    const found = tokens.filter((token: Token) => token.address === '0xfoO');
-    expect(found.length > 0).toBe(true);
-    expect(controller.config.nativeCurrency).toStrictEqual('gno');
+
+    const updateExchangeRatesStub = stub(controller, 'updateExchangeRates');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    assetStateChangeListener!({ tokens: [] });
+    expect(updateExchangeRatesStub.callCount).toStrictEqual(1);
+  });
+
+  it('should update exchange rates when native currency changes', async () => {
+    let currencyRateStateChangeListener: (state: any) => void;
+    const onAssetsStateChange = stub();
+    const onCurrencyRateStateChange = stub().callsFake((listener) => {
+      currencyRateStateChangeListener = listener;
+    });
+    const controller = new TokenRatesController(
+      {
+        onAssetsStateChange,
+        onCurrencyRateStateChange,
+      },
+      { interval: 10 },
+    );
+
+    const updateExchangeRatesStub = stub(controller, 'updateExchangeRates');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    currencyRateStateChangeListener!({ nativeCurrency: 'dai' });
+    expect(updateExchangeRatesStub.callCount).toStrictEqual(1);
   });
 });


### PR DESCRIPTION
The CurrencyRateController has been migrated to the new base controller. The configuration can now only be set during construction, as it was never changed at runtime in practice with the old controller. Similarly, the `disable` function was removed as it wasn't relied upon in practice.

One major change is that the controller doesn't poll after being constructed. The "start" method must be called for polling to start. The "start" and "stop" methods have been added to loosely follow the conventions used in `metamask-extension` to allow starting and stopping polling for the purpose of reducing network traffic.

A few tests required substantial updates because of this change. The ComposableController tests were easiest to fix by deleting the use of the CurrencyRateController completely, since that test was intended to test BaseController-based controllers specifically.

The last TokenRatesController test managed to mark the state change handlers in that controller as 'covered' without actually asserting anything related to that functionality. That broken test was split into two pieces, one for each state change handler. Those two tests still rely upon mocking a would-be private function, which isn't great, but it matches the patterns used elsewhere in that test module. To improve it would take a great deal of work, enough for a separate PR.