### PR TITLE
Use DI for controller communication rather than context

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,6 @@ console.log(datamodel.state); // {NetworkController: {...}, TokenRatesController
 console.log(datamodel.flatState); // {infura: {...}, contractExchangeRates: [...]}
 ```
 
-**Advanced Note:** The ComposableController builds a map of all child controllers keyed by controller name. This object is cached as a `context` instance variable on both the ComposableController itself as well as all child controllers. This means that child controllers can call methods on other sibling controllers through the `context` variable, e.g. `this.context.SomeController.someMethod()`.
-
 ## Linking during development
 
 Linking `@metamask/controllers` into other projects involves a special NPM command to ensure that dependencies are not duplicated. This is because `@metamask/controllers` ships modules that are transpiled but not bundled, and [NPM does not deduplicate](https://github.com/npm/npm/issues/7742) linked dependency trees.

--- a/src/BaseController.test.ts
+++ b/src/BaseController.test.ts
@@ -1,13 +1,10 @@
 import { stub } from 'sinon';
 import BaseController, { BaseConfig, BaseState } from './BaseController';
-import ComposableController from './ComposableController';
 
 const STATE = { name: 'foo' };
 const CONFIG = { disabled: true };
 
 class TestController extends BaseController<BaseConfig, BaseState> {
-  requiredControllers = ['Foo'];
-
   constructor(config?: BaseConfig, state?: BaseState) {
     super(config, state);
     this.initialize();
@@ -67,12 +64,5 @@ describe('BaseController', () => {
     controller.unsubscribe(() => null);
     controller.notify();
     expect(listener.called).toBe(false);
-  });
-
-  it('should throw if siblings are missing dependencies', () => {
-    const controller = new TestController();
-    expect(() => {
-      new ComposableController([controller]);
-    }).toThrow('BaseController must be composed with Foo.');
   });
 });

--- a/src/BaseController.ts
+++ b/src/BaseController.ts
@@ -1,5 +1,3 @@
-import { ChildControllerContext } from './ComposableController';
-
 /**
  * State change callbacks
  */
@@ -32,13 +30,6 @@ export interface BaseState {
  */
 export class BaseController<C extends BaseConfig, S extends BaseState> {
   /**
-   * Map of all sibling child controllers keyed by name if this
-   * controller is composed using a ComposableController, allowing
-   * any API on any sibling controller to be accessed
-   */
-  context: ChildControllerContext = {};
-
-  /**
    * Default options used to configure this controller
    */
   defaultConfig: C = {} as C;
@@ -57,11 +48,6 @@ export class BaseController<C extends BaseConfig, S extends BaseState> {
    * Name of this controller used during composition
    */
   name = 'BaseController';
-
-  /**
-   * List of required sibling controllers this controller needs to function
-   */
-  requiredControllers: string[] = [];
 
   private readonly initialConfig: C;
 
@@ -155,18 +141,6 @@ export class BaseController<C extends BaseConfig, S extends BaseState> {
     }
     this.internalListeners.forEach((listener) => {
       listener(this.internalState);
-    });
-  }
-
-  /**
-   * Extension point called if and when this controller is composed
-   * with other controllers using a ComposableController
-   */
-  onComposed() {
-    this.requiredControllers.forEach((name) => {
-      if (!this.context[name]) {
-        throw new Error(`${this.name} must be composed with ${name}.`);
-      }
     });
   }
 

--- a/src/assets/AccountTrackerController.test.ts
+++ b/src/assets/AccountTrackerController.test.ts
@@ -1,28 +1,39 @@
 import { stub, spy } from 'sinon';
 import HttpProvider from 'ethjs-provider-http';
 import type { ContactEntry } from '../user/AddressBookController';
-import PreferencesController from '../user/PreferencesController';
+import { PreferencesController } from '../user/PreferencesController';
 import AccountTrackerController from './AccountTrackerController';
 
 const provider = new HttpProvider('https://ropsten.infura.io/v3/341eacb578dd44a1a049cbc5f6fd4035');
 
 describe('AccountTrackerController', () => {
   it('should set default state', () => {
-    const controller = new AccountTrackerController({ onPreferencesStateChange: stub(), initialIdentities: {} });
+    const controller = new AccountTrackerController({
+      onPreferencesStateChange: stub(),
+      getIdentities: () => ({}),
+    });
     expect(controller.state).toEqual({
       accounts: {},
     });
   });
 
   it('should throw when provider property is accessed', () => {
-    const controller = new AccountTrackerController({ onPreferencesStateChange: stub(), initialIdentities: {} });
+    const controller = new AccountTrackerController({
+      onPreferencesStateChange: stub(),
+      getIdentities: () => ({}),
+    });
     expect(() => console.log(controller.provider)).toThrow('Property only used for setting');
   });
 
   it('should get real balance', async () => {
     const address = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
     const controller = new AccountTrackerController(
-      { onPreferencesStateChange: stub(), initialIdentities: { [address]: {} as ContactEntry } },
+      {
+        onPreferencesStateChange: stub(),
+        getIdentities: () => {
+          return { [address]: {} as ContactEntry };
+        },
+      },
       { provider },
     );
     await controller.refresh();
@@ -31,7 +42,12 @@ describe('AccountTrackerController', () => {
 
   it('should sync addresses', () => {
     const controller = new AccountTrackerController(
-      { onPreferencesStateChange: stub(), initialIdentities: { baz: {} as ContactEntry } },
+      {
+        onPreferencesStateChange: stub(),
+        getIdentities: () => {
+          return { baz: {} as ContactEntry };
+        },
+      },
       { provider },
       {
         accounts: {
@@ -47,7 +63,10 @@ describe('AccountTrackerController', () => {
   it('should subscribe to new sibling preference controllers', async () => {
     const preferences = new PreferencesController();
     const controller = new AccountTrackerController(
-      { onPreferencesStateChange: (listener) => preferences.subscribe(listener), initialIdentities: {} },
+      {
+        onPreferencesStateChange: (listener) => preferences.subscribe(listener),
+        getIdentities: () => ({}),
+      },
       { provider },
     );
     controller.refresh = stub();
@@ -63,7 +82,7 @@ describe('AccountTrackerController', () => {
       const controller = new AccountTrackerController(
         {
           onPreferencesStateChange: (listener) => preferences.subscribe(listener),
-          initialIdentities: {},
+          getIdentities: () => ({}),
         },
         { provider, interval: 100 },
       );

--- a/src/assets/AccountTrackerController.test.ts
+++ b/src/assets/AccountTrackerController.test.ts
@@ -1,34 +1,37 @@
 import { stub, spy } from 'sinon';
 import HttpProvider from 'ethjs-provider-http';
+import type { ContactEntry } from '../user/AddressBookController';
 import PreferencesController from '../user/PreferencesController';
-import ComposableController from '../ComposableController';
 import AccountTrackerController from './AccountTrackerController';
 
 const provider = new HttpProvider('https://ropsten.infura.io/v3/341eacb578dd44a1a049cbc5f6fd4035');
 
 describe('AccountTrackerController', () => {
   it('should set default state', () => {
-    const controller = new AccountTrackerController();
+    const controller = new AccountTrackerController({ onPreferencesStateChange: stub(), initialIdentities: {} });
     expect(controller.state).toEqual({
       accounts: {},
     });
   });
 
   it('should throw when provider property is accessed', () => {
-    const controller = new AccountTrackerController();
+    const controller = new AccountTrackerController({ onPreferencesStateChange: stub(), initialIdentities: {} });
     expect(() => console.log(controller.provider)).toThrow('Property only used for setting');
   });
 
   it('should get real balance', async () => {
     const address = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-    const controller = new AccountTrackerController({ provider });
-    controller.context = { PreferencesController: { state: { identities: { [address]: {} } } } } as any;
+    const controller = new AccountTrackerController(
+      { onPreferencesStateChange: stub(), initialIdentities: { [address]: {} as ContactEntry } },
+      { provider },
+    );
     await controller.refresh();
     expect(controller.state.accounts[address].balance).toBeDefined();
   });
 
   it('should sync addresses', () => {
     const controller = new AccountTrackerController(
+      { onPreferencesStateChange: stub(), initialIdentities: { baz: {} as ContactEntry } },
       { provider },
       {
         accounts: {
@@ -37,17 +40,18 @@ describe('AccountTrackerController', () => {
         },
       },
     );
-    controller.context = { PreferencesController: { state: { identities: { baz: {} } } } } as any;
     controller.refresh();
     expect(controller.state.accounts).toEqual({ baz: { balance: '0x0' } });
   });
 
   it('should subscribe to new sibling preference controllers', async () => {
     const preferences = new PreferencesController();
-    const controller = new AccountTrackerController({ provider });
+    const controller = new AccountTrackerController(
+      { onPreferencesStateChange: (listener) => preferences.subscribe(listener), initialIdentities: {} },
+      { provider },
+    );
     controller.refresh = stub();
 
-    new ComposableController([controller, preferences]);
     preferences.setFeatureFlag('foo', true);
     expect((controller.refresh as any).called).toBe(true);
   });
@@ -55,11 +59,16 @@ describe('AccountTrackerController', () => {
   it('should call refresh every ten seconds', async () => {
     await new Promise<void>((resolve) => {
       const preferences = new PreferencesController();
-      const controller = new AccountTrackerController({ provider, interval: 100 });
+      const poll = spy(AccountTrackerController.prototype, 'poll');
+      const controller = new AccountTrackerController(
+        {
+          onPreferencesStateChange: (listener) => preferences.subscribe(listener),
+          initialIdentities: {},
+        },
+        { provider, interval: 100 },
+      );
       stub(controller, 'refresh');
-      const poll = spy(controller, 'poll');
 
-      new ComposableController([controller, preferences]);
       expect(poll.called).toBe(true);
       expect(poll.calledTwice).toBe(false);
       setTimeout(() => {

--- a/src/assets/AccountTrackerController.ts
+++ b/src/assets/AccountTrackerController.ts
@@ -50,7 +50,7 @@ export class AccountTrackerController extends BaseController<AccountTrackerConfi
 
   private syncAccounts() {
     const { accounts } = this.state;
-    const addresses = Object.keys(this.identities);
+    const addresses = Object.keys(this.getIdentities());
     const existing = Object.keys(accounts);
     const newAddresses = addresses.filter((address) => existing.indexOf(address) === -1);
     const oldAddresses = existing.filter((address) => addresses.indexOf(address) === -1);
@@ -68,24 +68,24 @@ export class AccountTrackerController extends BaseController<AccountTrackerConfi
    */
   name = 'AccountTrackerController';
 
-  private identities: PreferencesState['identities'];
+  private getIdentities: () => PreferencesState['identities'];
 
   /**
    * Creates an AccountTracker instance
    *
    * @param options
    * @param options.onPreferencesStateChange - Allows subscribing to preference controller state changes
-   * @param options.initialIdentities - The initial `identities` state from the Preferences controller
+   * @param options.getIdentities - Gets the identities from the Preferences store
    * @param config - Initial options used to configure this controller
    * @param state - Initial state to set on this controller
    */
   constructor(
     {
       onPreferencesStateChange,
-      initialIdentities,
+      getIdentities,
     }: {
       onPreferencesStateChange: (listener: (preferencesState: PreferencesState) => void) => void;
-      initialIdentities: PreferencesState['identities'];
+      getIdentities: () => PreferencesState['identities'];
     },
     config?: Partial<AccountTrackerConfig>,
     state?: Partial<AccountTrackerState>,
@@ -96,9 +96,8 @@ export class AccountTrackerController extends BaseController<AccountTrackerConfi
     };
     this.defaultState = { accounts: {} };
     this.initialize();
-    this.identities = initialIdentities;
-    onPreferencesStateChange(({ identities }) => {
-      this.identities = identities;
+    this.getIdentities = getIdentities;
+    onPreferencesStateChange(() => {
       this.refresh();
     });
     this.poll();

--- a/src/assets/AssetsDetectionController.ts
+++ b/src/assets/AssetsDetectionController.ts
@@ -104,7 +104,7 @@ export class AssetsDetectionController extends BaseController<AssetsDetectionCon
    * @param options.getBalancesInSingleCall - Gets the balances of a list of tokens for the given address
    * @param options.addTokens - Add a list of tokens
    * @param options.addCollectible - Add a collectible
-   * @param options.initialAssetsState - The initial state of the Assets controller
+   * @param options.getAssetsState - Gets the current state of the Assets controller
    * @param config - Initial options used to configure this controller
    * @param state - Initial state to set on this controller
    */

--- a/src/keyring/KeyringController.test.ts
+++ b/src/keyring/KeyringController.test.ts
@@ -9,7 +9,6 @@ import { stub } from 'sinon';
 import Transaction from 'ethereumjs-tx';
 import MockEncryptor from '../../tests/mocks/mockEncryptor';
 import PreferencesController from '../user/PreferencesController';
-import ComposableController from '../ComposableController';
 import KeyringController, {
   AccountImportStrategy,
   Keyring,
@@ -33,10 +32,17 @@ describe('KeyringController', () => {
   let initialState: { isUnlocked: boolean; keyringTypes: string[]; keyrings: Keyring[] };
   const baseConfig: Partial<KeyringConfig> = { encryptor: new MockEncryptor() };
   beforeEach(async () => {
-    keyringController = new KeyringController(baseConfig);
     preferences = new PreferencesController();
+    keyringController = new KeyringController(
+      {
+        removeIdentity: preferences.removeIdentity.bind(preferences),
+        syncIdentities: preferences.syncIdentities.bind(preferences),
+        updateIdentities: preferences.updateIdentities.bind(preferences),
+        setSelectedAddress: preferences.setSelectedAddress.bind(preferences),
+      },
+      baseConfig,
+    );
 
-    new ComposableController([keyringController, preferences]);
     initialState = await keyringController.createNewVaultAndKeychain(password);
   });
 

--- a/src/user/PreferencesController.ts
+++ b/src/user/PreferencesController.ts
@@ -47,7 +47,6 @@ export interface PreferencesState extends BaseState {
   lostIdentities: { [address: string]: ContactEntry };
   selectedAddress: string;
 }
-
 /**
  * Controller that stores shared settings and exposes convenience methods
  */

--- a/src/user/PreferencesController.ts
+++ b/src/user/PreferencesController.ts
@@ -47,6 +47,7 @@ export interface PreferencesState extends BaseState {
   lostIdentities: { [address: string]: ContactEntry };
   selectedAddress: string;
 }
+
 /**
  * Controller that stores shared settings and exposes convenience methods
  */


### PR DESCRIPTION
We now setup inter-controller communication using dependency injection rather than the `context` property. Any dependency a controller has is passed in via a constructor parameter. This was done in preparation for migrating to BaseControllerV2 and the new controller messaging system - it's just a temporary solution that will let us migrate controllers one at a time.

The style of dependency injection here matches the extension (at least with the newer controllers anyway). Specific methods and state snapshots are injected rather than entire controllers, to help simplify unit tests and make it easier to understand how controllers interact.

The mobile PR that demonstrates this is here: https://github.com/MetaMask/metamask-mobile/pull/2416