### PR TITLE
Disallow using `require` for imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,8 +34,6 @@ module.exports = {
 
         // TODO re-enable most of these rules
         '@typescript-eslint/no-non-null-assertion': 'off',
-        '@typescript-eslint/no-require-imports': 'off',
-        '@typescript-eslint/no-var-requires': 'off',
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ethereumjs-tx": "^1.3.7",
     "ethereumjs-util": "^6.1.0",
     "ethereumjs-wallet": "^1.0.1",
+    "ethjs-util": "^0.1.6",
     "human-standard-collectible-abi": "^1.0.2",
     "human-standard-token-abi": "^2.0.0",
     "immer": "^8.0.1",

--- a/src/assets/AccountTrackerController.test.ts
+++ b/src/assets/AccountTrackerController.test.ts
@@ -1,9 +1,8 @@
 import { stub, spy } from 'sinon';
+import HttpProvider from 'ethjs-provider-http';
 import PreferencesController from '../user/PreferencesController';
 import ComposableController from '../ComposableController';
 import AccountTrackerController from './AccountTrackerController';
-
-const HttpProvider = require('ethjs-provider-http');
 
 const provider = new HttpProvider('https://ropsten.infura.io/v3/341eacb578dd44a1a049cbc5f6fd4035');
 

--- a/src/assets/AccountTrackerController.ts
+++ b/src/assets/AccountTrackerController.ts
@@ -1,9 +1,8 @@
+import EthQuery from 'eth-query';
 import { Mutex } from 'async-mutex';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import PreferencesController from '../user/PreferencesController';
 import { BNToHex, query, safelyExecuteWithTimeout } from '../util';
-
-const EthQuery = require('eth-query');
 
 /**
  * @type AccountInformation

--- a/src/assets/AssetsContractController.test.ts
+++ b/src/assets/AssetsContractController.test.ts
@@ -1,6 +1,5 @@
+import HttpProvider from 'ethjs-provider-http';
 import { AssetsContractController } from './AssetsContractController';
-
-const HttpProvider = require('ethjs-provider-http');
 
 const MAINNET_PROVIDER = new HttpProvider('https://mainnet.infura.io/v3/341eacb578dd44a1a049cbc5f6fd4035');
 const GODSADDRESS = '0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab';

--- a/src/assets/AssetsContractController.ts
+++ b/src/assets/AssetsContractController.ts
@@ -1,10 +1,9 @@
 import { BN } from 'ethereumjs-util';
+import Web3 from 'web3';
+import abiERC20 from 'human-standard-token-abi';
+import abiERC721 from 'human-standard-collectible-abi';
+import abiSingleCallBalancesContract from 'single-call-balance-checker-abi';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
-
-const Web3 = require('web3');
-const abiERC20 = require('human-standard-token-abi');
-const abiERC721 = require('human-standard-collectible-abi');
-const abiSingleCallBalancesContract = require('single-call-balance-checker-abi');
 
 const ERC721METADATA_INTERFACE_ID = '0x5b5e139f';
 const ERC721ENUMERABLE_INTERFACE_ID = '0x780e9d63';

--- a/src/assets/AssetsController.test.ts
+++ b/src/assets/AssetsController.test.ts
@@ -1,12 +1,11 @@
 import { createSandbox } from 'sinon';
 import nock from 'nock';
+import HttpProvider from 'ethjs-provider-http';
 import ComposableController from '../ComposableController';
 import PreferencesController from '../user/PreferencesController';
 import { NetworkController, NetworksChainId } from '../network/NetworkController';
 import { AssetsContractController } from './AssetsContractController';
 import AssetsController from './AssetsController';
-
-const HttpProvider = require('ethjs-provider-http');
 
 const KUDOSADDRESS = '0x2aea4add166ebf38b63d09a75de1a7b94aa24163';
 const MAINNET_PROVIDER = new HttpProvider('https://mainnet.infura.io/v3/341eacb578dd44a1a049cbc5f6fd4035');

--- a/src/assets/AssetsDetectionController.test.ts
+++ b/src/assets/AssetsDetectionController.test.ts
@@ -1,6 +1,6 @@
 import { createSandbox, stub } from 'sinon';
-import nock from 'nock';
 import { BN } from 'ethereumjs-util';
+import nock from 'nock';
 import { NetworkController, NetworksChainId } from '../network/NetworkController';
 import { PreferencesController } from '../user/PreferencesController';
 import { ComposableController } from '../ComposableController';

--- a/src/assets/AssetsDetectionController.ts
+++ b/src/assets/AssetsDetectionController.ts
@@ -1,4 +1,5 @@
 import { toChecksumAddress } from 'ethereumjs-util';
+import contractMap from '@metamask/contract-metadata';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import NetworkController, { NetworkType } from '../network/NetworkController';
 import PreferencesController from '../user/PreferencesController';
@@ -7,8 +8,6 @@ import AssetsContractController from './AssetsContractController';
 import { Token } from './TokenRatesController';
 
 import AssetsController from './AssetsController';
-
-const contractMap = require('@metamask/contract-metadata');
 
 const DEFAULT_INTERVAL = 180000;
 const MAINNET = 'mainnet';

--- a/src/assets/TokenBalancesController.test.ts
+++ b/src/assets/TokenBalancesController.test.ts
@@ -1,5 +1,6 @@
 import { createSandbox, stub } from 'sinon';
 import { BN } from 'ethereumjs-util';
+import HttpProvider from 'ethjs-provider-http';
 import ComposableController from '../ComposableController';
 import { NetworkController } from '../network/NetworkController';
 import { PreferencesController } from '../user/PreferencesController';
@@ -7,8 +8,6 @@ import { AssetsController } from './AssetsController';
 import { Token } from './TokenRatesController';
 import { AssetsContractController } from './AssetsContractController';
 import TokenBalancesController from './TokenBalancesController';
-
-const HttpProvider = require('ethjs-provider-http');
 
 const MAINNET_PROVIDER = new HttpProvider('https://mainnet.infura.io');
 

--- a/src/dependencies.d.ts
+++ b/src/dependencies.d.ts
@@ -1,0 +1,35 @@
+// TODO: Add types to each of these packages, replace them, or add full types here.
+
+declare module '@metamask/contract-metadata';
+
+declare module 'eth-ens-namehash';
+
+declare module 'eth-json-rpc-infura/src/createProvider';
+
+declare module 'eth-keyring-controller';
+
+declare module 'eth-phishing-detect/src/config.json';
+
+declare module 'eth-phishing-detect/src/detector';
+
+declare module 'eth-query';
+
+declare module 'ethereumjs-tx';
+
+declare module 'ethjs-provider-http';
+
+declare module 'ethjs-util';
+
+declare module 'human-standard-collectible-abi';
+
+declare module 'human-standard-token-abi';
+
+declare module 'isomorphic-fetch';
+
+declare module 'single-call-balance-checker-abi';
+
+declare module 'web3-provider-engine';
+
+declare module 'web3-provider-engine/subproviders/provider';
+
+declare module 'web3-provider-engine/zero';

--- a/src/keyring/KeyringController.test.ts
+++ b/src/keyring/KeyringController.test.ts
@@ -6,6 +6,7 @@ import {
   recoverTypedSignatureLegacy,
 } from 'eth-sig-util';
 import { stub } from 'sinon';
+import Transaction from 'ethereumjs-tx';
 import MockEncryptor from '../../tests/mocks/mockEncryptor';
 import PreferencesController from '../user/PreferencesController';
 import ComposableController from '../ComposableController';
@@ -15,8 +16,6 @@ import KeyringController, {
   KeyringConfig,
   SignTypedDataVersion,
 } from './KeyringController';
-
-const Transaction = require('ethereumjs-tx');
 
 const input =
   '{"version":3,"id":"534e0199-53f6-41a9-a8fe-d504702ee5e8","address":"b97c80fab7a3793bbe746864db80d236f1345ea7",' +

--- a/src/keyring/KeyringController.ts
+++ b/src/keyring/KeyringController.ts
@@ -1,14 +1,13 @@
-import { toChecksumAddress } from 'ethereumjs-util';
+import * as ethUtil from 'ethereumjs-util';
+import { stripHexPrefix } from 'ethjs-util';
 import { normalize as normalizeAddress, signTypedData, signTypedData_v4, signTypedDataLegacy } from 'eth-sig-util';
 import Wallet, { thirdparty as importers } from 'ethereumjs-wallet';
+import Keyring from 'eth-keyring-controller';
 import { Mutex } from 'async-mutex';
 import BaseController, { BaseConfig, BaseState, Listener } from '../BaseController';
 import PreferencesController from '../user/PreferencesController';
 import { PersonalMessageParams } from '../message-manager/PersonalMessageManager';
 import { TypedMessageParams } from '../message-manager/TypedMessageManager';
-
-const Keyring = require('eth-keyring-controller');
-const ethUtil = require('ethereumjs-util');
 
 const privates = new WeakMap();
 
@@ -292,7 +291,7 @@ export class KeyringController extends BaseController<KeyringConfig, KeyringStat
         if (!ethUtil.isValidPrivate(ethUtil.toBuffer(prefixed))) {
           throw new Error('Cannot import invalid private key.');
         }
-        privateKey = ethUtil.stripHexPrefix(prefixed);
+        privateKey = stripHexPrefix(prefixed);
         break;
       case 'json':
         let wallet;
@@ -501,7 +500,7 @@ export class KeyringController extends BaseController<KeyringConfig, KeyringStat
         async (keyring: KeyringObject, index: number): Promise<Keyring> => {
           const keyringAccounts = await keyring.getAccounts();
           const accounts = Array.isArray(keyringAccounts)
-            ? keyringAccounts.map((address) => toChecksumAddress(address))
+            ? keyringAccounts.map((address) => ethUtil.toChecksumAddress(address))
             : /* istanbul ignore next */ [];
           return {
             accounts,

--- a/src/network/NetworkController.test.ts
+++ b/src/network/NetworkController.test.ts
@@ -1,7 +1,6 @@
 import { stub } from 'sinon';
+import Web3ProviderEngine from 'web3-provider-engine';
 import NetworkController, { NetworksChainId, ProviderConfig, NetworkType } from './NetworkController';
-
-const Web3ProviderEngine = require('web3-provider-engine');
 
 const RPC_TARGET = 'http://foo';
 

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -1,10 +1,9 @@
+import EthQuery from 'eth-query';
+import Subprovider from 'web3-provider-engine/subproviders/provider';
+import createInfuraProvider from 'eth-json-rpc-infura/src/createProvider';
+import createMetamaskProvider from 'web3-provider-engine/zero';
 import { Mutex } from 'async-mutex';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
-
-const EthQuery = require('eth-query');
-const Subprovider = require('web3-provider-engine/subproviders/provider.js');
-const createInfuraProvider = require('eth-json-rpc-infura/src/createProvider');
-const createMetamaskProvider = require('web3-provider-engine//zero.js');
 
 /**
  * Human-readable network name

--- a/src/third-party/PhishingController.ts
+++ b/src/third-party/PhishingController.ts
@@ -1,8 +1,7 @@
+import DEFAULT_PHISHING_RESPONSE from 'eth-phishing-detect/src/config.json';
+import PhishingDetector from 'eth-phishing-detect/src/detector';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
 import { safelyExecute } from '../util';
-
-const DEFAULT_PHISHING_RESPONSE = require('eth-phishing-detect/src/config.json');
-const PhishingDetector = require('eth-phishing-detect/src/detector');
 
 /**
  * @type EthPhishingResponse

--- a/src/transaction/TransactionController.test.ts
+++ b/src/transaction/TransactionController.test.ts
@@ -1,4 +1,5 @@
 import { stub } from 'sinon';
+import HttpProvider from 'ethjs-provider-http';
 import { NetworksChainId } from '../network/NetworkController';
 import { TransactionController, TransactionStatus, TransactionMeta } from './TransactionController';
 
@@ -57,8 +58,6 @@ function mockFetchs(data: any) {
     }),
   );
 }
-
-const HttpProvider = require('ethjs-provider-http');
 
 const MOCK_PRFERENCES = { state: { selectedAddress: 'foo' } };
 const PROVIDER = new HttpProvider('https://ropsten.infura.io/v3/341eacb578dd44a1a049cbc5f6fd4035');

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -1,6 +1,9 @@
 import { EventEmitter } from 'events';
-import { BN, addHexPrefix, bufferToHex } from 'ethereumjs-util';
+import { addHexPrefix, bufferToHex, BN } from 'ethereumjs-util';
 import { ethErrors } from 'eth-rpc-errors';
+import MethodRegistry from 'eth-method-registry';
+import EthQuery from 'eth-query';
+import Transaction from 'ethereumjs-tx';
 import { v1 as random } from 'uuid';
 import { Mutex } from 'async-mutex';
 import BaseController, { BaseConfig, BaseState } from '../BaseController';
@@ -17,10 +20,6 @@ import {
   handleTransactionFetch,
   query,
 } from '../util';
-
-const MethodRegistry = require('eth-method-registry');
-const EthQuery = require('eth-query');
-const Transaction = require('ethereumjs-tx');
 
 /**
  * @type Result

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,13 +1,12 @@
 import 'isomorphic-fetch';
 import { BN } from 'ethereumjs-util';
 import nock from 'nock';
-
+import HttpProvider from 'ethjs-provider-http';
+import EthQuery from 'eth-query';
 import * as util from './util';
 
 const SOME_API = 'https://someapi.com';
 const SOME_FAILING_API = 'https://somefailingapi.com';
-const HttpProvider = require('ethjs-provider-http');
-const EthQuery = require('eth-query');
 
 const mockFlags: { [key: string]: any } = {
   estimateGas: null,

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,7 @@
-import { addHexPrefix, isValidAddress, bufferToHex } from 'ethereumjs-util';
+import { addHexPrefix, isValidAddress, bufferToHex, BN } from 'ethereumjs-util';
+import { stripHexPrefix } from 'ethjs-util';
 import { ethErrors } from 'eth-rpc-errors';
+import ensNamehash from 'eth-ens-namehash';
 import { TYPED_MESSAGE_SCHEMA, typedSignatureHash } from 'eth-sig-util';
 import jsonschema from 'jsonschema';
 import { Transaction, FetchAllOptions } from './transaction/TransactionController';
@@ -7,9 +9,6 @@ import { MessageParams } from './message-manager/MessageManager';
 import { PersonalMessageParams } from './message-manager/PersonalMessageManager';
 import { TypedMessageParams } from './message-manager/TypedMessageManager';
 import { Token } from './assets/TokenRatesController';
-
-const { BN, stripHexPrefix } = require('ethereumjs-util');
-const ensNamehash = require('eth-ens-namehash');
 
 const hexRe = /^[0-9A-Fa-f]+$/gu;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2985,7 +2985,7 @@ ethjs-util@0.1.3:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
 
-ethjs-util@0.1.6, ethjs-util@^0.1.3:
+ethjs-util@0.1.6, ethjs-util@^0.1.3, ethjs-util@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ethjs-util/-/ethjs-util-0.1.6.tgz#f308b62f185f9fe6237132fb2a9818866a5cd536"
   integrity sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==


### PR DESCRIPTION
The ESLint rule `@typescript-eslint/no-require-imports` has been re-enabled, which prevents using `require` to import modules. We have been using `require` in this codebase primarily to avoid the warning from TypeScript about each dependency that lacks types. That warning has been adding an empty declaration for each third-party module we use that lacks types. Effectively this declares them as type `any`.