### PR TITLE
Remove unnecessary ESLint rule override

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,19 +36,6 @@ module.exports = {
         '@typescript-eslint/no-non-null-assertion': 'off',
         '@typescript-eslint/no-require-imports': 'off',
         '@typescript-eslint/no-var-requires': 'off',
-        '@typescript-eslint/member-delimiter-style': [
-          'error',
-          {
-            multiline: {
-              delimiter: 'semi',
-              requireLast: true,
-            },
-            singleline: {
-              delimiter: 'semi',
-              requireLast: false,
-            },
-          },
-        ],
       },
     },
   ],


### PR DESCRIPTION
The rule `@typescript-eslint/member-delimiter-style` was being set with the exact same options used in `@metamask/eslint-config/config/typescript`. It was redundant, so it has been removed.