### PR TITLE
Add restricted controller messenger

### DIFF
--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -577,6 +577,7 @@ describe('getPersistentState', () => {
     // The 'VisitorController' records strings that represent visitors.
     // The 'VisitorOverflowController' monitors the 'VisitorController' to ensure the number of
     // visitors doesn't exceed the maximum capacity. If it does, it will clear out all visitors.
+
     type VisitorControllerState = {
       visitors: string[];
     };
@@ -588,12 +589,14 @@ describe('getPersistentState', () => {
       type: `VisitorController:stateChange`;
       payload: [VisitorControllerState, Patch[]];
     };
+
     const visitorControllerStateMetadata = {
       visitors: {
         persist: true,
         anonymous: true,
       },
     };
+
     class VisitorController extends BaseController<'VisitorController', VisitorControllerState> {
       constructor(
         messagingSystem: RestrictedControllerMessenger<

--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -33,8 +33,13 @@ class MockController extends BaseController<'CountController', CountControllerSt
 describe('BaseController', () => {
   it('should set initial state', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'CountController',
+      [],
+      ['CountController:stateChange'],
+    );
     const controller = new MockController({
-      messenger: controllerMessenger,
+      messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
       metadata: CountControllerStateMetadata,
@@ -45,8 +50,13 @@ describe('BaseController', () => {
 
   it('should set initial schema', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'CountController',
+      [],
+      ['CountController:stateChange'],
+    );
     const controller = new MockController({
-      messenger: controllerMessenger,
+      messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
       metadata: CountControllerStateMetadata,
@@ -57,8 +67,13 @@ describe('BaseController', () => {
 
   it('should not allow mutating state directly', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'CountController',
+      [],
+      ['CountController:stateChange'],
+    );
     const controller = new MockController({
-      messenger: controllerMessenger,
+      messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
       metadata: CountControllerStateMetadata,
@@ -71,8 +86,13 @@ describe('BaseController', () => {
 
   it('should allow updating state by modifying draft', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'CountController',
+      [],
+      ['CountController:stateChange'],
+    );
     const controller = new MockController({
-      messenger: controllerMessenger,
+      messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
       metadata: CountControllerStateMetadata,
@@ -87,8 +107,13 @@ describe('BaseController', () => {
 
   it('should allow updating state by return a value', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'CountController',
+      [],
+      ['CountController:stateChange'],
+    );
     const controller = new MockController({
-      messenger: controllerMessenger,
+      messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
       metadata: CountControllerStateMetadata,
@@ -103,8 +128,13 @@ describe('BaseController', () => {
 
   it('should throw an error if update callback modifies draft and returns value', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'CountController',
+      [],
+      ['CountController:stateChange'],
+    );
     const controller = new MockController({
-      messenger: controllerMessenger,
+      messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
       metadata: CountControllerStateMetadata,
@@ -122,8 +152,13 @@ describe('BaseController', () => {
 
   it('should inform subscribers of state changes', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'CountController',
+      [],
+      ['CountController:stateChange'],
+    );
     const controller = new MockController({
-      messenger: controllerMessenger,
+      messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
       metadata: CountControllerStateMetadata,
@@ -145,8 +180,13 @@ describe('BaseController', () => {
 
   it('should inform a subscriber of each state change once even after multiple subscriptions', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'CountController',
+      [],
+      ['CountController:stateChange'],
+    );
     const controller = new MockController({
-      messenger: controllerMessenger,
+      messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
       metadata: CountControllerStateMetadata,
@@ -166,8 +206,13 @@ describe('BaseController', () => {
 
   it('should no longer inform a subscriber about state changes after unsubscribing', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'CountController',
+      [],
+      ['CountController:stateChange'],
+    );
     const controller = new MockController({
-      messenger: controllerMessenger,
+      messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
       metadata: CountControllerStateMetadata,
@@ -185,8 +230,13 @@ describe('BaseController', () => {
 
   it('should no longer inform a subscriber about state changes after unsubscribing once, even if they subscribed many times', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'CountController',
+      [],
+      ['CountController:stateChange'],
+    );
     const controller = new MockController({
-      messenger: controllerMessenger,
+      messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
       metadata: CountControllerStateMetadata,
@@ -205,8 +255,13 @@ describe('BaseController', () => {
 
   it('should throw when unsubscribing listener who was never subscribed', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'CountController',
+      [],
+      ['CountController:stateChange'],
+    );
     new MockController({
-      messenger: controllerMessenger,
+      messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
       metadata: CountControllerStateMetadata,
@@ -220,8 +275,13 @@ describe('BaseController', () => {
 
   it('should no longer update subscribers after being destroyed', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'CountController',
+      [],
+      ['CountController:stateChange'],
+    );
     const controller = new MockController({
-      messenger: controllerMessenger,
+      messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
       metadata: CountControllerStateMetadata,

--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -33,11 +33,11 @@ class MockController extends BaseController<'CountController', CountControllerSt
 describe('BaseController', () => {
   it('should set initial state', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'CountController',
-      [],
-      ['CountController:stateChange'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'CountController',
+      allowedActions: [],
+      allowedEvents: ['CountController:stateChange'],
+    });
     const controller = new MockController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
@@ -50,11 +50,11 @@ describe('BaseController', () => {
 
   it('should set initial schema', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'CountController',
-      [],
-      ['CountController:stateChange'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'CountController',
+      allowedActions: [],
+      allowedEvents: ['CountController:stateChange'],
+    });
     const controller = new MockController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
@@ -67,11 +67,11 @@ describe('BaseController', () => {
 
   it('should not allow mutating state directly', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'CountController',
-      [],
-      ['CountController:stateChange'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'CountController',
+      allowedActions: [],
+      allowedEvents: ['CountController:stateChange'],
+    });
     const controller = new MockController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
@@ -86,11 +86,11 @@ describe('BaseController', () => {
 
   it('should allow updating state by modifying draft', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'CountController',
-      [],
-      ['CountController:stateChange'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'CountController',
+      allowedActions: [],
+      allowedEvents: ['CountController:stateChange'],
+    });
     const controller = new MockController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
@@ -107,11 +107,11 @@ describe('BaseController', () => {
 
   it('should allow updating state by return a value', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'CountController',
-      [],
-      ['CountController:stateChange'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'CountController',
+      allowedActions: [],
+      allowedEvents: ['CountController:stateChange'],
+    });
     const controller = new MockController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
@@ -128,11 +128,11 @@ describe('BaseController', () => {
 
   it('should throw an error if update callback modifies draft and returns value', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'CountController',
-      [],
-      ['CountController:stateChange'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'CountController',
+      allowedActions: [],
+      allowedEvents: ['CountController:stateChange'],
+    });
     const controller = new MockController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
@@ -152,11 +152,11 @@ describe('BaseController', () => {
 
   it('should inform subscribers of state changes', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'CountController',
-      [],
-      ['CountController:stateChange'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'CountController',
+      allowedActions: [],
+      allowedEvents: ['CountController:stateChange'],
+    });
     const controller = new MockController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
@@ -180,11 +180,11 @@ describe('BaseController', () => {
 
   it('should inform a subscriber of each state change once even after multiple subscriptions', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'CountController',
-      [],
-      ['CountController:stateChange'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'CountController',
+      allowedActions: [],
+      allowedEvents: ['CountController:stateChange'],
+    });
     const controller = new MockController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
@@ -206,11 +206,11 @@ describe('BaseController', () => {
 
   it('should no longer inform a subscriber about state changes after unsubscribing', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'CountController',
-      [],
-      ['CountController:stateChange'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'CountController',
+      allowedActions: [],
+      allowedEvents: ['CountController:stateChange'],
+    });
     const controller = new MockController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
@@ -230,11 +230,11 @@ describe('BaseController', () => {
 
   it('should no longer inform a subscriber about state changes after unsubscribing once, even if they subscribed many times', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'CountController',
-      [],
-      ['CountController:stateChange'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'CountController',
+      allowedActions: [],
+      allowedEvents: ['CountController:stateChange'],
+    });
     const controller = new MockController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
@@ -255,11 +255,11 @@ describe('BaseController', () => {
 
   it('should throw when unsubscribing listener who was never subscribed', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'CountController',
-      [],
-      ['CountController:stateChange'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'CountController',
+      allowedActions: [],
+      allowedEvents: ['CountController:stateChange'],
+    });
     new MockController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
@@ -275,11 +275,11 @@ describe('BaseController', () => {
 
   it('should no longer update subscribers after being destroyed', () => {
     const controllerMessenger = new ControllerMessenger<never, CountControllerEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'CountController',
-      [],
-      ['CountController:stateChange'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'CountController',
+      allowedActions: [],
+      allowedEvents: ['CountController:stateChange'],
+    });
     const controller = new MockController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',

--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -13,14 +13,14 @@ type CountControllerEvent = {
   payload: [CountControllerState, Patch[]];
 };
 
-const CountControllerStateMetadata = {
+const countControllerStateMetadata = {
   count: {
     persist: true,
     anonymous: true,
   },
 };
 
-class MockController extends BaseController<'CountController', CountControllerState> {
+class CountController extends BaseController<'CountController', CountControllerState> {
   update(callback: (state: Draft<CountControllerState>) => void | CountControllerState) {
     super.update(callback);
   }
@@ -38,11 +38,11 @@ describe('BaseController', () => {
       allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
-    const controller = new MockController({
+    const controller = new CountController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
-      metadata: CountControllerStateMetadata,
+      metadata: countControllerStateMetadata,
     });
 
     expect(controller.state).toEqual({ count: 0 });
@@ -55,14 +55,14 @@ describe('BaseController', () => {
       allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
-    const controller = new MockController({
+    const controller = new CountController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
-      metadata: CountControllerStateMetadata,
+      metadata: countControllerStateMetadata,
     });
 
-    expect(controller.metadata).toEqual(CountControllerStateMetadata);
+    expect(controller.metadata).toEqual(countControllerStateMetadata);
   });
 
   it('should not allow mutating state directly', () => {
@@ -72,11 +72,11 @@ describe('BaseController', () => {
       allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
-    const controller = new MockController({
+    const controller = new CountController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
-      metadata: CountControllerStateMetadata,
+      metadata: countControllerStateMetadata,
     });
 
     expect(() => {
@@ -91,11 +91,11 @@ describe('BaseController', () => {
       allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
-    const controller = new MockController({
+    const controller = new CountController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
-      metadata: CountControllerStateMetadata,
+      metadata: countControllerStateMetadata,
     });
 
     controller.update((draft) => {
@@ -112,11 +112,11 @@ describe('BaseController', () => {
       allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
-    const controller = new MockController({
+    const controller = new CountController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
-      metadata: CountControllerStateMetadata,
+      metadata: countControllerStateMetadata,
     });
 
     controller.update(() => {
@@ -133,11 +133,11 @@ describe('BaseController', () => {
       allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
-    const controller = new MockController({
+    const controller = new CountController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
-      metadata: CountControllerStateMetadata,
+      metadata: countControllerStateMetadata,
     });
 
     expect(() => {
@@ -157,11 +157,11 @@ describe('BaseController', () => {
       allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
-    const controller = new MockController({
+    const controller = new CountController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
-      metadata: CountControllerStateMetadata,
+      metadata: countControllerStateMetadata,
     });
     const listener1 = sinon.stub();
     const listener2 = sinon.stub();
@@ -185,11 +185,11 @@ describe('BaseController', () => {
       allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
-    const controller = new MockController({
+    const controller = new CountController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
-      metadata: CountControllerStateMetadata,
+      metadata: countControllerStateMetadata,
     });
     const listener1 = sinon.stub();
 
@@ -211,11 +211,11 @@ describe('BaseController', () => {
       allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
-    const controller = new MockController({
+    const controller = new CountController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
-      metadata: CountControllerStateMetadata,
+      metadata: countControllerStateMetadata,
     });
     const listener1 = sinon.stub();
 
@@ -235,11 +235,11 @@ describe('BaseController', () => {
       allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
-    const controller = new MockController({
+    const controller = new CountController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
-      metadata: CountControllerStateMetadata,
+      metadata: countControllerStateMetadata,
     });
     const listener1 = sinon.stub();
 
@@ -260,11 +260,11 @@ describe('BaseController', () => {
       allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
-    new MockController({
+    new CountController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
-      metadata: CountControllerStateMetadata,
+      metadata: countControllerStateMetadata,
     });
     const listener1 = sinon.stub();
 
@@ -280,11 +280,11 @@ describe('BaseController', () => {
       allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
-    const controller = new MockController({
+    const controller = new CountController({
       messenger: restrictedControllerMessenger,
       name: 'CountController',
       state: { count: 0 },
-      metadata: CountControllerStateMetadata,
+      metadata: countControllerStateMetadata,
     });
     const listener1 = sinon.stub();
     const listener2 = sinon.stub();

--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -600,8 +600,8 @@ describe('getPersistentState', () => {
           'VisitorController',
           VisitorControllerAction | VisitorOverflowControllerAction,
           VisitorControllerEvent | VisitorOverflowControllerEvent,
-          string,
-          string
+          never,
+          never
         >,
       ) {
         super({
@@ -658,8 +658,8 @@ describe('getPersistentState', () => {
           'VisitorOverflowController',
           VisitorControllerAction | VisitorOverflowControllerAction,
           VisitorControllerEvent | VisitorOverflowControllerEvent,
-          string,
-          string
+          'VisitorController:clear',
+          'VisitorController:stateChange'
         >,
       ) {
         super({

--- a/src/BaseControllerV2.ts
+++ b/src/BaseControllerV2.ts
@@ -4,7 +4,7 @@ import { enablePatches, produceWithPatches } from 'immer';
 // eslint-disable-next-line no-duplicate-imports
 import type { Draft, Patch } from 'immer';
 
-import type { ControllerMessenger } from './ControllerMessenger';
+import type { RestrictedControllerMessenger, Namespaced } from './ControllerMessenger';
 
 enablePatches();
 
@@ -101,7 +101,13 @@ type Json = null | boolean | number | string | Json[] | { [prop: string]: Json }
 export class BaseController<N extends string, S extends Record<string, unknown>> {
   private internalState: IsJsonable<S>;
 
-  private messagingSystem: ControllerMessenger<never, { type: `${N}:stateChange`; payload: [S, Patch[]] }>;
+  private messagingSystem: RestrictedControllerMessenger<
+    N,
+    never,
+    { type: `${N}:stateChange`; payload: [S, Patch[]] },
+    any,
+    any
+  >;
 
   private name: N;
 
@@ -123,7 +129,7 @@ export class BaseController<N extends string, S extends Record<string, unknown>>
     name,
     state,
   }: {
-    messenger: ControllerMessenger<never, { type: `${N}:stateChange`; payload: [S, Patch[]] }>;
+    messenger: RestrictedControllerMessenger<N, never, { type: `${N}:stateChange`; payload: [S, Patch[]] }, any, any>;
     metadata: StateMetadata<S>;
     name: N;
     state: IsJsonable<S>;
@@ -159,7 +165,7 @@ export class BaseController<N extends string, S extends Record<string, unknown>>
   protected update(callback: (state: Draft<IsJsonable<S>>) => void | IsJsonable<S>) {
     const [nextState, patches] = produceWithPatches(this.internalState, callback);
     this.internalState = nextState as IsJsonable<S>;
-    this.messagingSystem.publish(`${this.name}:stateChange` as `${N}:stateChange`, nextState as S, patches);
+    this.messagingSystem.publish(`${this.name}:stateChange` as Namespaced<N, any>, nextState as S, patches);
   }
 
   /**
@@ -172,7 +178,7 @@ export class BaseController<N extends string, S extends Record<string, unknown>>
    * listeners from being garbage collected.
    */
   protected destroy() {
-    this.messagingSystem.clearEventSubscriptions(`${this.name}:stateChange` as `${N}:stateChange`);
+    this.messagingSystem.clearEventSubscriptions(`${this.name}:stateChange` as Namespaced<N, any>);
   }
 }
 

--- a/src/BaseControllerV2.ts
+++ b/src/BaseControllerV2.ts
@@ -95,19 +95,18 @@ export interface StatePropertyMetadata<T> {
 }
 
 type Json = null | boolean | number | string | Json[] | { [prop: string]: Json };
+
+type StateChangeEvent<N extends string, S, E> = E extends { type: `${N}:stateChange`; payload: [S, Patch[]] }
+  ? E
+  : never;
+
 /**
  * Controller class that provides state management, subscriptions, and state metadata
  */
 export class BaseController<N extends string, S extends Record<string, unknown>> {
   private internalState: IsJsonable<S>;
 
-  private messagingSystem: RestrictedControllerMessenger<
-    N,
-    never,
-    { type: `${N}:stateChange`; payload: [S, Patch[]] },
-    any,
-    any
-  >;
+  protected messagingSystem: RestrictedControllerMessenger<N, any, StateChangeEvent<N, S, any>, string, string>;
 
   private name: N;
 
@@ -129,7 +128,7 @@ export class BaseController<N extends string, S extends Record<string, unknown>>
     name,
     state,
   }: {
-    messenger: RestrictedControllerMessenger<N, never, { type: `${N}:stateChange`; payload: [S, Patch[]] }, any, any>;
+    messenger: RestrictedControllerMessenger<N, any, StateChangeEvent<N, S, any>, string, string>;
     metadata: StateMetadata<S>;
     name: N;
     state: IsJsonable<S>;

--- a/src/ControllerMessenger.test.ts
+++ b/src/ControllerMessenger.test.ts
@@ -400,7 +400,7 @@ describe('RestrictedControllerMessenger', () => {
 
     expect(() => {
       restrictedControllerMessenger.registerActionHandler('PingController:ping', () => undefined);
-    }).toThrow();
+    }).toThrow('A handler for PingController:ping has already been registered');
   });
 
   it('should throw when calling unregistered action', () => {
@@ -414,7 +414,7 @@ describe('RestrictedControllerMessenger', () => {
 
     expect(() => {
       restrictedControllerMessenger.call('PingController:ping');
-    }).toThrow();
+    }).toThrow('A handler for PingController:ping has not been registered');
   });
 
   it('should throw when calling an action that has been unregistered', () => {
@@ -428,7 +428,7 @@ describe('RestrictedControllerMessenger', () => {
 
     expect(() => {
       restrictedControllerMessenger.call('PingController:ping');
-    }).toThrow();
+    }).toThrow('A handler for PingController:ping has not been registered');
 
     let pingCount = 0;
     restrictedControllerMessenger.registerActionHandler('PingController:ping', () => {
@@ -439,7 +439,7 @@ describe('RestrictedControllerMessenger', () => {
 
     expect(() => {
       restrictedControllerMessenger.call('PingController:ping');
-    }).toThrow();
+    }).toThrow('A handler for PingController:ping has not been registered');
     expect(pingCount).toEqual(0);
   });
 
@@ -585,7 +585,9 @@ describe('RestrictedControllerMessenger', () => {
     });
 
     const handler = sinon.stub();
-    expect(() => restrictedControllerMessenger.unsubscribe('MessageController:message', handler)).toThrow();
+    expect(() => restrictedControllerMessenger.unsubscribe('MessageController:message', handler)).toThrow(
+      `Subscription not found for event: 'MessageController:message'`,
+    );
   });
 
   it('should throw when unsubscribing a handler that is not subscribed', () => {
@@ -601,7 +603,9 @@ describe('RestrictedControllerMessenger', () => {
     const handler2 = sinon.stub();
     restrictedControllerMessenger.subscribe('MessageController:message', handler1);
 
-    expect(() => restrictedControllerMessenger.unsubscribe('MessageController:message', handler2)).toThrow();
+    expect(() => restrictedControllerMessenger.unsubscribe('MessageController:message', handler2)).toThrow(
+      `Subscription not found for event: 'MessageController:message'`,
+    );
   });
 
   it('should not call subscriber after clearing event subscriptions', () => {

--- a/src/ControllerMessenger.test.ts
+++ b/src/ControllerMessenger.test.ts
@@ -294,11 +294,11 @@ describe('RestrictedControllerMessenger', () => {
   it('should allow registering and calling an action handler', () => {
     type CountAction = { type: 'CountController:count'; handler: (increment: number) => void };
     const controllerMessenger = new ControllerMessenger<CountAction, never>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'CountController',
-      ['CountController:count'],
-      [],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'CountController',
+      allowedActions: ['CountController:count'],
+      allowedEvents: [],
+    });
 
     let count = 0;
     restrictedControllerMessenger.registerActionHandler('CountController:count', (increment: number) => {
@@ -314,11 +314,11 @@ describe('RestrictedControllerMessenger', () => {
       | { type: 'MessageController:concat'; handler: (message: string) => void }
       | { type: 'MessageController:reset'; handler: (initialMessage: string) => void };
     const controllerMessenger = new ControllerMessenger<MessageAction, never>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'MessageController',
-      ['MessageController:reset', 'MessageController:concat'],
-      [],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: ['MessageController:reset', 'MessageController:concat'],
+      allowedEvents: [],
+    });
 
     let message = '';
     restrictedControllerMessenger.registerActionHandler('MessageController:reset', (initialMessage: string) => {
@@ -337,11 +337,11 @@ describe('RestrictedControllerMessenger', () => {
   it('should allow registering and calling an action handler with no parameters', () => {
     type IncrementAction = { type: 'CountController:increment'; handler: () => void };
     const controllerMessenger = new ControllerMessenger<IncrementAction, never>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'CountController',
-      ['CountController:increment'],
-      [],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'CountController',
+      allowedActions: ['CountController:increment'],
+      allowedEvents: [],
+    });
 
     let count = 0;
     restrictedControllerMessenger.registerActionHandler('CountController:increment', () => {
@@ -355,11 +355,11 @@ describe('RestrictedControllerMessenger', () => {
   it('should allow registering and calling an action handler with multiple parameters', () => {
     type MessageAction = { type: 'MessageController:message'; handler: (to: string, message: string) => void };
     const controllerMessenger = new ControllerMessenger<MessageAction, never>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'MessageController',
-      ['MessageController:message'],
-      [],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: ['MessageController:message'],
+      allowedEvents: [],
+    });
 
     const messages: Record<string, string> = {};
     restrictedControllerMessenger.registerActionHandler('MessageController:message', (to, message) => {
@@ -373,11 +373,11 @@ describe('RestrictedControllerMessenger', () => {
   it('should allow registering and calling an action handler with a return value', () => {
     type AddAction = { type: 'MathController:add'; handler: (a: number, b: number) => number };
     const controllerMessenger = new ControllerMessenger<AddAction, never>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'MathController',
-      ['MathController:add'],
-      [],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'MathController',
+      allowedActions: ['MathController:add'],
+      allowedEvents: [],
+    });
 
     restrictedControllerMessenger.registerActionHandler('MathController:add', (a, b) => {
       return a + b;
@@ -390,11 +390,11 @@ describe('RestrictedControllerMessenger', () => {
   it('should not allow registering multiple action handlers under the same name', () => {
     type CountAction = { type: 'PingController:ping'; handler: () => void };
     const controllerMessenger = new ControllerMessenger<CountAction, never>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'PingController',
-      ['PingController:ping'],
-      [],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'PingController',
+      allowedActions: ['PingController:ping'],
+      allowedEvents: [],
+    });
 
     restrictedControllerMessenger.registerActionHandler('PingController:ping', () => undefined);
 
@@ -406,11 +406,11 @@ describe('RestrictedControllerMessenger', () => {
   it('should throw when calling unregistered action', () => {
     type CountAction = { type: 'PingController:ping'; handler: () => void };
     const controllerMessenger = new ControllerMessenger<CountAction, never>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'PingController',
-      ['PingController:ping'],
-      [],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'PingController',
+      allowedActions: ['PingController:ping'],
+      allowedEvents: [],
+    });
 
     expect(() => {
       restrictedControllerMessenger.call('PingController:ping');
@@ -420,11 +420,11 @@ describe('RestrictedControllerMessenger', () => {
   it('should throw when calling an action that has been unregistered', () => {
     type PingAction = { type: 'PingController:ping'; handler: () => void };
     const controllerMessenger = new ControllerMessenger<PingAction, never>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'PingController',
-      ['PingController:ping'],
-      [],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'PingController',
+      allowedActions: ['PingController:ping'],
+      allowedEvents: [],
+    });
 
     expect(() => {
       restrictedControllerMessenger.call('PingController:ping');
@@ -446,11 +446,11 @@ describe('RestrictedControllerMessenger', () => {
   it('should publish event to subscriber', () => {
     type MessageEvent = { type: 'MessageController:message'; payload: [string] };
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'MessageController',
-      [],
-      ['MessageController:message'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: ['MessageController:message'],
+    });
 
     const handler = sinon.stub();
     restrictedControllerMessenger.subscribe('MessageController:message', handler);
@@ -465,11 +465,11 @@ describe('RestrictedControllerMessenger', () => {
       | { type: 'MessageController:message'; payload: [string] }
       | { type: 'MessageController:ping'; payload: [] };
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'MessageController',
-      [],
-      ['MessageController:message', 'MessageController:ping'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: ['MessageController:message', 'MessageController:ping'],
+    });
 
     const messageHandler = sinon.stub();
     const pingHandler = sinon.stub();
@@ -488,11 +488,11 @@ describe('RestrictedControllerMessenger', () => {
   it('should publish event with no payload to subscriber', () => {
     type PingEvent = { type: 'PingController:ping'; payload: [] };
     const controllerMessenger = new ControllerMessenger<never, PingEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'PingController',
-      [],
-      ['PingController:ping'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'PingController',
+      allowedActions: [],
+      allowedEvents: ['PingController:ping'],
+    });
 
     const handler = sinon.stub();
     restrictedControllerMessenger.subscribe('PingController:ping', handler);
@@ -505,11 +505,11 @@ describe('RestrictedControllerMessenger', () => {
   it('should publish event with multiple payload parameters to subscriber', () => {
     type MessageEvent = { type: 'MessageController:message'; payload: [string, string] };
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'MessageController',
-      [],
-      ['MessageController:message'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: ['MessageController:message'],
+    });
 
     const handler = sinon.stub();
     restrictedControllerMessenger.subscribe('MessageController:message', handler);
@@ -522,11 +522,11 @@ describe('RestrictedControllerMessenger', () => {
   it('should publish event once to subscriber even if subscribed multiple times', () => {
     type MessageEvent = { type: 'MessageController:message'; payload: [string] };
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'MessageController',
-      [],
-      ['MessageController:message'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: ['MessageController:message'],
+    });
 
     const handler = sinon.stub();
     restrictedControllerMessenger.subscribe('MessageController:message', handler);
@@ -540,11 +540,11 @@ describe('RestrictedControllerMessenger', () => {
   it('should publish event to many subscribers', () => {
     type MessageEvent = { type: 'MessageController:message'; payload: [string] };
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'MessageController',
-      [],
-      ['MessageController:message'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: ['MessageController:message'],
+    });
 
     const handler1 = sinon.stub();
     const handler2 = sinon.stub();
@@ -561,11 +561,11 @@ describe('RestrictedControllerMessenger', () => {
   it('should not call subscriber after unsubscribing', () => {
     type MessageEvent = { type: 'MessageController:message'; payload: [string] };
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'MessageController',
-      [],
-      ['MessageController:message'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: ['MessageController:message'],
+    });
 
     const handler = sinon.stub();
     restrictedControllerMessenger.subscribe('MessageController:message', handler);
@@ -578,11 +578,11 @@ describe('RestrictedControllerMessenger', () => {
   it('should throw when unsubscribing when there are no subscriptions', () => {
     type MessageEvent = { type: 'MessageController:message'; payload: [string] };
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'MessageController',
-      [],
-      ['MessageController:message'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: ['MessageController:message'],
+    });
 
     const handler = sinon.stub();
     expect(() => restrictedControllerMessenger.unsubscribe('MessageController:message', handler)).toThrow();
@@ -591,11 +591,11 @@ describe('RestrictedControllerMessenger', () => {
   it('should throw when unsubscribing a handler that is not subscribed', () => {
     type MessageEvent = { type: 'MessageController:message'; payload: [string] };
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'MessageController',
-      [],
-      ['MessageController:message'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: ['MessageController:message'],
+    });
 
     const handler1 = sinon.stub();
     const handler2 = sinon.stub();
@@ -607,11 +607,11 @@ describe('RestrictedControllerMessenger', () => {
   it('should not call subscriber after clearing event subscriptions', () => {
     type MessageEvent = { type: 'MessageController:message'; payload: [string] };
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'MessageController',
-      [],
-      ['MessageController:message'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: ['MessageController:message'],
+    });
 
     const handler = sinon.stub();
     restrictedControllerMessenger.subscribe('MessageController:message', handler);
@@ -624,11 +624,11 @@ describe('RestrictedControllerMessenger', () => {
   it('should not throw when clearing event that has no subscriptions', () => {
     type MessageEvent = { type: 'MessageController:message'; payload: [string] };
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'MessageController',
-      [],
-      ['MessageController:message'],
-    );
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: ['MessageController:message'],
+    });
 
     expect(() => restrictedControllerMessenger.clearEventSubscriptions('MessageController:message')).not.toThrow();
   });
@@ -636,12 +636,16 @@ describe('RestrictedControllerMessenger', () => {
   it('should allow calling an external action', () => {
     type CountAction = { type: 'CountController:count'; handler: (increment: number) => void };
     const controllerMessenger = new ControllerMessenger<CountAction, never>();
-    const externalRestrictedControllerMessenger = controllerMessenger.getRestricted('CountController', [], []);
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'OtherController',
-      ['CountController:count'],
-      [],
-    );
+    const externalRestrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'CountController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'OtherController',
+      allowedActions: ['CountController:count'],
+      allowedEvents: [],
+    });
 
     let count = 0;
     externalRestrictedControllerMessenger.registerActionHandler('CountController:count', (increment: number) => {
@@ -655,12 +659,16 @@ describe('RestrictedControllerMessenger', () => {
   it('should allow subscribing to an external event', () => {
     type MessageEvent = { type: 'MessageController:message'; payload: [string] };
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
-    const externalRestrictedControllerMessenger = controllerMessenger.getRestricted('MessageController', [], []);
-    const restrictedControllerMessenger = controllerMessenger.getRestricted(
-      'OtherController',
-      [],
-      ['MessageController:message'],
-    );
+    const externalRestrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'MessageController',
+      allowedActions: [],
+      allowedEvents: [],
+    });
+    const restrictedControllerMessenger = controllerMessenger.getRestricted({
+      name: 'OtherController',
+      allowedActions: [],
+      allowedEvents: ['MessageController:message'],
+    });
 
     const handler = sinon.stub();
     restrictedControllerMessenger.subscribe('MessageController:message', handler);

--- a/src/ControllerMessenger.test.ts
+++ b/src/ControllerMessenger.test.ts
@@ -289,3 +289,384 @@ describe('ControllerMessenger', () => {
     expect(handler.callCount).toEqual(0);
   });
 });
+
+describe('RestrictedControllerMessenger', () => {
+  it('should allow registering and calling an action handler', () => {
+    type CountAction = { type: 'CountController:count'; handler: (increment: number) => void };
+    const controllerMessenger = new ControllerMessenger<CountAction, never>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'CountController',
+      ['CountController:count'],
+      [],
+    );
+
+    let count = 0;
+    restrictedControllerMessenger.registerActionHandler('CountController:count', (increment: number) => {
+      count += increment;
+    });
+    restrictedControllerMessenger.call('CountController:count', 1);
+
+    expect(count).toEqual(1);
+  });
+
+  it('should allow registering and calling multiple different action handlers', () => {
+    type MessageAction =
+      | { type: 'MessageController:concat'; handler: (message: string) => void }
+      | { type: 'MessageController:reset'; handler: (initialMessage: string) => void };
+    const controllerMessenger = new ControllerMessenger<MessageAction, never>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'MessageController',
+      ['MessageController:reset', 'MessageController:concat'],
+      [],
+    );
+
+    let message = '';
+    restrictedControllerMessenger.registerActionHandler('MessageController:reset', (initialMessage: string) => {
+      message = initialMessage;
+    });
+    restrictedControllerMessenger.registerActionHandler('MessageController:concat', (s: string) => {
+      message += s;
+    });
+
+    restrictedControllerMessenger.call('MessageController:reset', 'hello');
+    restrictedControllerMessenger.call('MessageController:concat', ', world');
+
+    expect(message).toEqual('hello, world');
+  });
+
+  it('should allow registering and calling an action handler with no parameters', () => {
+    type IncrementAction = { type: 'CountController:increment'; handler: () => void };
+    const controllerMessenger = new ControllerMessenger<IncrementAction, never>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'CountController',
+      ['CountController:increment'],
+      [],
+    );
+
+    let count = 0;
+    restrictedControllerMessenger.registerActionHandler('CountController:increment', () => {
+      count += 1;
+    });
+    restrictedControllerMessenger.call('CountController:increment');
+
+    expect(count).toEqual(1);
+  });
+
+  it('should allow registering and calling an action handler with multiple parameters', () => {
+    type MessageAction = { type: 'MessageController:message'; handler: (to: string, message: string) => void };
+    const controllerMessenger = new ControllerMessenger<MessageAction, never>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'MessageController',
+      ['MessageController:message'],
+      [],
+    );
+
+    const messages: Record<string, string> = {};
+    restrictedControllerMessenger.registerActionHandler('MessageController:message', (to, message) => {
+      messages[to] = message;
+    });
+    restrictedControllerMessenger.call('MessageController:message', '0x123', 'hello');
+
+    expect(messages['0x123']).toEqual('hello');
+  });
+
+  it('should allow registering and calling an action handler with a return value', () => {
+    type AddAction = { type: 'MathController:add'; handler: (a: number, b: number) => number };
+    const controllerMessenger = new ControllerMessenger<AddAction, never>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'MathController',
+      ['MathController:add'],
+      [],
+    );
+
+    restrictedControllerMessenger.registerActionHandler('MathController:add', (a, b) => {
+      return a + b;
+    });
+    const result = restrictedControllerMessenger.call('MathController:add', 5, 10);
+
+    expect(result).toEqual(15);
+  });
+
+  it('should not allow registering multiple action handlers under the same name', () => {
+    type CountAction = { type: 'PingController:ping'; handler: () => void };
+    const controllerMessenger = new ControllerMessenger<CountAction, never>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'PingController',
+      ['PingController:ping'],
+      [],
+    );
+
+    restrictedControllerMessenger.registerActionHandler('PingController:ping', () => undefined);
+
+    expect(() => {
+      restrictedControllerMessenger.registerActionHandler('PingController:ping', () => undefined);
+    }).toThrow();
+  });
+
+  it('should throw when calling unregistered action', () => {
+    type CountAction = { type: 'PingController:ping'; handler: () => void };
+    const controllerMessenger = new ControllerMessenger<CountAction, never>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'PingController',
+      ['PingController:ping'],
+      [],
+    );
+
+    expect(() => {
+      restrictedControllerMessenger.call('PingController:ping');
+    }).toThrow();
+  });
+
+  it('should throw when calling an action that has been unregistered', () => {
+    type PingAction = { type: 'PingController:ping'; handler: () => void };
+    const controllerMessenger = new ControllerMessenger<PingAction, never>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'PingController',
+      ['PingController:ping'],
+      [],
+    );
+
+    expect(() => {
+      restrictedControllerMessenger.call('PingController:ping');
+    }).toThrow();
+
+    let pingCount = 0;
+    restrictedControllerMessenger.registerActionHandler('PingController:ping', () => {
+      pingCount += 1;
+    });
+
+    restrictedControllerMessenger.unregisterActionHandler('PingController:ping');
+
+    expect(() => {
+      restrictedControllerMessenger.call('PingController:ping');
+    }).toThrow();
+    expect(pingCount).toEqual(0);
+  });
+
+  it('should publish event to subscriber', () => {
+    type MessageEvent = { type: 'MessageController:message'; payload: [string] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'MessageController',
+      [],
+      ['MessageController:message'],
+    );
+
+    const handler = sinon.stub();
+    restrictedControllerMessenger.subscribe('MessageController:message', handler);
+    restrictedControllerMessenger.publish('MessageController:message', 'hello');
+
+    expect(handler.calledWithExactly('hello')).toBeTruthy();
+    expect(handler.callCount).toEqual(1);
+  });
+
+  it('should allow publishing multiple different events to subscriber', () => {
+    type MessageEvent =
+      | { type: 'MessageController:message'; payload: [string] }
+      | { type: 'MessageController:ping'; payload: [] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'MessageController',
+      [],
+      ['MessageController:message', 'MessageController:ping'],
+    );
+
+    const messageHandler = sinon.stub();
+    const pingHandler = sinon.stub();
+    restrictedControllerMessenger.subscribe('MessageController:message', messageHandler);
+    restrictedControllerMessenger.subscribe('MessageController:ping', pingHandler);
+
+    restrictedControllerMessenger.publish('MessageController:message', 'hello');
+    restrictedControllerMessenger.publish('MessageController:ping');
+
+    expect(messageHandler.calledWithExactly('hello')).toBeTruthy();
+    expect(messageHandler.callCount).toEqual(1);
+    expect(pingHandler.calledWithExactly()).toBeTruthy();
+    expect(pingHandler.callCount).toEqual(1);
+  });
+
+  it('should publish event with no payload to subscriber', () => {
+    type PingEvent = { type: 'PingController:ping'; payload: [] };
+    const controllerMessenger = new ControllerMessenger<never, PingEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'PingController',
+      [],
+      ['PingController:ping'],
+    );
+
+    const handler = sinon.stub();
+    restrictedControllerMessenger.subscribe('PingController:ping', handler);
+    restrictedControllerMessenger.publish('PingController:ping');
+
+    expect(handler.calledWithExactly()).toBeTruthy();
+    expect(handler.callCount).toEqual(1);
+  });
+
+  it('should publish event with multiple payload parameters to subscriber', () => {
+    type MessageEvent = { type: 'MessageController:message'; payload: [string, string] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'MessageController',
+      [],
+      ['MessageController:message'],
+    );
+
+    const handler = sinon.stub();
+    restrictedControllerMessenger.subscribe('MessageController:message', handler);
+    restrictedControllerMessenger.publish('MessageController:message', 'hello', 'there');
+
+    expect(handler.calledWithExactly('hello', 'there')).toBeTruthy();
+    expect(handler.callCount).toEqual(1);
+  });
+
+  it('should publish event once to subscriber even if subscribed multiple times', () => {
+    type MessageEvent = { type: 'MessageController:message'; payload: [string] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'MessageController',
+      [],
+      ['MessageController:message'],
+    );
+
+    const handler = sinon.stub();
+    restrictedControllerMessenger.subscribe('MessageController:message', handler);
+    restrictedControllerMessenger.subscribe('MessageController:message', handler);
+    restrictedControllerMessenger.publish('MessageController:message', 'hello');
+
+    expect(handler.calledWithExactly('hello')).toBeTruthy();
+    expect(handler.callCount).toEqual(1);
+  });
+
+  it('should publish event to many subscribers', () => {
+    type MessageEvent = { type: 'MessageController:message'; payload: [string] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'MessageController',
+      [],
+      ['MessageController:message'],
+    );
+
+    const handler1 = sinon.stub();
+    const handler2 = sinon.stub();
+    restrictedControllerMessenger.subscribe('MessageController:message', handler1);
+    restrictedControllerMessenger.subscribe('MessageController:message', handler2);
+    restrictedControllerMessenger.publish('MessageController:message', 'hello');
+
+    expect(handler1.calledWithExactly('hello')).toBeTruthy();
+    expect(handler1.callCount).toEqual(1);
+    expect(handler2.calledWithExactly('hello')).toBeTruthy();
+    expect(handler2.callCount).toEqual(1);
+  });
+
+  it('should not call subscriber after unsubscribing', () => {
+    type MessageEvent = { type: 'MessageController:message'; payload: [string] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'MessageController',
+      [],
+      ['MessageController:message'],
+    );
+
+    const handler = sinon.stub();
+    restrictedControllerMessenger.subscribe('MessageController:message', handler);
+    restrictedControllerMessenger.unsubscribe('MessageController:message', handler);
+    restrictedControllerMessenger.publish('MessageController:message', 'hello');
+
+    expect(handler.callCount).toEqual(0);
+  });
+
+  it('should throw when unsubscribing when there are no subscriptions', () => {
+    type MessageEvent = { type: 'MessageController:message'; payload: [string] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'MessageController',
+      [],
+      ['MessageController:message'],
+    );
+
+    const handler = sinon.stub();
+    expect(() => restrictedControllerMessenger.unsubscribe('MessageController:message', handler)).toThrow();
+  });
+
+  it('should throw when unsubscribing a handler that is not subscribed', () => {
+    type MessageEvent = { type: 'MessageController:message'; payload: [string] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'MessageController',
+      [],
+      ['MessageController:message'],
+    );
+
+    const handler1 = sinon.stub();
+    const handler2 = sinon.stub();
+    restrictedControllerMessenger.subscribe('MessageController:message', handler1);
+
+    expect(() => restrictedControllerMessenger.unsubscribe('MessageController:message', handler2)).toThrow();
+  });
+
+  it('should not call subscriber after clearing event subscriptions', () => {
+    type MessageEvent = { type: 'MessageController:message'; payload: [string] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'MessageController',
+      [],
+      ['MessageController:message'],
+    );
+
+    const handler = sinon.stub();
+    restrictedControllerMessenger.subscribe('MessageController:message', handler);
+    restrictedControllerMessenger.clearEventSubscriptions('MessageController:message');
+    restrictedControllerMessenger.publish('MessageController:message', 'hello');
+
+    expect(handler.callCount).toEqual(0);
+  });
+
+  it('should not throw when clearing event that has no subscriptions', () => {
+    type MessageEvent = { type: 'MessageController:message'; payload: [string] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'MessageController',
+      [],
+      ['MessageController:message'],
+    );
+
+    expect(() => restrictedControllerMessenger.clearEventSubscriptions('MessageController:message')).not.toThrow();
+  });
+
+  it('should allow calling an external action', () => {
+    type CountAction = { type: 'CountController:count'; handler: (increment: number) => void };
+    const controllerMessenger = new ControllerMessenger<CountAction, never>();
+    const externalRestrictedControllerMessenger = controllerMessenger.getRestricted('CountController', [], []);
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'OtherController',
+      ['CountController:count'],
+      [],
+    );
+
+    let count = 0;
+    externalRestrictedControllerMessenger.registerActionHandler('CountController:count', (increment: number) => {
+      count += increment;
+    });
+    restrictedControllerMessenger.call('CountController:count', 1);
+
+    expect(count).toEqual(1);
+  });
+
+  it('should allow subscribing to an external event', () => {
+    type MessageEvent = { type: 'MessageController:message'; payload: [string] };
+    const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
+    const externalRestrictedControllerMessenger = controllerMessenger.getRestricted('MessageController', [], []);
+    const restrictedControllerMessenger = controllerMessenger.getRestricted(
+      'OtherController',
+      [],
+      ['MessageController:message'],
+    );
+
+    const handler = sinon.stub();
+    restrictedControllerMessenger.subscribe('MessageController:message', handler);
+    externalRestrictedControllerMessenger.publish('MessageController:message', 'hello');
+
+    expect(handler.calledWithExactly('hello')).toBeTruthy();
+    expect(handler.callCount).toEqual(1);
+  });
+});

--- a/src/ControllerMessenger.ts
+++ b/src/ControllerMessenger.ts
@@ -14,6 +14,11 @@ type ExtractEventPayload<Event, T> = Event extends { type: T; payload: infer P }
 type ActionConstraint = { type: string; handler: (...args: any) => unknown };
 type EventConstraint = { type: string; payload: unknown[] };
 
+/**
+ * A namespaced string
+ *
+ * This type verifies that the string T is prefixed by the string Name followed by a colon.
+ */
 export type Namespaced<Name extends string, T> = T extends `${Name}:${string}` ? T : never;
 
 /**

--- a/src/ControllerMessenger.ts
+++ b/src/ControllerMessenger.ts
@@ -251,11 +251,15 @@ export class ControllerMessenger<Action extends ActionConstraint, Event extends 
     this.events.clear();
   }
 
-  getRestricted<N extends string, AllowedAction extends string, AllowedEvent extends string>(
-    name: N,
-    allowedActions: Extract<Action['type'], AllowedAction>[] | [],
-    allowedEvents: Extract<Event['type'], AllowedEvent>[] | [],
-  ) {
+  getRestricted<N extends string, AllowedAction extends string, AllowedEvent extends string>({
+    name,
+    allowedActions,
+    allowedEvents,
+  }: {
+    name: N;
+    allowedActions: Extract<Action['type'], AllowedAction>[] | [];
+    allowedEvents: Extract<Event['type'], AllowedEvent>[] | [];
+  }) {
     return new RestrictedControllerMessenger<N, Action, Event, AllowedAction, AllowedEvent>(
       this,
       name,

--- a/src/ControllerMessenger.ts
+++ b/src/ControllerMessenger.ts
@@ -90,7 +90,7 @@ export class RestrictedControllerMessenger<
    * @throws Will throw when a handler has been registered for this action type already.
    */
   registerActionHandler<T extends Namespaced<N, Action['type']>>(action: T, handler: ActionHandler<Action, T>) {
-    /* istanbul ignore if */
+    /* istanbul ignore if */ // Branch unreachable with valid types
     if (!action.startsWith(`${this.controllerName}:`)) {
       throw new Error(`Only allowed registering action handlers prefixed by '${this.controllerName}:'`);
     }
@@ -107,7 +107,7 @@ export class RestrictedControllerMessenger<
    * @param actionType - The action type. This is a unqiue identifier for this action.
    */
   unregisterActionHandler<T extends Namespaced<N, Action['type']>>(action: T) {
-    /* istanbul ignore if */
+    /* istanbul ignore if */ // Branch unreachable with valid types
     if (!action.startsWith(`${this.controllerName}:`)) {
       throw new Error(`Only allowed unregistering action handlers prefixed by '${this.controllerName}:'`);
     }
@@ -131,7 +131,7 @@ export class RestrictedControllerMessenger<
     action: T,
     ...params: ExtractActionParameters<Action, T>
   ): ExtractActionResponse<Action, T> {
-    /* istanbul ignore if */
+    /* istanbul ignore if */ // Branch unreachable with valid types
     if (!this.allowedActions.includes(action)) {
       throw new Error(`Action missing from allow list: ${action}`);
     }
@@ -150,7 +150,7 @@ export class RestrictedControllerMessenger<
    *   match the type of this payload.
    */
   publish<E extends Namespaced<N, Event['type']>>(event: E, ...payload: ExtractEventPayload<Event, E>) {
-    /* istanbul ignore if */
+    /* istanbul ignore if */ // Branch unreachable with valid types
     if (!event.startsWith(`${this.controllerName}:`)) {
       throw new Error(`Only allowed publishing events prefixed by '${this.controllerName}:'`);
     }
@@ -169,7 +169,7 @@ export class RestrictedControllerMessenger<
    *   match the type of the payload for this event type.
    */
   subscribe<E extends AllowedEvent>(event: E, handler: ExtractEvenHandler<Event, E>) {
-    /* istanbul ignore if */
+    /* istanbul ignore if */ // Branch unreachable with valid types
     if (!this.allowedEvents.includes(event)) {
       throw new Error(`Event missing from allow list: ${event}`);
     }
@@ -188,7 +188,7 @@ export class RestrictedControllerMessenger<
    * @throws Will throw when the given event handler is not registered for this event.
    */
   unsubscribe<E extends AllowedEvent>(event: E, handler: ExtractEvenHandler<Event, E>) {
-    /* istanbul ignore if */
+    /* istanbul ignore if */ // Branch unreachable with valid types
     if (!this.allowedEvents.includes(event)) {
       throw new Error(`Event missing from allow list: ${event}`);
     }
@@ -205,7 +205,7 @@ export class RestrictedControllerMessenger<
    * @param eventType - The event type. This is a unique identifier for this event.
    */
   clearEventSubscriptions<E extends Namespaced<N, Event['type']>>(event: E) {
-    /* istanbul ignore if */
+    /* istanbul ignore if */ // Branch unreachable with valid types
     if (!event.startsWith(`${this.controllerName}:`)) {
       throw new Error(`Only allowed clearing events prefixed by '${this.controllerName}:'`);
     }

--- a/src/ControllerMessenger.ts
+++ b/src/ControllerMessenger.ts
@@ -31,14 +31,19 @@ export class RestrictedControllerMessenger<
 
   private allowedEvents: AllowedEvent[];
 
-  constructor(
-    controllerMessenger: ControllerMessenger<Action, Event>,
-    controllerName: N,
-    allowedActions: AllowedAction[],
-    allowedEvents: AllowedEvent[],
-  ) {
+  constructor({
+    controllerMessenger,
+    name,
+    allowedActions,
+    allowedEvents,
+  }: {
+    controllerMessenger: ControllerMessenger<Action, Event>;
+    name: N;
+    allowedActions: AllowedAction[];
+    allowedEvents: AllowedEvent[];
+  }) {
     this.controllerMessenger = controllerMessenger;
-    this.controllerName = controllerName;
+    this.controllerName = name;
     this.allowedActions = allowedActions;
     this.allowedEvents = allowedEvents;
   }
@@ -260,11 +265,11 @@ export class ControllerMessenger<Action extends ActionConstraint, Event extends 
     allowedActions: Extract<Action['type'], AllowedAction>[] | [];
     allowedEvents: Extract<Event['type'], AllowedEvent>[] | [];
   }) {
-    return new RestrictedControllerMessenger<N, Action, Event, AllowedAction, AllowedEvent>(
-      this,
+    return new RestrictedControllerMessenger<N, Action, Event, AllowedAction, AllowedEvent>({
+      controllerMessenger: this,
       name,
       allowedActions,
       allowedEvents,
-    );
+    });
   }
 }


### PR DESCRIPTION
A method has been added to the controller messenger that returns a _restricted_ instance of the controller messenger. This instance is restricted to registering actions and events within a particular namespace, typically being the name of the controller. Access to event subscriptions and calling actions is also restricted based on the given allowlist for each.

This is meant to address feedback left on the [Controller Messaging System proposal](https://www.notion.so/Controller-Messaging-System-617efb02b9e54bd0a0b0e44c6f776d85).