### PR TITLE
Only apply TypeScript lint rules to `.ts` files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,52 +1,53 @@
 module.exports = {
   root: true,
-  extends: [
-    '@metamask/eslint-config',
-    '@metamask/eslint-config/config/jest',
-    '@metamask/eslint-config/config/nodejs',
-    '@metamask/eslint-config/config/typescript',
-  ],
+  extends: ['@metamask/eslint-config', '@metamask/eslint-config/config/jest', '@metamask/eslint-config/config/nodejs'],
   ignorePatterns: ['!.eslintrc.js', '!jest.config.js', 'node_modules', 'dist', 'docs', 'coverage', '*.d.ts'],
   overrides: [
     {
       files: ['*.js'],
       parserOptions: {
+        ecmaVersion: '2018',
         sourceType: 'script',
+      },
+    },
+    {
+      files: ['*.ts'],
+      extends: ['@metamask/eslint-config/config/typescript'],
+      rules: {
+        // `no-shadow` has incompatibilities with TypeScript
+        'no-shadow': 'off',
+        '@typescript-eslint/no-shadow': 'error',
+
+        // Prettier handles indentation. This rule conflicts with prettier in some cases
+        '@typescript-eslint/indent': 'off',
+
+        // disabled due to incompatibility with Record<string, unknown>
+        // See https://github.com/Microsoft/TypeScript/issues/15300#issuecomment-702872440
+        '@typescript-eslint/consistent-type-definitions': 'off',
+
+        // TODO re-enable most of these rules
+        '@typescript-eslint/no-non-null-assertion': 'off',
+        '@typescript-eslint/no-require-imports': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
+        '@typescript-eslint/no-var-requires': 'off',
+        '@typescript-eslint/member-delimiter-style': [
+          'error',
+          {
+            multiline: {
+              delimiter: 'semi',
+              requireLast: true,
+            },
+            singleline: {
+              delimiter: 'semi',
+              requireLast: false,
+            },
+          },
+        ],
+        '@typescript-eslint/prefer-optional-chain': 'off',
       },
     },
   ],
   rules: {
-    // `no-shadow` has incompatibilities with TypeScript
-    'no-shadow': 'off',
-    '@typescript-eslint/no-shadow': 'error',
-
-    // Prettier handles indentation. This rule conflicts with prettier in some cases
-    '@typescript-eslint/indent': 'off',
-
-    // disabled due to incompatibility with Record<string, unknown>
-    // See https://github.com/Microsoft/TypeScript/issues/15300#issuecomment-702872440
-    '@typescript-eslint/consistent-type-definitions': 'off',
-
-    // TODO re-enable most of these rules
-    '@typescript-eslint/no-non-null-assertion': 'off',
-    '@typescript-eslint/no-require-imports': 'off',
-    '@typescript-eslint/no-unused-vars': 'off',
-    '@typescript-eslint/no-var-requires': 'off',
-    '@typescript-eslint/member-delimiter-style': [
-      'error',
-      {
-        multiline: {
-          delimiter: 'semi',
-          requireLast: true,
-        },
-        singleline: {
-          delimiter: 'semi',
-          requireLast: false,
-        },
-      },
-    ],
-    '@typescript-eslint/prefer-optional-chain': 'off',
-
     'accessor-pairs': 'off',
     camelcase: 'off',
     'consistent-return': 'off',
@@ -76,5 +77,10 @@ module.exports = {
     'jest/prefer-strict-equal': 'off',
     'jest/require-to-throw-message': 'off',
     'jest/valid-expect-in-promise': 'off',
+  },
+  settings: {
+    'import/resolver': {
+      typescript: {},
+    },
   },
 };

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@typescript-eslint/eslint-plugin": "^4.18.0",
     "@typescript-eslint/parser": "^4.18.0",
     "eslint": "^7.20.0",
+    "eslint-import-resolver-typescript": "^2.4.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.1.5",
     "eslint-plugin-node": "^11.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2352,6 +2352,17 @@ eslint-import-resolver-node@^0.3.4:
     debug "^2.6.9"
     resolve "^1.13.1"
 
+eslint-import-resolver-typescript@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.4.0.tgz#ec1e7063ebe807f0362a7320543aaed6fe1100e1"
+  integrity sha512-useJKURidCcldRLCNKWemr1fFQL1SzB3G4a0li6lFGvlc5xGe1hY343bvG07cbpCzPuM/lK19FIJB3XGFSkplA==
+  dependencies:
+    debug "^4.1.1"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    resolve "^1.17.0"
+    tsconfig-paths "^3.9.0"
+
 eslint-module-utils@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz#579ebd094f56af7797d19c9866c9c9486629bfa6"
@@ -3392,7 +3403,7 @@ glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.4:
+glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==


### PR DESCRIPTION
The TypeScript lint rules were being applied to all files covered by the linter, including JavaScript files. Surprisingly this hasn't been much of an issue (I guess most of them are compatible with JavaScript too?), but it became an obstacle when trying to re-enable the rule `@typescript-eslint/no-shadow`.

TypeScript lint rules are now only applied to TypeScript files.

A new dependency was required to ensure we could import TypeScript modules from JavaScript modules. We do this in one place at the moment, in the JavaScript tests for the ApprovalController. Apparently the ESLint `import` plugin doesn't know how to resolve TypeScript modules without a custom resolver. We hadn't encountered this problem previously because `import/no-unresolved` was disabled in our TypeScript ESLint config, so it didn't warn us about the dependency being unresolved.

The `ecmaVersion` was also updated to be 2018 for JavaScript files, to reflect the language features we currently rely upon (we use object spread in one place, which was introduced in ES2018).