### PR TITLE
Improve JSON types

### DIFF
--- a/src/BaseControllerV2.ts
+++ b/src/BaseControllerV2.ts
@@ -23,7 +23,8 @@ type primitive = null | boolean | number | string;
 
 type DefinitelyNotJsonable = ((...args: any[]) => any) | undefined;
 
-// Type copied from https://github.com/Microsoft/TypeScript/issues/1897#issuecomment-710744173
+// Credit to https://github.com/grant-dennison for this type
+// Source: https://github.com/Microsoft/TypeScript/issues/1897#issuecomment-710744173
 export type IsJsonable<T> =
   // Check if there are any non-jsonable types represented in the union
   // Note: use of tuples in this first condition side-steps distributive conditional types
@@ -43,7 +44,11 @@ export type IsJsonable<T> =
       ? // It's an object
         {
           // Iterate over keys in object case
-          [P in keyof T]: IsJsonable<T[P]>; // Recursive call for children
+          [P in keyof T]: P extends string
+            ? // Recursive call for children
+              IsJsonable<T[P]>
+            : // Exclude non-string keys
+              never;
         }
       : // Otherwise any other non-object no bueno
         never
@@ -87,7 +92,7 @@ export interface StatePropertyMetadata<T> {
   anonymous: boolean | StateDeriver<T>;
 }
 
-type Json = null | boolean | number | string | Json[] | { [prop: string]: Json } | Partial<Record<never, never>>;
+type Json = null | boolean | number | string | Json[] | { [prop: string]: Json };
 /**
  * Controller class that provides state management, subscriptions, and state metadata
  */


### PR DESCRIPTION
The JSON types (`Json` and `IsJsonable`) have been improved:

* The last part of the `Json` union type was redundant, and has been removed (`Partial<Record<never, never>>`).
* A check has been added to `IsJsonable` to prevent the use of numeric keys in objects. In testing I've found this doesn't prevent all cases of this, but it does prevent some.

[`IsJsonable` playground link with tests](https://www.typescriptlang.org/play?#code/C4TwDgpgBGBOCWBbex4DdoF4oDsCuANgQLABQUFUAPlAEYD29BEAhjmZdbnorRLB0o0AzsAQ4A5mTKhIUACIQAZvBwoIBEADl6wAFLD6OFrWZRsACgsBKcwD4obELZp4cAE2WqI76aVnQAJLCBkYmzAA8ACoOmIIA9PFQAMIAFhAAxgDWUPBKUMDpsNAsxY44ILhGALQAVobGptABwlDFcBDCEDjAPrk4BelQbvBGCUk6vQBcw11Q9PnAeGDMraqD8K0qsKJQGUbuKKMDwvCe1aIQYK2Hogi0eKgYewdHYQQF4J3jUBZd0KlgMBrlNEhIUKk8LQAHT7RDxZAZWD0QxKYDxKJfADKSPgYHRm2EeE68QATABOADMADYABwAYkJxLhiG6wGqABYAKyUrkUnmk6yCADaAFEAB5iFgZYDRAA0Ci8al6mkmoUazDsAF0oBBJd13K1hTgIBhYFrBBQAPxQRJQHQ4OoNcLNL7DNRGKAAdxYW3obncusQ+JAlsoUV1+o8rTgSCOGDD1ttSQACghkE9oJtHBkMldgC7E+GizM7QB5Qr8L2baAZdLZXL5UqwFih8icKARvW9aO-VRKfhQACq1mFFvbnBtdoAgrAWyBWqVoMJIBl4CwCABuKC1PC7OuZHLN1u65isnqfSBFijBdUuiJDuxjkvJqAVorVuYHht5ea0WqZMARZ2p0BCqOytwutUJqStUYEmlAAACLS4vi1SgeB8S0Gw1QtEWXZRoaf4ATKRZTkkgTAAA5IuAz0P+gHXlAADeTEUHalH8CwvTzGaUBZBAC79MRgF7L6EBsVAwopsJAkgAsnZajMMndgarR3KoUgTh2k6vgASpkeA7OgtYbh8Sj0LAeypPABDuMU7DaTpnC3s6TTRNJWp2JJFClkkEoZAQeCeFUjoaZI-GCcIPmUCaZqbkxAC+L7lpWsCfiUFTzGloXVPRJHAFUdDEjg9BMXF-Bhn5b5pRluX1GETSXtAIyej6foBlUhUQMGoBFhVsAJaQZBKG4MrHAUnSyjEFgNTgMyuY1kQxNYMxoPQZwsT8URTbkawDJWLzBrZ3HHGQyXDaQ4H8Eo0rQNOW3tiwMz4Lw-BDRdZCBb6rQAEKPRQLAAIQvTwfCDedfjXbAt15lAABqAOOFaoNvRDpCfVdPQ3XdUAABpI89CjcRAH1Q9jMO4wAmoTKPE70ZOXdDsPQAAWoTqPg1wAZKj4jNkMzuMAOq0zMNj2OUID86Q+w4LsTjmNwRCOLRUt+HacJgLZg5lgA0jIU0WPgRDWENvSiBYt0EF0psGxbAAMtv+IbABELtO+bwAWGOHuG8xiW+xbwr21qgde8xjgzPbUAB2bhsK76UDTmHFgJ39KcR0TEe0DMYjEgqGQzP7iUKu4MzCv7CqkgqLs2S7Wqx3bXsVyXLFE7X8Au63xsEAqlKh0NX1GIYzDQgQ9ASBYEfCgAjEpUAzzHQoy8PTAQGPE8WHoWJllo0JgKUXRbzve-heCSggFPUlzzMi8B9Yy8a-Qx3MFZhTIl60XOxbJpevTEA2BTsaCAf95AkxsAPJuV8ia-3-uLRu38vZpwRinZBeNUFZUTlTDBlRE6sxwSrKAQsU48xUCadwGdr7zzvinLkhDXpc1cB4XmFChpAA)

[`Json` playground link with tests](https://www.typescriptlang.org/play?#code/C4TwDgpgBAUgzgewHZQLxSQVwDbagHygCMEFsIBDFQrAWyIgCcCo5hGBLJAcxfmQDaAXRYBvKALCMEYAFyt2XbkPn8UAXwCwAKB0AzTEgDGwDsijAIbADwAVAHwAKAFaIkqtwEp5ANwQcAEyhRHSgoAHpwqFsrYCgOOHiUYAALaCMEWjAObApTZB0tXW0uS0Y9CiNoAEFg0KgKeToGRgBuQp0dI1y4RIAhOu0wigBCJsx6JnbtIp1QSCgAYTRB4fHJto7i0qYKqqgAEVWJPVJ5Nk4eFQwJlvqBIgoAqRl1luukCB8mLZ0d8sq0AAascKAB+N5TX4lJBlPbQAAaoPkBzyEGmsxhcMBUAAmqCIYc0RjOljdjiAFrIm4bFiGAIQPRcCABEnbWHk-YAdQJ8kcnjQ9gaSBAbK6yDYwpAKywuAaiSootJkSgGSyOSYUAA8gBpOaxRyy7CeaaWNiOCrYOAQE3680ABlt2jNwEcACI3U6XY5hF6DaJ1H7zQJ7UIg67xI0oPaoIHTQbFfKluHHImKIkDinI-JxER5OxMBAADSqnPqdQlgLyAQBksAJhLbpSHDdQjjdtdNYrwSjTZb3aNJYAzGHpjoVWrsuRmKlpAB3OAdw0QOdEyz8lMCT6r1HrzyjpfZjArtcQfmxlNpxLVS8ipN9W-S9NQIGPpMIt-P3GfxIUn9QLkU3pRlmQCFMAFYk2aTVCGAplPjA6YgA)