### PR TITLE
Ensure `uuid` is type-checked

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@metamask/contract-metadata": "^1.23.0",
+    "@types/uuid": "^8.3.0",
     "async-mutex": "^0.2.6",
     "babel-runtime": "^6.26.0",
     "eth-ens-namehash": "^2.0.8",

--- a/src/assets/AssetsController.ts
+++ b/src/assets/AssetsController.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import { toChecksumAddress } from 'ethereumjs-util';
+import { v1 as random } from 'uuid';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import PreferencesController from '../user/PreferencesController';
 import NetworkController, { NetworkType } from '../network/NetworkController';
@@ -9,7 +10,6 @@ import { AssetsContractController } from './AssetsContractController';
 import { ApiCollectibleResponse } from './AssetsDetectionController';
 
 const { Mutex } = require('async-mutex');
-const random = require('uuid').v1;
 
 /**
  * @type Collectible

--- a/src/message-manager/MessageManager.ts
+++ b/src/message-manager/MessageManager.ts
@@ -1,3 +1,4 @@
+import { v1 as random } from 'uuid';
 import { validateSignMessageData, normalizeMessageData } from '../util';
 import AbstractMessageManager, {
   AbstractMessage,
@@ -5,8 +6,6 @@ import AbstractMessageManager, {
   AbstractMessageParamsMetamask,
   OriginalRequest,
 } from './AbstractMessageManager';
-
-const random = require('uuid').v1;
 
 /**
  * @type Message

--- a/src/message-manager/PersonalMessageManager.ts
+++ b/src/message-manager/PersonalMessageManager.ts
@@ -1,3 +1,4 @@
+import { v1 as random } from 'uuid';
 import { validateSignMessageData, normalizeMessageData } from '../util';
 import AbstractMessageManager, {
   AbstractMessage,
@@ -5,8 +6,6 @@ import AbstractMessageManager, {
   AbstractMessageParamsMetamask,
   OriginalRequest,
 } from './AbstractMessageManager';
-
-const random = require('uuid').v1;
 
 /**
  * @type Message

--- a/src/message-manager/TypedMessageManager.ts
+++ b/src/message-manager/TypedMessageManager.ts
@@ -1,3 +1,4 @@
+import { v1 as random } from 'uuid';
 import { validateTypedSignMessageDataV3, validateTypedSignMessageDataV1 } from '../util';
 import AbstractMessageManager, {
   AbstractMessage,
@@ -5,8 +6,6 @@ import AbstractMessageManager, {
   AbstractMessageParamsMetamask,
   OriginalRequest,
 } from './AbstractMessageManager';
-
-const random = require('uuid').v1;
 
 /**
  * @type TypedMessage

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 import { addHexPrefix, bufferToHex } from 'ethereumjs-util';
 import { ethErrors } from 'eth-rpc-errors';
+import { v1 as random } from 'uuid';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import NetworkController from '../network/NetworkController';
 
@@ -19,7 +20,6 @@ import {
 const MethodRegistry = require('eth-method-registry');
 const EthQuery = require('eth-query');
 const Transaction = require('ethereumjs-tx');
-const random = require('uuid').v1;
 const { BN } = require('ethereumjs-util');
 const { Mutex } = require('async-mutex');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -895,6 +895,11 @@
   resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.9.2.tgz#2c4f7743287218f5c2d9a83db3806672aa48530d"
   integrity sha512-KgOKTAD+9X+qvZnB5S1+onqKc4E+PZ+T6CM/NA5ohRPLHJXb+yCJMVf8pWOnvuBuKFNUAJW8N97IA6lba6mZGg==
 
+"@types/uuid@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
+
 "@types/web3@^1.0.6":
   version "1.0.19"
   resolved "https://registry.yarnpkg.com/@types/web3/-/web3-1.0.19.tgz#46b85d91d398ded9ab7c85a5dd57cb33ac558924"


### PR DESCRIPTION
Our use of the dependency `uuid` is now type-checked. The imports have been updated to use `import` rather than `require`, and the package `@types/uuid` has been added to bring in type definitions.