### PR TITLE
Re-enable `accessor-pairs` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,7 +53,6 @@ module.exports = {
     },
   ],
   rules: {
-    'accessor-pairs': 'off',
     camelcase: 'off',
     'consistent-return': 'off',
     'default-case': 'off',

--- a/src/assets/AccountTrackerController.test.ts
+++ b/src/assets/AccountTrackerController.test.ts
@@ -15,6 +15,11 @@ describe('AccountTrackerController', () => {
     });
   });
 
+  it('should throw when provider property is accessed', () => {
+    const controller = new AccountTrackerController();
+    expect(() => console.log(controller.provider)).toThrow();
+  });
+
   it('should get real balance', async () => {
     const address = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
     const controller = new AccountTrackerController({ provider });

--- a/src/assets/AccountTrackerController.ts
+++ b/src/assets/AccountTrackerController.ts
@@ -95,10 +95,16 @@ export class AccountTrackerController extends BaseController<AccountTrackerConfi
   /**
    * Sets a new provider
    *
+   * TODO: Replace this wth a method
+   *
    * @param provider - Provider used to create a new underlying EthQuery instance
    */
   set provider(provider: any) {
     this.ethQuery = new EthQuery(provider);
+  }
+
+  get provider() {
+    throw new Error('Property only used for setting');
   }
 
   /**

--- a/src/assets/AssetsContractController.test.ts
+++ b/src/assets/AssetsContractController.test.ts
@@ -20,6 +20,10 @@ describe('AssetsContractController', () => {
     });
   });
 
+  it('should throw when provider property is accessed', () => {
+    expect(() => console.log(assetsContract.provider)).toThrow();
+  });
+
   it('should determine if contract supports interface correctly', async () => {
     assetsContract.configure({ provider: MAINNET_PROVIDER });
     const CKSupportsEnumerable = await assetsContract.contractSupportsEnumerableInterface(CKADDRESS);

--- a/src/assets/AssetsContractController.ts
+++ b/src/assets/AssetsContractController.ts
@@ -82,10 +82,16 @@ export class AssetsContractController extends BaseController<AssetsContractConfi
   /**
    * Sets a new provider
    *
+   * TODO: Replace this wth a method
+   *
    * @property provider - Provider used to create a new underlying Web3 instance
    */
   set provider(provider: any) {
     this.web3 = new Web3(provider);
+  }
+
+  get provider() {
+    throw new Error('Property only used for setting');
   }
 
   /**

--- a/src/assets/CurrencyRateController.test.ts
+++ b/src/assets/CurrencyRateController.test.ts
@@ -46,6 +46,18 @@ describe('CurrencyRateController', () => {
     controller.disabled = true;
   });
 
+  it('should throw when currentCurrency property is accessed', () => {
+    const fetchExchangeRateStub = stub();
+    const controller = new CurrencyRateController({}, {}, fetchExchangeRateStub);
+    expect(() => console.log(controller.currentCurrency)).toThrow();
+  });
+
+  it('should throw when nativeCurrency property is accessed', () => {
+    const fetchExchangeRateStub = stub();
+    const controller = new CurrencyRateController({}, {}, fetchExchangeRateStub);
+    expect(() => console.log(controller.nativeCurrency)).toThrow();
+  });
+
   it('should poll and update rate in the right interval', async () => {
     const fetchExchangeRateStub = stub();
     const controller = new CurrencyRateController({ interval: 100 }, {}, fetchExchangeRateStub);

--- a/src/assets/CurrencyRateController.ts
+++ b/src/assets/CurrencyRateController.ts
@@ -101,6 +101,8 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
   /**
    * Sets a currency to track
    *
+   * TODO: Replace this wth a method
+   *
    * @param currentCurrency - ISO 4217 currency code
    */
   set currentCurrency(currentCurrency: string) {
@@ -108,14 +110,24 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
     safelyExecute(() => this.updateExchangeRate());
   }
 
+  get currentCurrency() {
+    throw new Error('Property only used for setting');
+  }
+
   /**
    * Sets a new native currency
+   *
+   * TODO: Replace this wth a method
    *
    * @param symbol - Symbol for the base asset
    */
   set nativeCurrency(symbol: string) {
     this.activeNativeCurrency = symbol;
     safelyExecute(() => this.updateExchangeRate());
+  }
+
+  get nativeCurrency() {
+    throw new Error('Property only used for setting');
   }
 
   /**

--- a/src/assets/TokenRatesController.test.ts
+++ b/src/assets/TokenRatesController.test.ts
@@ -49,6 +49,11 @@ describe('TokenRatesController', () => {
     });
   });
 
+  it('should throw when tokens property is accessed', () => {
+    const controller = new TokenRatesController();
+    expect(() => console.log(controller.tokens)).toThrow();
+  });
+
   it('should poll and update rate in the right interval', () => {
     return new Promise<void>((resolve) => {
       const mock = stub(TokenRatesController.prototype, 'fetchExchangeRate');

--- a/src/assets/TokenRatesController.ts
+++ b/src/assets/TokenRatesController.ts
@@ -119,11 +119,17 @@ export class TokenRatesController extends BaseController<TokenRatesConfig, Token
   /**
    * Sets a new token list to track prices
    *
+   * TODO: Replace this wth a method
+   *
    * @param tokens - List of tokens to track exchange rates for
    */
   set tokens(tokens: Token[]) {
     this.tokenList = tokens;
     !this.disabled && safelyExecute(() => this.updateExchangeRates());
+  }
+
+  get tokens() {
+    throw new Error('Property only used for setting');
   }
 
   /**

--- a/src/network/NetworkController.test.ts
+++ b/src/network/NetworkController.test.ts
@@ -17,6 +17,11 @@ describe('NetworkController', () => {
     });
   });
 
+  it('should throw when providerConfig property is accessed', () => {
+    const controller = new NetworkController();
+    expect(() => console.log(controller.providerConfig)).toThrow();
+  });
+
   it('should create a provider instance for default infura network', () => {
     const testConfig = {
       infuraProjectId: 'foo',

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -188,6 +188,8 @@ export class NetworkController extends BaseController<NetworkConfig, NetworkStat
   /**
    * Sets a new configuration for web3-provider-engine
    *
+   * TODO: Replace this wth a method
+   *
    * @param providerConfig - web3-provider-engine configuration
    */
   set providerConfig(providerConfig: ProviderConfig) {
@@ -196,6 +198,10 @@ export class NetworkController extends BaseController<NetworkConfig, NetworkStat
     this.initializeProvider(type, rpcTarget, chainId, ticker, nickname);
     this.registerProvider();
     this.lookupNetwork();
+  }
+
+  get providerConfig() {
+    throw new Error('Property only used for setting');
   }
 
   /**


### PR DESCRIPTION
The `accessor-pairs` ESLint rule has been re-enabled, which requires any setter to have a corresponding getter (and vice-versa).

All of our rule violations were for properties that we use only as setters. In each case a getter was added that throws an error, which should help prevent accidental use of the getter. The default behaviour was to return `undefined`, which could lead to silent failures.

Long-term we should stop using setters like this. If we want to allow changing a property but not accessing, we can use a method. Methods are generally easier to understand than setters because it's clear to the consumer that side-effects are possible, and they have more informative type signatures (e.g. they can return a Promise when they perform some async operation, so that the caller knows when the operation has finished).

But replacing the setters would be a breaking change, so that has been left for another time. A TODO comment has been left to remind us to replace the setter with a method (e.g. during the migration to the new base controller).