### PR TITLE
Prefer optional chain

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,7 +43,6 @@ module.exports = {
             },
           },
         ],
-        '@typescript-eslint/prefer-optional-chain': 'off',
       },
     },
   ],

--- a/src/ComposableController.ts
+++ b/src/ComposableController.ts
@@ -65,7 +65,7 @@ export class ComposableController extends BaseController<any, any> {
       const { name } = controller;
       this.context[name] = controller;
       controller.context = this.context;
-      this.cachedState && this.cachedState[name] && controller.update(this.cachedState[name]);
+      this.cachedState?.[name] && controller.update(this.cachedState[name]);
       initialState[name] = controller.state;
       controller.subscribe((state) => {
         this.update({ [name]: state });

--- a/src/assets/AssetsController.ts
+++ b/src/assets/AssetsController.ts
@@ -846,10 +846,9 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
       const { networkType } = this.config;
       this.configure({ selectedAddress });
       this.update({
-        collectibleContracts:
-          (allCollectibleContracts[selectedAddress] && allCollectibleContracts[selectedAddress][networkType]) || [],
-        collectibles: (allCollectibles[selectedAddress] && allCollectibles[selectedAddress][networkType]) || [],
-        tokens: (allTokens[selectedAddress] && allTokens[selectedAddress][networkType]) || [],
+        collectibleContracts: allCollectibleContracts[selectedAddress]?.[networkType] || [],
+        collectibles: allCollectibles[selectedAddress]?.[networkType] || [],
+        tokens: allTokens[selectedAddress]?.[networkType] || [],
       });
     });
     network.subscribe(({ provider }) => {
@@ -858,10 +857,9 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
       const networkType = provider.type;
       this.configure({ networkType });
       this.update({
-        collectibleContracts:
-          (allCollectibleContracts[selectedAddress] && allCollectibleContracts[selectedAddress][networkType]) || [],
-        collectibles: (allCollectibles[selectedAddress] && allCollectibles[selectedAddress][networkType]) || [],
-        tokens: (allTokens[selectedAddress] && allTokens[selectedAddress][networkType]) || [],
+        collectibleContracts: allCollectibleContracts[selectedAddress]?.[networkType] || [],
+        collectibles: allCollectibles[selectedAddress]?.[networkType] || [],
+        tokens: allTokens[selectedAddress]?.[networkType] || [],
       });
     });
   }

--- a/src/assets/CurrencyRateController.ts
+++ b/src/assets/CurrencyRateController.ts
@@ -58,7 +58,7 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
   private fetchExchangeRate: typeof defaultFetchExchangeRate;
 
   private getCurrentCurrencyFromState(state?: Partial<CurrencyRateState>) {
-    return state && state.currentCurrency ? state.currentCurrency : 'usd';
+    return state?.currentCurrency ? state.currentCurrency : 'usd';
   }
 
   /**

--- a/src/message-manager/AbstractMessageManager.test.ts
+++ b/src/message-manager/AbstractMessageManager.test.ts
@@ -187,11 +187,11 @@ describe('AbstractTestManager', () => {
         type: 'type',
       });
       const messageBefore = controller.getMessage(messageId);
-      expect(messageBefore && messageBefore.status).toEqual('status');
+      expect(messageBefore?.status).toEqual('status');
 
       controller.setMessageStatus(messageId, 'newstatus');
       const messageAfter = controller.getMessage(messageId);
-      expect(messageAfter && messageAfter.status).toEqual('newstatus');
+      expect(messageAfter?.status).toEqual('newstatus');
     });
 
     it('should throw an error if message is not found', () => {

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -152,7 +152,7 @@ export class NetworkController extends BaseController<NetworkConfig, NetworkStat
 
   private safelyStopProvider(provider: any) {
     setTimeout(() => {
-      provider && provider.stop();
+      provider?.stop();
     }, 500);
   }
 

--- a/src/third-party/EnsController.ts
+++ b/src/third-party/EnsController.ts
@@ -131,7 +131,7 @@ export class EnsController extends BaseController<BaseConfig, EnsState> {
     const normalizedAddress = address ? toChecksumAddress(address) : null;
     const subState = this.state.ensEntries[chainId];
 
-    if (subState && subState[normalizedEnsName] && subState[normalizedEnsName].address === normalizedAddress) {
+    if (subState?.[normalizedEnsName] && subState[normalizedEnsName].address === normalizedAddress) {
       return false;
     }
 

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -676,8 +676,8 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
             (meta.chainId === currentChainId || (!meta.chainId && meta.networkID === currentNetworkID))
           ) {
             const txObj = await query(this.ethQuery, 'getTransactionByHash', [meta.transactionHash]);
-            /* istanbul ignore else */
-            if (txObj && txObj.blockNumber) {
+            /* istanbul ignore next */
+            if (txObj?.blockNumber) {
               transactions[index].status = 'confirmed';
               this.hub.emit(`${meta.id}:confirmed`, meta);
               gotUpdates = true;

--- a/src/util.ts
+++ b/src/util.ts
@@ -115,23 +115,11 @@ export async function handleTransactionFetch(
   opt?: FetchAllOptions,
 ): Promise<[{ [result: string]: [] }, { [result: string]: [] }]> {
   // transactions
-  const etherscanTxUrl = getEtherscanApiUrl(
-    networkType,
-    address,
-    'txlist',
-    opt && opt.fromBlock,
-    opt && opt.etherscanApiKey,
-  );
+  const etherscanTxUrl = getEtherscanApiUrl(networkType, address, 'txlist', opt?.fromBlock, opt?.etherscanApiKey);
   const etherscanTxResponsePromise = handleFetch(etherscanTxUrl);
 
   // tokens
-  const etherscanTokenUrl = getEtherscanApiUrl(
-    networkType,
-    address,
-    'tokentx',
-    opt && opt.fromBlock,
-    opt && opt.etherscanApiKey,
-  );
+  const etherscanTokenUrl = getEtherscanApiUrl(networkType, address, 'tokentx', opt?.fromBlock, opt?.etherscanApiKey);
   const etherscanTokenResponsePromise = handleFetch(etherscanTokenUrl);
 
   let [etherscanTxResponse, etherscanTokenResponse] = await Promise.all([
@@ -212,7 +200,7 @@ export async function safelyExecute(operation: () => Promise<any>, logError = fa
     if (logError) {
       console.error(error);
     }
-    retry && retry(error);
+    retry?.(error);
   }
 }
 


### PR DESCRIPTION
The ESLint rule `@typescript-eslint/prefer-optional-chain` has been re-enabled. All rule violations have been updated to use the optional chain operator.