### PR TITLE
Import `async-mutex` using `import`

### DIFF
--- a/src/assets/AccountTrackerController.ts
+++ b/src/assets/AccountTrackerController.ts
@@ -1,9 +1,9 @@
+import { Mutex } from 'async-mutex';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import PreferencesController from '../user/PreferencesController';
 import { BNToHex, query, safelyExecuteWithTimeout } from '../util';
 
 const EthQuery = require('eth-query');
-const { Mutex } = require('async-mutex');
 
 /**
  * @type AccountInformation

--- a/src/assets/AssetsController.ts
+++ b/src/assets/AssetsController.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 import { toChecksumAddress } from 'ethereumjs-util';
 import { v1 as random } from 'uuid';
+import { Mutex } from 'async-mutex';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import PreferencesController from '../user/PreferencesController';
 import NetworkController, { NetworkType } from '../network/NetworkController';
@@ -8,8 +9,6 @@ import { safelyExecute, handleFetch, validateTokenToWatch } from '../util';
 import { Token } from './TokenRatesController';
 import { AssetsContractController } from './AssetsContractController';
 import { ApiCollectibleResponse } from './AssetsDetectionController';
-
-const { Mutex } = require('async-mutex');
 
 /**
  * @type Collectible

--- a/src/assets/CurrencyRateController.ts
+++ b/src/assets/CurrencyRateController.ts
@@ -1,8 +1,7 @@
+import { Mutex } from 'async-mutex';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import { safelyExecute } from '../util';
 import { fetchExchangeRate as defaultFetchExchangeRate } from '../apis/crypto-compare';
-
-const { Mutex } = require('async-mutex');
 
 /**
  * @type CurrencyRateConfig

--- a/src/keyring/KeyringController.ts
+++ b/src/keyring/KeyringController.ts
@@ -1,13 +1,13 @@
 import { toChecksumAddress } from 'ethereumjs-util';
 import { normalize as normalizeAddress, signTypedData, signTypedData_v4, signTypedDataLegacy } from 'eth-sig-util';
 import Wallet, { thirdparty as importers } from 'ethereumjs-wallet';
+import { Mutex } from 'async-mutex';
 import BaseController, { BaseConfig, BaseState, Listener } from '../BaseController';
 import PreferencesController from '../user/PreferencesController';
 import { PersonalMessageParams } from '../message-manager/PersonalMessageManager';
 import { TypedMessageParams } from '../message-manager/TypedMessageManager';
 
 const Keyring = require('eth-keyring-controller');
-const { Mutex } = require('async-mutex');
 const ethUtil = require('ethereumjs-util');
 
 const privates = new WeakMap();

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -1,10 +1,10 @@
+import { Mutex } from 'async-mutex';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 
 const EthQuery = require('eth-query');
 const Subprovider = require('web3-provider-engine/subproviders/provider.js');
 const createInfuraProvider = require('eth-json-rpc-infura/src/createProvider');
 const createMetamaskProvider = require('web3-provider-engine//zero.js');
-const { Mutex } = require('async-mutex');
 
 /**
  * Human-readable network name

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 import { addHexPrefix, bufferToHex } from 'ethereumjs-util';
 import { ethErrors } from 'eth-rpc-errors';
 import { v1 as random } from 'uuid';
+import { Mutex } from 'async-mutex';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import NetworkController from '../network/NetworkController';
 
@@ -21,7 +22,6 @@ const MethodRegistry = require('eth-method-registry');
 const EthQuery = require('eth-query');
 const Transaction = require('ethereumjs-tx');
 const { BN } = require('ethereumjs-util');
-const { Mutex } = require('async-mutex');
 
 /**
  * @type Result


### PR DESCRIPTION
`async-mutex` is now imported using `import` rather than `require`. This ensures that TypeScript is type checking our usage of the module, rather than typing it as `any`.

No other changes were required.