### PR TITLE
Remove use of actionCall, fix updateViewed, manage state with objects…

### DIFF
--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -27,7 +27,7 @@ interface NotificationMap {
 /**
   * A map of notification ids to StateNotification objects
   */
-interface StateNotificationMap {
+export interface StateNotificationMap {
   [id: number]: StateNotification;
 }
 

--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -36,7 +36,7 @@ interface StateNotificationMap {
  * from `metamask-extension`
  */
 export interface NotificationConfig extends BaseConfig{
-  allNotifications: NotificationMap | undefined;
+  allNotifications: NotificationMap;
 }
 
 /**
@@ -65,7 +65,7 @@ export class NotificationController extends BaseController<NotificationConfig, N
    * @param state - Initial state to set on this controller
    */
   constructor(config: NotificationConfig, state?: NotificationState) {
-    const { allNotifications = {} } = config;
+    const { allNotifications } = config;
     super(config, state || defaultState);
     this.allNotifications = { ...allNotifications };
     this.initialize();

--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -10,8 +10,11 @@ interface Notification {
   description: string;
   date: string;
   image?: string;
-  isShown?: boolean;
   actionText?: string;
+}
+
+interface StateNotification extends Notification {
+  isShown: boolean;
 }
 
 /**
@@ -19,6 +22,13 @@ interface Notification {
   */
 interface NotificationMap {
   [id: number]: Notification;
+}
+
+/**
+  * A map of notification ids to StateNotification objects
+  */
+interface StateNotificationMap {
+  [id: number]: StateNotification;
 }
 
 /**
@@ -34,7 +44,7 @@ export interface NotificationConfig extends BaseConfig{
  * that are still active
  */
 export interface NotificationState extends BaseState{
-  notifications: NotificationMap;
+  notifications: StateNotificationMap;
 }
 
 const defaultState = {
@@ -71,9 +81,9 @@ export class NotificationController extends BaseController<NotificationConfig, N
    *  @param allNotifications
    */
   private _addNotifications(): void{
-    const newNotifications: NotificationMap = {};
+    const newNotifications: StateNotificationMap = {};
 
-    Object.values(this.allNotifications).forEach((notification: Notification) => {
+    Object.values(this.allNotifications).forEach((notification: StateNotification) => {
       if (!this.state.notifications[notification.id]) {
         newNotifications[notification.id] = {
           ...notification,
@@ -81,8 +91,7 @@ export class NotificationController extends BaseController<NotificationConfig, N
         };
       }
     });
-
-    this.update(newNotifications);
+    this.update({ notifications: newNotifications });
   }
 
   /**

--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -84,12 +84,12 @@ export class NotificationController extends BaseController<NotificationConfig, N
     const newNotifications: StateNotificationMap = {};
 
     Object.values(this.allNotifications).forEach((notification: StateNotification) => {
-      if (!this.state.notifications[notification.id]) {
-        newNotifications[notification.id] = {
+      newNotifications[notification.id] = this.state.notifications[notification.id]
+        ? this.state.notifications[notification.id]
+        : {
           ...notification,
           isShown: false,
         };
-      }
     });
     this.update({ notifications: newNotifications });
   }

--- a/tests/NotificationController.test.ts
+++ b/tests/NotificationController.test.ts
@@ -1,144 +1,125 @@
 import {
   NotificationConfig,
-  NotificationController,
   NotificationState,
+  NotificationController,
+  StateNotificationMap,
 } from '../src/notification/NotificationController';
 
-const swapsHandler = jest.fn();
-const mobileHandler = jest.fn();
-const npsHandler = jest.fn();
 const config1: NotificationConfig = {
-  allNotifications: [
-    {
+  allNotifications: {
+    1: {
       id: 1,
       title: 'Now Swap tokens directly in your wallet!',
       description:
         'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
       date: '12/8/2020',
       image: 'image url',
-      action: {
-        actionText: 'Start swapping',
-        actionFunction: swapsHandler,
-      },
+      actionText: 'Start swapping',
     },
-    {
+    2: {
       id: 2,
       title: 'MetaMask Mobile is here!',
       description:
         'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
       date: '12/8/2020',
-      action: {
-        actionText: 'Get the mobile app',
-        actionFunction: mobileHandler,
-      },
+      actionText: 'Get the mobile app',
     },
-  ],
+  },
 };
 
 const config2: NotificationConfig = {
-  allNotifications: [
-    {
-      id: 1,
-      title: 'Now Swap tokens directly in your wallet!',
-      description:
-        'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
-      date: '12/8/2020',
-    },
-    {
-      id: 2,
-      title: 'MetaMask Mobile is here!',
-      description:
-        'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
-      date: '12/8/2020',
-      image: 'image url',
-    },
-  ],
-};
-
-const config3: NotificationConfig = {
-  allNotifications: [
-    {
+  allNotifications: {
+    1: {
       id: 1,
       title: 'Now Swap tokens directly in your wallet!',
       description:
         'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
       date: '12/8/2020',
       image: 'image url',
-      action: {
-        actionText: 'Start swapping',
-        actionFunction: swapsHandler,
-      },
+      actionText: 'Start swapping',
     },
-    {
+    2: {
       id: 2,
       title: 'MetaMask Mobile is here!',
       description:
         'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
       date: '12/8/2020',
-      action: {
-        actionText: 'Get the mobile app',
-        actionFunction: mobileHandler,
-      },
+      actionText: 'Get the mobile app',
     },
-    {
+    3: {
       id: 3,
       title: 'Help improve MetaMask',
       description: 'Please shae your experience in this 5 minute survey',
       date: '12/8/2020',
-      action: {
-        actionText: 'Start Survey',
-        actionFunction: npsHandler,
-      },
+      actionText: 'Start Survey',
     },
-  ],
+  },
+};
+
+const state1: NotificationState = {
+  notifications: {
+    1: {
+      id: 1,
+      title: 'Now Swap tokens directly in your wallet!',
+      description:
+        'MetaMask now aggregates multiple decentralized exchange aggregators to ensure you always get the best swap price with the lowest netwrok fees.',
+      date: '12/8/2020',
+      image: 'image url',
+      actionText: 'Start swapping',
+      isShown: true,
+    },
+    2: {
+      id: 2,
+      title: 'MetaMask Mobile is here!',
+      description:
+        'Sync with your extension wallet in seconds. Scan the QR code with your mobile camera to download the app.',
+      date: '12/8/2020',
+      actionText: 'Get the mobile app',
+      isShown: true,
+    },
+  },
 };
 
 describe('notification controller', () => {
-  let state: NotificationState;
   it('should add notifications to state', () => {
     const controller = new NotificationController(config1);
     expect(Object.keys(controller.state.notifications)).toHaveLength(2);
-    state = controller.state;
-  });
-  it('should not add new notifcation to state when actiontion is not present', () => {
-    try {
-      new NotificationController(config2);
-    } catch (error) {
-      expect(error.message).toEqual('Must have an actionText and actionFunction.');
-    }
+    const expectedStateNotifications: StateNotificationMap = {
+      1: {
+        ...config1.allNotifications[1],
+        isShown: false,
+      },
+      2: {
+        ...config1.allNotifications[2],
+        isShown: false,
+      },
+    };
+    expect(controller.state.notifications).toEqual(expectedStateNotifications);
   });
 
-  let controller: NotificationController;
   it('should add new notifcation to state', () => {
-    controller = new NotificationController(config3, state);
+    const controller = new NotificationController(config2, state1);
     expect(Object.keys(controller.state.notifications)).toHaveLength(3);
+    expect(controller.state.notifications[1].isShown).toBe(true);
+    expect(controller.state.notifications[2].isShown).toBe(true);
+    expect(controller.state.notifications[3].isShown).toBe(false);
   });
 
-  describe('calling the actionFunction', () => {
-    it('should return the actionFunction corresponding to the id', () => {
-      controller.actionCall(1);
-      expect(swapsHandler).toHaveBeenCalled();
-      controller.actionCall(2);
-      expect(mobileHandler).toHaveBeenCalled();
-      controller.actionCall(3);
-      expect(npsHandler).toHaveBeenCalled();
-      try {
-        expect(controller.actionCall(4)).toBeUndefined();
-      } catch (error) {
-        expect(error.message).toEqual('Incomplete notification.');
-      }
-    });
-  });
   describe('update viewed notifications', () => {
-    it('should update isshown status', () => {
+    it('should update isShown status', () => {
+      const controller = new NotificationController(config2);
       controller.updateViewed({ 1: true });
-      expect(controller.state.notifications[1].isShown).toBeTruthy();
-      expect(controller.state.notifications[2].isShown).toBeFalsy();
+      expect(controller.state.notifications[1].isShown).toBe(true);
+      expect(controller.state.notifications[2].isShown).toBe(false);
+      expect(controller.state.notifications[3].isShown).toBe(false);
     });
-    it('should update isshown of more than one notifications', () => {
+
+    it('should update isShown of more than one notifications', () => {
+      const controller = new NotificationController(config2);
       controller.updateViewed({ 2: true, 3: true });
-      expect(controller.state.notifications[2].isShown).toBeTruthy();
-      expect(controller.state.notifications[3].isShown).toBeTruthy();
+      expect(controller.state.notifications[1].isShown).toBe(false);
+      expect(controller.state.notifications[2].isShown).toBe(true);
+      expect(controller.state.notifications[3].isShown).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Compares to #329 

This PR makes some changes to the NotificationsController added with #329 

The following changes are made:
- The `actionCall` method, and therefore the `actionFunction` property are removed. These will be handled on the client side.
- With the removal of these methods, the `action` interface can be removed and the `Notification` interface can be simplified
- Notifications are now stored in state via an object, which simplifies the code for retrieving and updating state
- A fix is made within the `updateViewed` method