### PR TITLE
Enable `esModuleInterop`

### DIFF
--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -1,5 +1,5 @@
 import type { Draft, Patch } from 'immer';
-import * as sinon from 'sinon';
+import sinon from 'sinon';
 
 import { BaseController, getAnonymizedState, getPersistentState } from './BaseControllerV2';
 import { ControllerMessenger } from './ControllerMessenger';

--- a/src/ControllerMessenger.test.ts
+++ b/src/ControllerMessenger.test.ts
@@ -1,4 +1,4 @@
-import * as sinon from 'sinon';
+import sinon from 'sinon';
 
 import { ControllerMessenger } from './ControllerMessenger';
 

--- a/src/apis/crypto-compare.test.ts
+++ b/src/apis/crypto-compare.test.ts
@@ -1,4 +1,4 @@
-import * as nock from 'nock';
+import nock from 'nock';
 
 import { fetchExchangeRate } from './crypto-compare';
 

--- a/src/approval/ApprovalController.test.ts
+++ b/src/approval/ApprovalController.test.ts
@@ -1,5 +1,5 @@
 import { errorCodes } from 'eth-rpc-errors';
-import * as sinon from 'sinon';
+import sinon from 'sinon';
 import ApprovalController from './ApprovalController';
 
 const STORE_KEY = 'pendingApprovals';

--- a/src/assets/AssetsController.test.ts
+++ b/src/assets/AssetsController.test.ts
@@ -1,5 +1,5 @@
 import { createSandbox } from 'sinon';
-import * as nock from 'nock';
+import nock from 'nock';
 import ComposableController from '../ComposableController';
 import PreferencesController from '../user/PreferencesController';
 import { NetworkController, NetworksChainId } from '../network/NetworkController';

--- a/src/assets/AssetsDetectionController.test.ts
+++ b/src/assets/AssetsDetectionController.test.ts
@@ -1,5 +1,5 @@
 import { createSandbox, stub } from 'sinon';
-import * as nock from 'nock';
+import nock from 'nock';
 import { BN } from 'ethereumjs-util';
 import { NetworkController, NetworksChainId } from '../network/NetworkController';
 import { PreferencesController } from '../user/PreferencesController';

--- a/src/assets/TokenRatesController.test.ts
+++ b/src/assets/TokenRatesController.test.ts
@@ -1,5 +1,5 @@
 import { stub } from 'sinon';
-import * as nock from 'nock';
+import nock from 'nock';
 import ComposableController from '../ComposableController';
 import { PreferencesController } from '../user/PreferencesController';
 import { NetworkController } from '../network/NetworkController';

--- a/src/third-party/PhishingController.test.ts
+++ b/src/third-party/PhishingController.test.ts
@@ -1,5 +1,5 @@
 import { stub } from 'sinon';
-import * as nock from 'nock';
+import nock from 'nock';
 import PhishingController from './PhishingController';
 
 describe('PhishingController', () => {

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,6 +1,6 @@
 import 'isomorphic-fetch';
 import { BN } from 'ethereumjs-util';
-import * as nock from 'nock';
+import nock from 'nock';
 
 import * as util from './util';
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,7 @@
 import { addHexPrefix, isValidAddress, bufferToHex } from 'ethereumjs-util';
 import { ethErrors } from 'eth-rpc-errors';
 import { TYPED_MESSAGE_SCHEMA, typedSignatureHash } from 'eth-sig-util';
-import * as jsonschema from 'jsonschema';
+import jsonschema from 'jsonschema';
 import { Transaction, FetchAllOptions } from './transaction/TransactionController';
 import { MessageParams } from './message-manager/MessageManager';
 import { PersonalMessageParams } from './message-manager/PersonalMessageManager';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "declarationDir": "dist",
+    "esModuleInterop": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "noUnusedLocals": true,


### PR DESCRIPTION
This flag makes it easier to work with ES5 dependencies in TypeScript, and it improves type checking for all dependencies by ensuring namespace imports aren't called accidentally. It is described in more detail in [the changelog where it was introduced](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#support-for-import-d-from-cjs-from-commonjs-modules-with---esmoduleinterop).

In particular, see this note:

>Note: The new behavior is added under a flag to avoid unwarranted breaks to existing code bases. **We highly recommend applying it both to new and existing projects**. For existing projects, namespace imports (`import * as express from "express"; express();`) will need to be converted to default imports (`import express from "express"; express();`).

Any namespace imports where the namespace is called have been converted to default imports. This only applied to two dependencies: `nock` and `sinon`.