### PR TITLE
Add missing dependency and disallow extraneous requires

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,7 +59,6 @@ module.exports = {
     'guard-for-in': 'off',
     'implicit-arrow-linebreak': 'off',
     'import/no-anonymous-default-export': 'off',
-    'import/no-extraneous-dependencies': 'off',
     'import/no-unassigned-import': 'off',
     'lines-around-comment': 'off',
     'no-async-promise-executor': 'off',
@@ -72,8 +71,6 @@ module.exports = {
     'no-useless-escape': 'off',
     radix: 'off',
     'require-atomic-updates': 'off',
-
-    'node/no-extraneous-require': 'off',
 
     'jest/expect-expect': 'off',
     'jest/no-conditional-expect': 'off',

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eth-query": "^2.1.2",
     "eth-rpc-errors": "^4.0.0",
     "eth-sig-util": "^3.0.0",
+    "ethereumjs-tx": "^1.3.7",
     "ethereumjs-util": "^6.1.0",
     "ethereumjs-wallet": "^1.0.1",
     "human-standard-collectible-abi": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2731,7 +2731,7 @@ ethereumjs-common@^1.1.0:
   resolved "https://registry.yarnpkg.com/ethereumjs-common/-/ethereumjs-common-1.3.1.tgz#a5cffac41beb7ad393283b2e5aa71fadf8a9cc73"
   integrity sha512-kexqNgM2q29RKoZPPjehPREeqbr/vhYfT9Ho8FVeH3f7USjBuYp1iZ1qjqklk8FSMvEKPpMJFYSOunikw30Prw==
 
-ethereumjs-tx@^1.2.0, ethereumjs-tx@^1.2.2:
+ethereumjs-tx@^1.2.0, ethereumjs-tx@^1.2.2, ethereumjs-tx@^1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz#88323a2d875b10549b8347e09f4862b546f3d89a"
   integrity sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==


### PR DESCRIPTION
The `node/no-extraneous-require` and `import/no-extraneous-dependencies` rules have been re-enabled. The one violation was `ethereumjs-tx`, which is a module we are using that wasn't listed among our dependencies. It has been added, using the version that was being used in practice via another dependency (which was v1.3.7).