### PR TITLE
Migrate mock encryptor to TypeScript

### DIFF
--- a/src/keyring/KeyringController.test.ts
+++ b/src/keyring/KeyringController.test.ts
@@ -6,12 +6,12 @@ import {
   recoverTypedSignatureLegacy,
 } from 'eth-sig-util';
 import { stub } from 'sinon';
+import MockEncryptor from '../../tests/mocks/mockEncryptor';
 import PreferencesController from '../user/PreferencesController';
 import ComposableController from '../ComposableController';
 import KeyringController, { Keyring, KeyringConfig } from './KeyringController';
 
 const Transaction = require('ethereumjs-tx');
-const mockEncryptor: any = require('../../tests/mocks/mockEncryptor');
 
 const input =
   '{"version":3,"id":"534e0199-53f6-41a9-a8fe-d504702ee5e8","address":"b97c80fab7a3793bbe746864db80d236f1345ea7",' +
@@ -27,7 +27,7 @@ describe('KeyringController', () => {
   let keyringController: KeyringController;
   let preferences: PreferencesController;
   let initialState: { isUnlocked: boolean; keyringTypes: string[]; keyrings: Keyring[] };
-  const baseConfig: Partial<KeyringConfig> = { encryptor: mockEncryptor };
+  const baseConfig: Partial<KeyringConfig> = { encryptor: new MockEncryptor() };
   beforeEach(async () => {
     keyringController = new KeyringController(baseConfig);
     preferences = new PreferencesController();

--- a/tests/mocks/mockEncryptor.ts
+++ b/tests/mocks/mockEncryptor.ts
@@ -1,32 +1,30 @@
-const sinon = require('sinon');
-
 const mockHex = '0xabcdef0123456789';
 const mockKey = Buffer.alloc(32);
-let cacheVal;
+let cacheVal: any;
 
-module.exports = {
-  encrypt: sinon.stub().callsFake(function (_password, dataObj) {
+export default class MockEncryptor {
+  encrypt(_password: string, dataObj: any) {
     cacheVal = dataObj;
     return Promise.resolve(mockHex);
-  }),
+  }
 
-  decrypt(_password, _text) {
+  decrypt(_password: string, _text: string) {
     return Promise.resolve(cacheVal || {});
-  },
+  }
 
-  encryptWithKey(key, dataObj) {
+  encryptWithKey(key: string, dataObj: any) {
     return this.encrypt(key, dataObj);
-  },
+  }
 
-  decryptWithKey(key, text) {
+  decryptWithKey(key: string, text: string) {
     return this.decrypt(key, text);
-  },
+  }
 
-  keyFromPassword(_password) {
+  keyFromPassword(_password: string) {
     return Promise.resolve(mockKey);
-  },
+  }
 
   generateSalt() {
     return 'WHADDASALT!';
-  },
-};
+  }
+}


### PR DESCRIPTION
The mock encryptor we use for the KeyringController tests has been migrated to TypeScript. It has also been converted from an object literal to a class, as it seemed a bit more conventional that way. The `encrypt` function is also no longer a sinon stub - the stub functionality was not used at all.