### PR TITLE
Add controller messaging system

### DIFF
--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -9,7 +9,7 @@ type CountControllerState = {
 };
 
 type CountControllerEvent = {
-  type: `CountController:state-change`;
+  type: `CountController:stateChange`;
   payload: [CountControllerState, Patch[]];
 };
 
@@ -129,8 +129,8 @@ describe('BaseController', () => {
     const listener1 = sinon.stub();
     const listener2 = sinon.stub();
 
-    controllerMessenger.subscribe('CountController:state-change', listener1);
-    controllerMessenger.subscribe('CountController:state-change', listener2);
+    controllerMessenger.subscribe('CountController:stateChange', listener1);
+    controllerMessenger.subscribe('CountController:stateChange', listener2);
     controller.update(() => {
       return { count: 1 };
     });
@@ -151,8 +151,8 @@ describe('BaseController', () => {
     );
     const listener1 = sinon.stub();
 
-    controllerMessenger.subscribe('CountController:state-change', listener1);
-    controllerMessenger.subscribe('CountController:state-change', listener1);
+    controllerMessenger.subscribe('CountController:stateChange', listener1);
+    controllerMessenger.subscribe('CountController:stateChange', listener1);
 
     controller.update(() => {
       return { count: 1 };
@@ -172,8 +172,8 @@ describe('BaseController', () => {
     );
     const listener1 = sinon.stub();
 
-    controllerMessenger.subscribe('CountController:state-change', listener1);
-    controllerMessenger.unsubscribe('CountController:state-change', listener1);
+    controllerMessenger.subscribe('CountController:stateChange', listener1);
+    controllerMessenger.unsubscribe('CountController:stateChange', listener1);
     controller.update(() => {
       return { count: 1 };
     });
@@ -191,9 +191,9 @@ describe('BaseController', () => {
     );
     const listener1 = sinon.stub();
 
-    controllerMessenger.subscribe('CountController:state-change', listener1);
-    controllerMessenger.subscribe('CountController:state-change', listener1);
-    controllerMessenger.unsubscribe('CountController:state-change', listener1);
+    controllerMessenger.subscribe('CountController:stateChange', listener1);
+    controllerMessenger.subscribe('CountController:stateChange', listener1);
+    controllerMessenger.unsubscribe('CountController:stateChange', listener1);
     controller.update(() => {
       return { count: 1 };
     });
@@ -207,7 +207,7 @@ describe('BaseController', () => {
     const listener1 = sinon.stub();
 
     expect(() => {
-      controllerMessenger.unsubscribe('CountController:state-change', listener1);
+      controllerMessenger.unsubscribe('CountController:stateChange', listener1);
     }).toThrow();
   });
 
@@ -222,8 +222,8 @@ describe('BaseController', () => {
     const listener1 = sinon.stub();
     const listener2 = sinon.stub();
 
-    controllerMessenger.subscribe('CountController:state-change', listener1);
-    controllerMessenger.subscribe('CountController:state-change', listener2);
+    controllerMessenger.subscribe('CountController:stateChange', listener1);
+    controllerMessenger.subscribe('CountController:stateChange', listener2);
     controller.destroy();
     controller.update(() => {
       return { count: 1 };

--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -1,21 +1,27 @@
-import type { Draft } from 'immer';
+import type { Draft, Patch } from 'immer';
 import * as sinon from 'sinon';
 
 import { BaseController, getAnonymizedState, getPersistentState } from './BaseControllerV2';
+import { ControllerMessenger } from './ControllerMessenger';
 
-type MockControllerState = {
+type CountControllerState = {
   count: number;
 };
 
-const mockControllerStateMetadata = {
+type CountControllerEvent = {
+  type: `CountController:state-change`;
+  payload: [CountControllerState, Patch[]];
+};
+
+const CountControllerStateMetadata = {
   count: {
     persist: true,
     anonymous: true,
   },
 };
 
-class MockController extends BaseController<MockControllerState> {
-  update(callback: (state: Draft<MockControllerState>) => void | MockControllerState) {
+class MockController extends BaseController<'CountController', CountControllerState> {
+  update(callback: (state: Draft<CountControllerState>) => void | CountControllerState) {
     super.update(callback);
   }
 
@@ -26,19 +32,37 @@ class MockController extends BaseController<MockControllerState> {
 
 describe('BaseController', () => {
   it('should set initial state', () => {
-    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
+    const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const controller = new MockController(
+      controllerMessenger,
+      'CountController',
+      { count: 0 },
+      CountControllerStateMetadata,
+    );
 
     expect(controller.state).toEqual({ count: 0 });
   });
 
   it('should set initial schema', () => {
-    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
+    const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const controller = new MockController(
+      controllerMessenger,
+      'CountController',
+      { count: 0 },
+      CountControllerStateMetadata,
+    );
 
-    expect(controller.metadata).toEqual(mockControllerStateMetadata);
+    expect(controller.metadata).toEqual(CountControllerStateMetadata);
   });
 
   it('should not allow mutating state directly', () => {
-    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
+    const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const controller = new MockController(
+      controllerMessenger,
+      'CountController',
+      { count: 0 },
+      CountControllerStateMetadata,
+    );
 
     expect(() => {
       controller.state = { count: 1 };
@@ -46,7 +70,13 @@ describe('BaseController', () => {
   });
 
   it('should allow updating state by modifying draft', () => {
-    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
+    const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const controller = new MockController(
+      controllerMessenger,
+      'CountController',
+      { count: 0 },
+      CountControllerStateMetadata,
+    );
 
     controller.update((draft) => {
       draft.count += 1;
@@ -56,7 +86,13 @@ describe('BaseController', () => {
   });
 
   it('should allow updating state by return a value', () => {
-    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
+    const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const controller = new MockController(
+      controllerMessenger,
+      'CountController',
+      { count: 0 },
+      CountControllerStateMetadata,
+    );
 
     controller.update(() => {
       return { count: 1 };
@@ -66,7 +102,13 @@ describe('BaseController', () => {
   });
 
   it('should throw an error if update callback modifies draft and returns value', () => {
-    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
+    const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const controller = new MockController(
+      controllerMessenger,
+      'CountController',
+      { count: 0 },
+      CountControllerStateMetadata,
+    );
 
     expect(() => {
       controller.update((draft) => {
@@ -77,7 +119,13 @@ describe('BaseController', () => {
   });
 
   it('should inform subscribers of state changes', () => {
-    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
+    const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const controller = new MockController(
+      controllerMessenger,
+      'CountController',
+      { count: 0 },
+      CountControllerStateMetadata,
+    );
     const listener1 = sinon.stub();
     const listener2 = sinon.stub();
 
@@ -94,7 +142,13 @@ describe('BaseController', () => {
   });
 
   it('should inform a subscriber of each state change once even after multiple subscriptions', () => {
-    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
+    const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const controller = new MockController(
+      controllerMessenger,
+      'CountController',
+      { count: 0 },
+      CountControllerStateMetadata,
+    );
     const listener1 = sinon.stub();
 
     controller.subscribe(listener1);
@@ -108,7 +162,13 @@ describe('BaseController', () => {
   });
 
   it('should no longer inform a subscriber about state changes after unsubscribing', () => {
-    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
+    const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const controller = new MockController(
+      controllerMessenger,
+      'CountController',
+      { count: 0 },
+      CountControllerStateMetadata,
+    );
     const listener1 = sinon.stub();
 
     controller.subscribe(listener1);
@@ -121,7 +181,13 @@ describe('BaseController', () => {
   });
 
   it('should no longer inform a subscriber about state changes after unsubscribing once, even if they subscribed many times', () => {
-    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
+    const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const controller = new MockController(
+      controllerMessenger,
+      'CountController',
+      { count: 0 },
+      CountControllerStateMetadata,
+    );
     const listener1 = sinon.stub();
 
     controller.subscribe(listener1);
@@ -134,17 +200,29 @@ describe('BaseController', () => {
     expect(listener1.callCount).toEqual(0);
   });
 
-  it('should allow unsubscribing listeners who were never subscribed', () => {
-    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
+  it('should throw when unsubscribing listener who was never subscribed', () => {
+    const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const controller = new MockController(
+      controllerMessenger,
+      'CountController',
+      { count: 0 },
+      CountControllerStateMetadata,
+    );
     const listener1 = sinon.stub();
 
     expect(() => {
       controller.unsubscribe(listener1);
-    }).not.toThrow();
+    }).toThrow();
   });
 
   it('should no longer update subscribers after being destroyed', () => {
-    const controller = new MockController({ count: 0 }, mockControllerStateMetadata);
+    const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const controller = new MockController(
+      controllerMessenger,
+      'CountController',
+      { count: 0 },
+      CountControllerStateMetadata,
+    );
     const listener1 = sinon.stub();
     const listener2 = sinon.stub();
 

--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -129,8 +129,8 @@ describe('BaseController', () => {
     const listener1 = sinon.stub();
     const listener2 = sinon.stub();
 
-    controller.subscribe(listener1);
-    controller.subscribe(listener2);
+    controllerMessenger.subscribe('CountController:state-change', listener1);
+    controllerMessenger.subscribe('CountController:state-change', listener2);
     controller.update(() => {
       return { count: 1 };
     });
@@ -151,8 +151,9 @@ describe('BaseController', () => {
     );
     const listener1 = sinon.stub();
 
-    controller.subscribe(listener1);
-    controller.subscribe(listener1);
+    controllerMessenger.subscribe('CountController:state-change', listener1);
+    controllerMessenger.subscribe('CountController:state-change', listener1);
+
     controller.update(() => {
       return { count: 1 };
     });
@@ -171,8 +172,8 @@ describe('BaseController', () => {
     );
     const listener1 = sinon.stub();
 
-    controller.subscribe(listener1);
-    controller.unsubscribe(listener1);
+    controllerMessenger.subscribe('CountController:state-change', listener1);
+    controllerMessenger.unsubscribe('CountController:state-change', listener1);
     controller.update(() => {
       return { count: 1 };
     });
@@ -190,9 +191,9 @@ describe('BaseController', () => {
     );
     const listener1 = sinon.stub();
 
-    controller.subscribe(listener1);
-    controller.subscribe(listener1);
-    controller.unsubscribe(listener1);
+    controllerMessenger.subscribe('CountController:state-change', listener1);
+    controllerMessenger.subscribe('CountController:state-change', listener1);
+    controllerMessenger.unsubscribe('CountController:state-change', listener1);
     controller.update(() => {
       return { count: 1 };
     });
@@ -202,16 +203,11 @@ describe('BaseController', () => {
 
   it('should throw when unsubscribing listener who was never subscribed', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
-    const controller = new MockController(
-      controllerMessenger,
-      'CountController',
-      { count: 0 },
-      CountControllerStateMetadata,
-    );
+    new MockController(controllerMessenger, 'CountController', { count: 0 }, CountControllerStateMetadata);
     const listener1 = sinon.stub();
 
     expect(() => {
-      controller.unsubscribe(listener1);
+      controllerMessenger.unsubscribe('CountController:state-change', listener1);
     }).toThrow();
   });
 
@@ -226,8 +222,8 @@ describe('BaseController', () => {
     const listener1 = sinon.stub();
     const listener2 = sinon.stub();
 
-    controller.subscribe(listener1);
-    controller.subscribe(listener2);
+    controllerMessenger.subscribe('CountController:state-change', listener1);
+    controllerMessenger.subscribe('CountController:state-change', listener2);
     controller.destroy();
     controller.update(() => {
       return { count: 1 };

--- a/src/BaseControllerV2.ts
+++ b/src/BaseControllerV2.ts
@@ -141,24 +141,6 @@ export class BaseController<N extends string, S extends Record<string, unknown>>
   }
 
   /**
-   * Adds new listener to be notified of state changes
-   *
-   * @param listener - Callback triggered when state changes
-   */
-  subscribe(listener: Listener<S>) {
-    this.messagingSystem.subscribe(`${this.name}:state-change` as `${N}:state-change`, listener);
-  }
-
-  /**
-   * Removes existing listener from receiving state changes
-   *
-   * @param listener - Callback to remove
-   */
-  unsubscribe(listener: Listener<S>) {
-    this.messagingSystem.unsubscribe(`${this.name}:state-change` as `${N}:state-change`, listener);
-  }
-
-  /**
    * Updates controller state. Accepts a callback that is passed a draft copy
    * of the controller state. If a value is returned, it is set as the new
    * state. Otherwise, any changes made within that callback to the draft are

--- a/src/BaseControllerV2.ts
+++ b/src/BaseControllerV2.ts
@@ -101,7 +101,7 @@ type Json = null | boolean | number | string | Json[] | { [prop: string]: Json }
 export class BaseController<N extends string, S extends Record<string, unknown>> {
   private internalState: IsJsonable<S>;
 
-  private messagingSystem: ControllerMessenger<never, { type: `${N}:state-change`; payload: [S, Patch[]] }>;
+  private messagingSystem: ControllerMessenger<never, { type: `${N}:stateChange`; payload: [S, Patch[]] }>;
 
   private name: N;
 
@@ -116,7 +116,7 @@ export class BaseController<N extends string, S extends Record<string, unknown>>
    *   and which parts should be persisted.
    */
   constructor(
-    messagingSystem: ControllerMessenger<never, { type: `${N}:state-change`; payload: [S, Patch[]] }>,
+    messagingSystem: ControllerMessenger<never, { type: `${N}:stateChange`; payload: [S, Patch[]] }>,
     name: N,
     state: IsJsonable<S>,
     metadata: StateMetadata<S>,
@@ -152,7 +152,7 @@ export class BaseController<N extends string, S extends Record<string, unknown>>
   protected update(callback: (state: Draft<IsJsonable<S>>) => void | IsJsonable<S>) {
     const [nextState, patches] = produceWithPatches(this.internalState, callback);
     this.internalState = nextState as IsJsonable<S>;
-    this.messagingSystem.publish(`${this.name}:state-change` as `${N}:state-change`, nextState as S, patches);
+    this.messagingSystem.publish(`${this.name}:stateChange` as `${N}:stateChange`, nextState as S, patches);
   }
 
   /**
@@ -165,7 +165,7 @@ export class BaseController<N extends string, S extends Record<string, unknown>>
    * listeners from being garbage collected.
    */
   protected destroy() {
-    this.messagingSystem.clearEventSubscriptions(`${this.name}:state-change` as `${N}:state-change`);
+    this.messagingSystem.clearEventSubscriptions(`${this.name}:stateChange` as `${N}:stateChange`);
   }
 }
 

--- a/src/ControllerMessenger.test.ts
+++ b/src/ControllerMessenger.test.ts
@@ -1,0 +1,287 @@
+import * as sinon from 'sinon';
+
+import { ControllerMessenger } from './ControllerMessenger';
+
+describe('ControllerMessenger', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should allow registering and calling an action handler', () => {
+    type CountAction = { type: 'count'; handler: (increment: number) => void };
+    const controllerMessenger = new ControllerMessenger<CountAction, never>();
+
+    let count = 0;
+    controllerMessenger.registerActionHandler('count', (increment: number) => {
+      count += increment;
+    });
+    controllerMessenger.call('count', 1);
+
+    expect(count).toEqual(1);
+  });
+
+  it('should allow registering and calling multiple different action handlers', () => {
+    type MessageAction =
+      | { type: 'concat'; handler: (message: string) => void }
+      | { type: 'reset'; handler: (initialMessage: string) => void };
+    const controllerMessenger = new ControllerMessenger<MessageAction, never>();
+
+    let message = '';
+    controllerMessenger.registerActionHandler('reset', (initialMessage: string) => {
+      message = initialMessage;
+    });
+    controllerMessenger.registerActionHandler('concat', (s: string) => {
+      message += s;
+    });
+
+    controllerMessenger.call('reset', 'hello');
+    controllerMessenger.call('concat', ', world');
+
+    expect(message).toEqual('hello, world');
+  });
+
+  it('should allow registering and calling an action handler with no parameters', () => {
+    type IncrementAction = { type: 'increment'; handler: () => void };
+    const controllerMessenger = new ControllerMessenger<IncrementAction, never>();
+
+    let count = 0;
+    controllerMessenger.registerActionHandler('increment', () => {
+      count += 1;
+    });
+    controllerMessenger.call('increment');
+
+    expect(count).toEqual(1);
+  });
+
+  it('should allow registering and calling an action handler with multiple parameters', () => {
+    type MessageAction = { type: 'message'; handler: (to: string, message: string) => void };
+    const controllerMessenger = new ControllerMessenger<MessageAction, never>();
+
+    const messages: Record<string, string> = {};
+    controllerMessenger.registerActionHandler('message', (to, message) => {
+      messages[to] = message;
+    });
+    controllerMessenger.call('message', '0x123', 'hello');
+
+    expect(messages['0x123']).toEqual('hello');
+  });
+
+  it('should allow registering and calling an action handler with a return value', () => {
+    type AddAction = { type: 'add'; handler: (a: number, b: number) => number };
+    const controllerMessenger = new ControllerMessenger<AddAction, never>();
+
+    controllerMessenger.registerActionHandler('add', (a, b) => {
+      return a + b;
+    });
+    const result = controllerMessenger.call('add', 5, 10);
+
+    expect(result).toEqual(15);
+  });
+
+  it('should not allow registering multiple action handlers under the same name', () => {
+    type PingAction = { type: 'ping'; handler: () => void };
+    const controllerMessenger = new ControllerMessenger<PingAction, never>();
+
+    controllerMessenger.registerActionHandler('ping', () => undefined);
+
+    expect(() => {
+      controllerMessenger.registerActionHandler('ping', () => undefined);
+    }).toThrow();
+  });
+
+  it('should throw when calling unregistered action', () => {
+    type PingAction = { type: 'ping'; handler: () => void };
+    const controllerMessenger = new ControllerMessenger<PingAction, never>();
+
+    expect(() => {
+      controllerMessenger.call('ping');
+    }).toThrow();
+  });
+
+  it('should throw when calling an action that has been unregistered', () => {
+    type PingAction = { type: 'ping'; handler: () => void };
+    const controllerMessenger = new ControllerMessenger<PingAction, never>();
+
+    expect(() => {
+      controllerMessenger.call('ping');
+    }).toThrow();
+
+    let pingCount = 0;
+    controllerMessenger.registerActionHandler('ping', () => {
+      pingCount += 1;
+    });
+
+    controllerMessenger.unregisterActionHandler('ping');
+
+    expect(() => {
+      controllerMessenger.call('ping');
+    }).toThrow();
+    expect(pingCount).toEqual(0);
+  });
+
+  it('should throw when calling an action after actions have been reset', () => {
+    type PingAction = { type: 'ping'; handler: () => void };
+    const controllerMessenger = new ControllerMessenger<PingAction, never>();
+
+    expect(() => {
+      controllerMessenger.call('ping');
+    }).toThrow();
+
+    let pingCount = 0;
+    controllerMessenger.registerActionHandler('ping', () => {
+      pingCount += 1;
+    });
+
+    controllerMessenger.clearActions();
+
+    expect(() => {
+      controllerMessenger.call('ping');
+    }).toThrow();
+    expect(pingCount).toEqual(0);
+  });
+
+  it('should publish event to subscriber', () => {
+    type MessageEvent = { type: 'message'; payload: [string] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+
+    const handler = sinon.stub();
+    controllerMessenger.subscribe('message', handler);
+    controllerMessenger.publish('message', 'hello');
+
+    expect(handler.calledWithExactly('hello')).toBeTruthy();
+    expect(handler.callCount).toEqual(1);
+  });
+
+  it('should allow publishing multiple different events to subscriber', () => {
+    type MessageEvent = { type: 'message'; payload: [string] } | { type: 'ping'; payload: [] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+
+    const messageHandler = sinon.stub();
+    const pingHandler = sinon.stub();
+    controllerMessenger.subscribe('message', messageHandler);
+    controllerMessenger.subscribe('ping', pingHandler);
+
+    controllerMessenger.publish('message', 'hello');
+    controllerMessenger.publish('ping');
+
+    expect(messageHandler.calledWithExactly('hello')).toBeTruthy();
+    expect(messageHandler.callCount).toEqual(1);
+    expect(pingHandler.calledWithExactly()).toBeTruthy();
+    expect(pingHandler.callCount).toEqual(1);
+  });
+
+  it('should publish event with no payload to subscriber', () => {
+    type PingEvent = { type: 'ping'; payload: [] };
+    const controllerMessenger = new ControllerMessenger<never, PingEvent>();
+
+    const handler = sinon.stub();
+    controllerMessenger.subscribe('ping', handler);
+    controllerMessenger.publish('ping');
+
+    expect(handler.calledWithExactly()).toBeTruthy();
+    expect(handler.callCount).toEqual(1);
+  });
+
+  it('should publish event with multiple payload parameters to subscriber', () => {
+    type MessageEvent = { type: 'message'; payload: [string, string] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+
+    const handler = sinon.stub();
+    controllerMessenger.subscribe('message', handler);
+    controllerMessenger.publish('message', 'hello', 'there');
+
+    expect(handler.calledWithExactly('hello', 'there')).toBeTruthy();
+    expect(handler.callCount).toEqual(1);
+  });
+
+  it('should publish event once to subscriber even if subscribed multiple times', () => {
+    type MessageEvent = { type: 'message'; payload: [string] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+
+    const handler = sinon.stub();
+    controllerMessenger.subscribe('message', handler);
+    controllerMessenger.subscribe('message', handler);
+    controllerMessenger.publish('message', 'hello');
+
+    expect(handler.calledWithExactly('hello')).toBeTruthy();
+    expect(handler.callCount).toEqual(1);
+  });
+
+  it('should publish event to many subscribers', () => {
+    type MessageEvent = { type: 'message'; payload: [string] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+
+    const handler1 = sinon.stub();
+    const handler2 = sinon.stub();
+    controllerMessenger.subscribe('message', handler1);
+    controllerMessenger.subscribe('message', handler2);
+    controllerMessenger.publish('message', 'hello');
+
+    expect(handler1.calledWithExactly('hello')).toBeTruthy();
+    expect(handler1.callCount).toEqual(1);
+    expect(handler2.calledWithExactly('hello')).toBeTruthy();
+    expect(handler2.callCount).toEqual(1);
+  });
+
+  it('should not call subscriber after unsubscribing', () => {
+    type MessageEvent = { type: 'message'; payload: [string] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+
+    const handler = sinon.stub();
+    controllerMessenger.subscribe('message', handler);
+    controllerMessenger.unsubscribe('message', handler);
+    controllerMessenger.publish('message', 'hello');
+
+    expect(handler.callCount).toEqual(0);
+  });
+
+  it('should throw when unsubscribing when there are no subscriptions', () => {
+    type MessageEvent = { type: 'message'; payload: [string] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+
+    const handler = sinon.stub();
+    expect(() => controllerMessenger.unsubscribe('message', handler)).toThrow();
+  });
+
+  it('should throw when unsubscribing a handler that is not subscribed', () => {
+    type MessageEvent = { type: 'message'; payload: [string] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+
+    const handler1 = sinon.stub();
+    const handler2 = sinon.stub();
+    controllerMessenger.subscribe('message', handler1);
+
+    expect(() => controllerMessenger.unsubscribe('message', handler2)).toThrow();
+  });
+
+  it('should not call subscriber after clearing event subscriptions', () => {
+    type MessageEvent = { type: 'message'; payload: [string] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+
+    const handler = sinon.stub();
+    controllerMessenger.subscribe('message', handler);
+    controllerMessenger.clearEventSubscriptions('message');
+    controllerMessenger.publish('message', 'hello');
+
+    expect(handler.callCount).toEqual(0);
+  });
+
+  it('should not throw when clearing event that has no subscriptions', () => {
+    type MessageEvent = { type: 'message'; payload: [string] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+
+    expect(() => controllerMessenger.clearEventSubscriptions('message')).not.toThrow();
+  });
+
+  it('should not call subscriber after resetting subscriptions', () => {
+    type MessageEvent = { type: 'message'; payload: [string] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+
+    const handler = sinon.stub();
+    controllerMessenger.subscribe('message', handler);
+    controllerMessenger.clearSubscriptions();
+    controllerMessenger.publish('message', 'hello');
+
+    expect(handler.callCount).toEqual(0);
+  });
+});

--- a/src/ControllerMessenger.ts
+++ b/src/ControllerMessenger.ts
@@ -23,34 +23,76 @@ export class ControllerMessenger<Action extends ActionConstraint, Event extends 
 
   private events = new Map<Event['type'], Set<unknown>>();
 
-  registerActionHandler<T extends Action['type']>(action: T, handler: ActionHandler<Action, T>) {
-    if (this.actions.has(action)) {
-      throw new Error(`A handler for ${action} has already been registered`);
+  /**
+   * Register an action handler.
+   *
+   * This will make the registered function available to call via the `call` method.
+   *
+   * @param actionType - The action type. This is a unqiue identifier for this action.
+   * @param handler- The action handler. This function gets called when the `call` method is
+   *   invoked with the given action type.
+   * @throws Will throw when a handler has been registered for this action type already.
+   */
+  registerActionHandler<T extends Action['type']>(actionType: T, handler: ActionHandler<Action, T>) {
+    if (this.actions.has(actionType)) {
+      throw new Error(`A handler for ${actionType} has already been registered`);
     }
-    this.actions.set(action, handler);
+    this.actions.set(actionType, handler);
   }
 
-  unregisterActionHandler<T extends Action['type']>(action: T) {
-    this.actions.delete(action);
+  /**
+   * Unregister an action handler.
+   *
+   * This will prevent this action from being called.
+   *
+   * @param actionType - The action type. This is a unqiue identifier for this action.
+   */
+  unregisterActionHandler<T extends Action['type']>(actionType: T) {
+    this.actions.delete(actionType);
   }
 
+  /**
+   * Unregister all action handlers.
+   *
+   * This prevents all actions from being called.
+   */
   clearActions() {
     this.actions.clear();
   }
 
+  /**
+   * Call an action.
+   *
+   * This function will call the action handler corresponding to the given action type, passing
+   * along any parameters given.
+   *
+   * @param actionType - The action type. This is a unqiue identifier for this action.
+   * @param params - The action parameters. These must match the type of the parameters of the
+   *   registered action handler.
+   * @throws Will throw when no handler has been registered for the given type.
+   */
   call<T extends Action['type']>(
-    action: T,
+    actionType: T,
     ...params: ExtractActionParameters<Action, T>
   ): ExtractActionResponse<Action, T> {
-    const handler = this.actions.get(action) as ActionHandler<Action, T>;
+    const handler = this.actions.get(actionType) as ActionHandler<Action, T>;
     if (!handler) {
-      throw new Error(`A handler for ${action} has not been registered`);
+      throw new Error(`A handler for ${actionType} has not been registered`);
     }
     return handler(...params);
   }
 
-  publish<E extends Event['type']>(event: E, ...payload: ExtractEventPayload<Event, E>) {
-    const subscribers = this.events.get(event) as Set<ExtractEvenHandler<Event, E>>;
+  /**
+   * Publish an event.
+   *
+   * Publishes the given payload to all subscribers of the given event type.
+   *
+   * @param eventType - The event type. This is a unique identifier for this event.
+   * @param payload - The event payload. The type of the parameters for each event handler must
+   *   match the type of this payload.
+   */
+  publish<E extends Event['type']>(eventType: E, ...payload: ExtractEventPayload<Event, E>) {
+    const subscribers = this.events.get(eventType) as Set<ExtractEvenHandler<Event, E>>;
 
     if (subscribers) {
       for (const eventHandler of subscribers) {
@@ -59,30 +101,60 @@ export class ControllerMessenger<Action extends ActionConstraint, Event extends 
     }
   }
 
-  subscribe<E extends Event['type']>(event: E, handler: ExtractEvenHandler<Event, E>) {
-    let subscribers = this.events.get(event);
+  /**
+   * Subscribe to an event.
+   *
+   * Registers the given function as an event handler for the given event type.
+   *
+   * @param eventType - The event type. This is a unique identifier for this event.
+   * @param handler - The event handler. The type of the parameters for this event handler must
+   *   match the type of the payload for this event type.
+   */
+  subscribe<E extends Event['type']>(eventType: E, handler: ExtractEvenHandler<Event, E>) {
+    let subscribers = this.events.get(eventType);
     if (!subscribers) {
       subscribers = new Set();
     }
     subscribers.add(handler);
-    this.events.set(event, subscribers);
+    this.events.set(eventType, subscribers);
   }
 
-  unsubscribe<E extends Event['type']>(event: E, handler: ExtractEvenHandler<Event, E>) {
-    const subscribers = this.events.get(event);
+  /**
+   * Unsubscribe from an event.
+   *
+   * Unregisters the given function as an event handler for the given event.
+   *
+   * @param eventType - The event type. This is a unique identifier for this event.
+   * @param handler - The event handler to unregister.
+   * @throws Will throw when the given event handler is not registered for this event.
+   */
+  unsubscribe<E extends Event['type']>(eventType: E, handler: ExtractEvenHandler<Event, E>) {
+    const subscribers = this.events.get(eventType);
 
     if (!subscribers || !subscribers.has(handler)) {
-      throw new Error(`Subscription not found for event: '${event}'`);
+      throw new Error(`Subscription not found for event: '${eventType}'`);
     }
 
     subscribers.delete(handler);
-    this.events.set(event, subscribers);
+    this.events.set(eventType, subscribers);
   }
 
-  clearEventSubscriptions<E extends Event['type']>(event: E) {
-    this.events.delete(event);
+  /**
+   * Clear subscriptions for a specific event.
+   *
+   * This will remove all subscribed handlers for this event.
+   *
+   * @param eventType - The event type. This is a unique identifier for this event.
+   */
+  clearEventSubscriptions<E extends Event['type']>(eventType: E) {
+    this.events.delete(eventType);
   }
 
+  /**
+   * Clear all subscriptions.
+   *
+   * This will remove all subscribed handlers for all events.
+   */
   clearSubscriptions() {
     this.events.clear();
   }

--- a/src/ControllerMessenger.ts
+++ b/src/ControllerMessenger.ts
@@ -1,19 +1,15 @@
-export type ActionHandler<Action, ActionType> = (
+type ActionHandler<Action, ActionType> = (
   ...args: ExtractActionParameters<Action, ActionType>
 ) => ExtractActionResponse<Action, ActionType>;
-export type ExtractActionParameters<Action, T> = Action extends { type: T; handler: (...args: infer H) => any }
-  ? H
-  : never;
-export type ExtractActionResponse<Action, T> = Action extends { type: T; handler: (...args: any) => infer H }
-  ? H
-  : never;
+type ExtractActionParameters<Action, T> = Action extends { type: T; handler: (...args: infer H) => any } ? H : never;
+type ExtractActionResponse<Action, T> = Action extends { type: T; handler: (...args: any) => infer H } ? H : never;
 
-export type ExtractEvenHandler<Event, T> = Event extends { type: T; payload: infer P }
+type ExtractEvenHandler<Event, T> = Event extends { type: T; payload: infer P }
   ? P extends any[]
     ? (...payload: P) => void
     : never
   : never;
-export type ExtractEventPayload<Event, T> = Event extends { type: T; payload: infer P } ? P : never;
+type ExtractEventPayload<Event, T> = Event extends { type: T; payload: infer P } ? P : never;
 
 type ActionConstraint = { type: string; handler: (...args: any) => unknown };
 type EventConstraint = { type: string; payload: unknown[] };

--- a/src/ControllerMessenger.ts
+++ b/src/ControllerMessenger.ts
@@ -1,0 +1,89 @@
+export type ActionHandler<Action, ActionType> = (
+  ...args: ExtractActionParameters<Action, ActionType>
+) => ExtractActionResponse<Action, ActionType>;
+export type ExtractActionParameters<Action, T> = Action extends { type: T; handler: (...args: infer H) => any }
+  ? H
+  : never;
+export type ExtractActionResponse<Action, T> = Action extends { type: T; handler: (...args: any) => infer H }
+  ? H
+  : never;
+
+export type ExtractEvenHandler<Event, T> = Event extends { type: T; payload: infer P }
+  ? P extends any[]
+    ? (...payload: P) => void
+    : never
+  : never;
+export type ExtractEventPayload<Event, T> = Event extends { type: T; payload: infer P } ? P : never;
+
+type ActionConstraint = { type: string; handler: (...args: any) => unknown };
+type EventConstraint = { type: string; payload: unknown[] };
+
+export class ControllerMessenger<Action extends ActionConstraint, Event extends EventConstraint> {
+  private actions = new Map<Action['type'], unknown>();
+
+  private events = new Map<Event['type'], Set<unknown>>();
+
+  registerActionHandler<T extends Action['type']>(action: T, handler: ActionHandler<Action, T>) {
+    if (this.actions.has(action)) {
+      throw new Error(`A handler for ${action} has already been registered`);
+    }
+    this.actions.set(action, handler);
+  }
+
+  unregisterActionHandler<T extends Action['type']>(action: T) {
+    this.actions.delete(action);
+  }
+
+  clearActions() {
+    this.actions.clear();
+  }
+
+  call<T extends Action['type']>(
+    action: T,
+    ...params: ExtractActionParameters<Action, T>
+  ): ExtractActionResponse<Action, T> {
+    const handler = this.actions.get(action) as ActionHandler<Action, T>;
+    if (!handler) {
+      throw new Error(`A handler for ${action} has not been registered`);
+    }
+    return handler(...params);
+  }
+
+  publish<E extends Event['type']>(event: E, ...payload: ExtractEventPayload<Event, E>) {
+    const subscribers = this.events.get(event) as Set<ExtractEvenHandler<Event, E>>;
+
+    if (subscribers) {
+      for (const eventHandler of subscribers) {
+        eventHandler(...payload);
+      }
+    }
+  }
+
+  subscribe<E extends Event['type']>(event: E, handler: ExtractEvenHandler<Event, E>) {
+    let subscribers = this.events.get(event);
+    if (!subscribers) {
+      subscribers = new Set();
+    }
+    subscribers.add(handler);
+    this.events.set(event, subscribers);
+  }
+
+  unsubscribe<E extends Event['type']>(event: E, handler: ExtractEvenHandler<Event, E>) {
+    const subscribers = this.events.get(event);
+
+    if (!subscribers || !subscribers.has(handler)) {
+      throw new Error(`Subscription not found for event: '${event}'`);
+    }
+
+    subscribers.delete(handler);
+    this.events.set(event, subscribers);
+  }
+
+  clearEventSubscriptions<E extends Event['type']>(event: E) {
+    this.events.delete(event);
+  }
+
+  clearSubscriptions() {
+    this.events.clear();
+  }
+}

--- a/src/ControllerMessenger.ts
+++ b/src/ControllerMessenger.ts
@@ -18,6 +18,13 @@ export type ExtractEventPayload<Event, T> = Event extends { type: T; payload: in
 type ActionConstraint = { type: string; handler: (...args: any) => unknown };
 type EventConstraint = { type: string; payload: unknown[] };
 
+/**
+ * A messaging system for controllers.
+ *
+ * The controller messenger allows registering functions as 'actions' that can be called elsewhere,
+ * and it allows publishing and subscribing to events. Both actions and events are identified by
+ * unique strings.
+ */
 export class ControllerMessenger<Action extends ActionConstraint, Event extends EventConstraint> {
   private actions = new Map<Action['type'], unknown>();
 


### PR DESCRIPTION
Adds a controller messaging system, which will be used to facilitate inter-controller communication. The controller messenger acts as a message broker, passing actions and events back and forth between controllers. It is _fully type safe_.

This idea was described in the [Controller Messaging System proposal](https://www.notion.so/Controller-Messaging-System-617efb02b9e54bd0a0b0e44c6f776d85).

This controller messenger doesn't yet support attenuation, so it's not yet possible to restrict which actions and events are interacted with. That will be coming in a later PR.