### PR TITLE
Add `types` manifest field

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dist/"
   ],
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"


### PR DESCRIPTION
This field is recommended by the [TypeScript documentation about publishing](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html). It helps consumers find the type declarations.