### PR TITLE
Import `jsonschema` using `import`

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1,13 +1,13 @@
 import { addHexPrefix, isValidAddress, bufferToHex } from 'ethereumjs-util';
 import { ethErrors } from 'eth-rpc-errors';
 import { TYPED_MESSAGE_SCHEMA, typedSignatureHash } from 'eth-sig-util';
+import * as jsonschema from 'jsonschema';
 import { Transaction, FetchAllOptions } from './transaction/TransactionController';
 import { MessageParams } from './message-manager/MessageManager';
 import { PersonalMessageParams } from './message-manager/PersonalMessageManager';
 import { TypedMessageParams } from './message-manager/TypedMessageManager';
 import { Token } from './assets/TokenRatesController';
 
-const jsonschema = require('jsonschema');
 const { BN, stripHexPrefix } = require('ethereumjs-util');
 const ensNamehash = require('eth-ens-namehash');
 


### PR DESCRIPTION
`jsonschema` is now imported using `import` rather than `require`. This ensures that TypeScript is type checking our usage of the module, rather than typing it as `any`.

No other changes were required.