### PR TITLE
Update prettier from v2.1.1 to v2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "jest-environment-jsdom": "^25.0.0",
     "lint-staged": "^6.1.0",
     "nock": "^13.0.7",
-    "prettier": "^2.1.1",
+    "prettier": "^2.2.1",
     "sinon": "^9.2.4",
     "ts-jest": "^26.5.2",
     "typedoc": "^0.20.28",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5769,10 +5769,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.1.tgz#d9485dd5e499daa6cb547023b87a6cf51bee37d6"
-  integrity sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==
+prettier@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 pretty-format@^21.2.1:
   version "21.2.1"


### PR DESCRIPTION
This update includes support for TypeScript v4.1 features, such as template literal types.