### PR TITLE
Fix sinon types in ApprovalController tests

### DIFF
--- a/src/approval/ApprovalController.test.ts
+++ b/src/approval/ApprovalController.test.ts
@@ -1,7 +1,6 @@
 import { errorCodes } from 'eth-rpc-errors';
+import * as sinon from 'sinon';
 import ApprovalController from './ApprovalController';
-
-const sinon = require('sinon');
 
 const STORE_KEY = 'pendingApprovals';
 
@@ -255,11 +254,12 @@ describe('approval controller', () => {
   describe('resolve', () => {
     let approvalController: ApprovalController;
     let numDeletions: number;
-    let deleteSpy: typeof sinon.spy;
+    let deleteSpy: sinon.SinonSpy;
 
     beforeEach(() => {
       approvalController = new ApprovalController({ ...defaultConfig });
-      deleteSpy = sinon.spy(approvalController, '_delete');
+      // TODO: Stop using private methods in tests
+      deleteSpy = sinon.spy(approvalController as any, '_delete');
       numDeletions = 0;
     });
 
@@ -301,11 +301,12 @@ describe('approval controller', () => {
   describe('reject', () => {
     let approvalController: ApprovalController;
     let numDeletions: number;
-    let deleteSpy: typeof sinon.spy;
+    let deleteSpy: sinon.SinonSpy;
 
     beforeEach(() => {
       approvalController = new ApprovalController({ ...defaultConfig });
-      deleteSpy = sinon.spy(approvalController, '_delete');
+      // TODO: Stop using private methods in tests
+      deleteSpy = sinon.spy(approvalController as any, '_delete');
       numDeletions = 0;
     });
 


### PR DESCRIPTION
The types used in the ApprovalController tests for sinon tests were wrong. `typeof sinon.spy` was being used to get the spy type, but this returns the type of the `spy()` function, not of a spy instance.

Instead the type `SinonSpy` is used instead. This type is provided by the `@types/sinon` package. For some reason it seems to provide more correct type information than `ReturnType<typeof sinon['spy']>`, though I'm not sure why.

The sinon import was updated to use `import` rather than `require` as well, as TypeScript seemingly doesn't type anything that is imported using `require`.

This introduced two new type errors caused by us using private methods in the test. I've silenced these errors for now by casting to `any`, but we should update these tests later to stop relying upon internals.