### PR TITLE
Use consistent type for token balances

### DIFF
--- a/src/assets/AssetsContractController.ts
+++ b/src/assets/AssetsContractController.ts
@@ -1,8 +1,6 @@
+import { BN } from 'ethereumjs-util';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 
-// TODO: Destructuring this line introduces a compilation error
-// eslint-disable-next-line prefer-destructuring
-const BN = require('ethereumjs-util').BN;
 const Web3 = require('web3');
 const abiERC20 = require('human-standard-token-abi');
 const abiERC721 = require('human-standard-collectible-abi');
@@ -31,7 +29,7 @@ export interface AssetsContractConfig extends BaseConfig {
  * @property [tokenAddress] - Address of the token
  */
 export interface BalanceMap {
-  [tokenAddress: string]: string;
+  [tokenAddress: string]: BN;
 }
 
 /**
@@ -117,10 +115,10 @@ export class AssetsContractController extends BaseController<AssetsContractConfi
    * @param selectedAddress - Current account public address
    * @returns - Promise resolving to BN object containing balance for current account on specific asset contract
    */
-  async getBalanceOf(address: string, selectedAddress: string): Promise<typeof BN> {
+  async getBalanceOf(address: string, selectedAddress: string): Promise<BN> {
     const contract = this.web3.eth.contract(abiERC20).at(address);
-    return new Promise<typeof BN>((resolve, reject) => {
-      contract.balanceOf(selectedAddress, (error: Error, result: typeof BN) => {
+    return new Promise<BN>((resolve, reject) => {
+      contract.balanceOf(selectedAddress, (error: Error, result: BN) => {
         /* istanbul ignore if */
         if (error) {
           reject(error);
@@ -142,7 +140,7 @@ export class AssetsContractController extends BaseController<AssetsContractConfi
   getCollectibleTokenId(address: string, selectedAddress: string, index: number): Promise<number> {
     const contract = this.web3.eth.contract(abiERC721).at(address);
     return new Promise<number>((resolve, reject) => {
-      contract.tokenOfOwnerByIndex(selectedAddress, index, (error: Error, result: typeof BN) => {
+      contract.tokenOfOwnerByIndex(selectedAddress, index, (error: Error, result: BN) => {
         /* istanbul ignore if */
         if (error) {
           reject(error);
@@ -263,7 +261,7 @@ export class AssetsContractController extends BaseController<AssetsContractConfi
   async getBalancesInSingleCall(selectedAddress: string, tokensToDetect: string[]) {
     const contract = this.web3.eth.contract(abiSingleCallBalancesContract).at(SINGLE_CALL_BALANCES_ADDRESS);
     return new Promise<BalanceMap>((resolve, reject) => {
-      contract.balances([selectedAddress], tokensToDetect, (error: Error, result: typeof BN[]) => {
+      contract.balances([selectedAddress], tokensToDetect, (error: Error, result: BN[]) => {
         /* istanbul ignore if */
         if (error) {
           reject(error);
@@ -273,7 +271,7 @@ export class AssetsContractController extends BaseController<AssetsContractConfi
         /* istanbul ignore else */
         if (result.length > 0) {
           tokensToDetect.forEach((tokenAddress, index) => {
-            const balance: typeof BN = result[index];
+            const balance: BN = result[index];
             /* istanbul ignore else */
             if (!balance.isZero()) {
               nonZeroBalances[tokenAddress] = balance;

--- a/src/assets/AssetsDetectionController.test.ts
+++ b/src/assets/AssetsDetectionController.test.ts
@@ -1,13 +1,12 @@
 import { createSandbox, stub } from 'sinon';
 import * as nock from 'nock';
+import { BN } from 'ethereumjs-util';
 import { NetworkController, NetworksChainId } from '../network/NetworkController';
 import { PreferencesController } from '../user/PreferencesController';
 import { ComposableController } from '../ComposableController';
 import { AssetsController } from './AssetsController';
 import { AssetsContractController } from './AssetsContractController';
 import { AssetsDetectionController } from './AssetsDetectionController';
-
-const { BN } = require('ethereumjs-util');
 
 const DEFAULT_INTERVAL = 180000;
 const MAINNET = 'mainnet';

--- a/src/assets/TokenBalancesController.test.ts
+++ b/src/assets/TokenBalancesController.test.ts
@@ -1,4 +1,5 @@
 import { createSandbox, stub } from 'sinon';
+import { BN } from 'ethereumjs-util';
 import ComposableController from '../ComposableController';
 import { NetworkController } from '../network/NetworkController';
 import { PreferencesController } from '../user/PreferencesController';
@@ -7,7 +8,6 @@ import { Token } from './TokenRatesController';
 import { AssetsContractController } from './AssetsContractController';
 import TokenBalancesController from './TokenBalancesController';
 
-const { BN } = require('ethereumjs-util');
 const HttpProvider = require('ethjs-provider-http');
 
 const MAINNET_PROVIDER = new HttpProvider('https://mainnet.infura.io');
@@ -88,7 +88,7 @@ describe('TokenBalancesController', () => {
 
     new ComposableController([assets, assetsContract, network, preferences, tokenBalances]);
     assetsContract.configure({ provider: MAINNET_PROVIDER });
-    stub(assetsContract, 'getBalanceOf').returns(new BN(1));
+    stub(assetsContract, 'getBalanceOf').resolves(new BN(1));
     await tokenBalances.updateBalances();
     const mytoken = getToken(address);
     expect(mytoken?.balanceError).toBeNull();
@@ -113,11 +113,11 @@ describe('TokenBalancesController', () => {
     const mytoken = getToken(address);
     expect(mytoken?.balanceError).toBeInstanceOf(Error);
     expect(mytoken?.balanceError?.message).toBe(errorMsg);
-    expect(tokenBalances.state.contractBalances[address]).toEqual(0);
+    expect(tokenBalances.state.contractBalances[address].toNumber()).toEqual(0);
 
     // test reset case
     mock.restore();
-    stub(assetsContract, 'getBalanceOf').returns(new BN(1));
+    stub(assetsContract, 'getBalanceOf').resolves(new BN(1));
     await tokenBalances.updateBalances();
     expect(mytoken?.balanceError).toBeNull();
     expect(Object.keys(tokenBalances.state.contractBalances)).toContain(address);

--- a/src/assets/TokenBalancesController.ts
+++ b/src/assets/TokenBalancesController.ts
@@ -1,12 +1,9 @@
+import { BN } from 'ethereumjs-util';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import { safelyExecute } from '../util';
 import AssetsController from './AssetsController';
 import { Token } from './TokenRatesController';
 import { AssetsContractController } from './AssetsContractController';
-
-const { BN } = require('ethereumjs-util');
-
-export { BN };
 
 /**
  * @type TokenBalancesConfig
@@ -29,7 +26,7 @@ export interface TokenBalancesConfig extends BaseConfig {
  * @property contractBalances - Hash of token contract addresses to balances
  */
 export interface TokenBalancesState extends BaseState {
-  contractBalances: { [address: string]: typeof BN };
+  contractBalances: { [address: string]: BN };
 }
 
 /**
@@ -93,14 +90,14 @@ export class TokenBalancesController extends BaseController<TokenBalancesConfig,
     const assets = this.context.AssetsController as AssetsController;
     const { selectedAddress } = assets.config;
     const { tokens } = this.config;
-    const newContractBalances: { [address: string]: typeof BN } = {};
+    const newContractBalances: { [address: string]: BN } = {};
     for (const i in tokens) {
       const { address } = tokens[i];
       try {
         newContractBalances[address] = await assetsContract.getBalanceOf(address, selectedAddress);
         tokens[i].balanceError = null;
       } catch (error) {
-        newContractBalances[address] = 0;
+        newContractBalances[address] = new BN(0);
         tokens[i].balanceError = error;
       }
     }

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import { addHexPrefix, bufferToHex } from 'ethereumjs-util';
+import { BN, addHexPrefix, bufferToHex } from 'ethereumjs-util';
 import { ethErrors } from 'eth-rpc-errors';
 import { v1 as random } from 'uuid';
 import { Mutex } from 'async-mutex';
@@ -21,7 +21,6 @@ import {
 const MethodRegistry = require('eth-method-registry');
 const EthQuery = require('eth-query');
 const Transaction = require('ethereumjs-tx');
-const { BN } = require('ethereumjs-util');
 
 /**
  * @type Result

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,9 +1,8 @@
 import 'isomorphic-fetch';
+import { BN } from 'ethereumjs-util';
 import * as nock from 'nock';
 
 import * as util from './util';
-
-const { BN } = require('ethereumjs-util');
 
 const SOME_API = 'https://someapi.com';
 const SOME_FAILING_API = 'https://somefailingapi.com';


### PR DESCRIPTION
We have been using inconsistent types for token balances. We use a `BN` in most places, but if we fail to find a balance we set it to the number `0`.

We now use `BN` in all cases; `new BN(0)` is the fallback now instead of `0`.

This error was made possible because of various type errors surrounding `BN` and these balances. `typeof BN` was used as the type instead of `BN`, because `BN` was imported using `require` and TypeScript was treating it as a value rather than a class, and unhelpfully suggested using `typeof BN`. This resulted in the type being `any` in effect.

We now import `BN` using `import`, and use `BN` as the type.

This highlighted another problem as well: the return type of the `getBalancesInSingleCall` function in `AssetsContractController` was incorrect. It claimed to return a string balance, but in fact it returned a `BN` balance. The type has been corrected. Fortunately we were not actually _using_ the balance anywhere (I checked mobile as well). We only use the keys of the return type. The main utility of the method is that it automatically omits any tokens with zero balance.

Lastly, the type corrections also highlighted that we had an export not covered by unit tests. The type `BN` was being re-exported, presumably in response to a TypeScript error about the use of a private type. This is another case of TypeScript giving bad advice when it doesn't have proper type information. The unused export has been removed. I confirmed that it was unused in this repo as well as in mobile.