### PR TITLE
Allow custom nonce

### DIFF
--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -457,6 +457,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
     const currentChainId = network?.state?.provider?.chainId;
     const index = transactions.findIndex(({ id }) => transactionID === id);
     const transactionMeta = transactions[index];
+    const { nonce } = transactionMeta.transaction;
 
     try {
       const { from } = transactionMeta.transaction;
@@ -471,7 +472,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
       }
 
       transactionMeta.status = 'approved';
-      transactionMeta.transaction.nonce = await query(this.ethQuery, 'getTransactionCount', [from, 'pending']);
+      transactionMeta.transaction.nonce = nonce || await query(this.ethQuery, 'getTransactionCount', [from, 'pending']);
       transactionMeta.transaction.chainId = parseInt(currentChainId, undefined);
 
       const ethTransaction = new Transaction({ ...transactionMeta.transaction });

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -472,7 +472,8 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
       }
 
       transactionMeta.status = 'approved';
-      transactionMeta.transaction.nonce = nonce || await query(this.ethQuery, 'getTransactionCount', [from, 'pending']);
+      transactionMeta.transaction.nonce =
+        nonce || (await query(this.ethQuery, 'getTransactionCount', [from, 'pending']));
       transactionMeta.transaction.chainId = parseInt(currentChainId, undefined);
 
       const ethTransaction = new Transaction({ ...transactionMeta.transaction });


### PR DESCRIPTION
Allow the client to specify a nonce rather than using the network (but still falling back)

This is used in https://github.com/MetaMask/metamask-mobile/pull/2371