### PR TITLE
Restore `@typescript-eslint/no-shadow` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,8 +16,13 @@ module.exports = {
     },
   ],
   rules: {
+    // `no-shadow` has incompatibilities with TypeScript
     'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': 'error',
+
+    // Prettier handles indentation. This rule conflicts with prettier in some cases
     '@typescript-eslint/indent': 'off',
+
     // disabled due to incompatibility with Record<string, unknown>
     // See https://github.com/Microsoft/TypeScript/issues/15300#issuecomment-702872440
     '@typescript-eslint/consistent-type-definitions': 'off',


### PR DESCRIPTION
This rule was mistakenly removed in #393. It was not unused - it was in fact enabled, and prevented variable shadowing.

I've added a comment explaining this. I've also added a comment explaining why `@typescript-eslint/indent` is disabled, so we don't make a similar mistake there in the future.