### PR TITLE
Re-enable `default-case` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,7 +56,6 @@ module.exports = {
     'accessor-pairs': 'off',
     camelcase: 'off',
     'consistent-return': 'off',
-    'default-case': 'off',
     'function-paren-newline': 'off',
     'guard-for-in': 'off',
     'implicit-arrow-linebreak': 'off',

--- a/src/assets/AssetsController.ts
+++ b/src/assets/AssetsController.ts
@@ -668,6 +668,9 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
             return reject(new Error('User rejected to watch the asset.'));
           case SuggestedAssetStatus.failed:
             return reject(new Error(meta.error.message));
+          /* istanbul ignore next */
+          default:
+            return reject(new Error(`Unknown status: ${meta.status}`));
         }
       });
     });

--- a/src/network/NetworkController.test.ts
+++ b/src/network/NetworkController.test.ts
@@ -1,5 +1,5 @@
 import { stub } from 'sinon';
-import NetworkController, { NetworksChainId, ProviderConfig } from './NetworkController';
+import NetworkController, { NetworksChainId, ProviderConfig, NetworkType } from './NetworkController';
 
 const Web3ProviderEngine = require('web3-provider-engine');
 
@@ -107,6 +107,11 @@ describe('NetworkController', () => {
     const controller = new NetworkController();
     controller.setProviderType('localhost');
     expect(controller.state.provider.type).toBe('localhost');
+  });
+
+  it('should throw when setting an unrecognized provider type', () => {
+    const controller = new NetworkController();
+    expect(() => controller.setProviderType('junk' as NetworkType)).toThrow();
   });
 
   it('should verify the network on an error', async () => {

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -99,6 +99,8 @@ export class NetworkController extends BaseController<NetworkConfig, NetworkStat
       case 'rpc':
         rpcTarget && this.setupStandardProvider(rpcTarget, chainId, ticker, nickname);
         break;
+      default:
+        throw new Error(`Unrecognized network type: '${type}'`);
     }
   }
 

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -71,6 +71,7 @@ describe('util', () => {
     expect(util.getBuyURL('4')).toBe('https://www.rinkeby.io/');
     expect(util.getBuyURL('5')).toBe('https://goerli-faucet.slock.it/');
     expect(util.getBuyURL('42')).toBe('https://github.com/kovan-testnet/faucet');
+    expect(util.getBuyURL('unrecognized network ID')).toBeUndefined();
   });
 
   it('hexToBN', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -56,7 +56,7 @@ export function fractionBN(targetBN: any, numerator: number | string, denominato
  * @param amount - How much ETH is desired
  * @returns - URL to buy ETH based on network
  */
-export function getBuyURL(networkCode = '1', address?: string, amount = 5) {
+export function getBuyURL(networkCode = '1', address?: string, amount = 5): string | undefined {
   switch (networkCode) {
     case '1':
       return `https://buy.coinbase.com/?code=9ec56d01-7e81-5017-930c-513daa27bb6a&amount=${amount}&address=${address}&crypto_currency=ETH`;
@@ -68,6 +68,8 @@ export function getBuyURL(networkCode = '1', address?: string, amount = 5) {
       return 'https://goerli-faucet.slock.it/';
     case '42':
       return 'https://github.com/kovan-testnet/faucet';
+    default:
+      return undefined;
   }
 }
 


### PR DESCRIPTION
The `default-case` ESLint rule has been re-enabled, and all violations have been addressed. Most of the default causes will throw an error, because the function couldn't function properly in that circumstance. There was one case (`getBuyURL`) where it seemed reasonable to return undefined, so the behaviour was left unchanged.

Tests have been added for any default cases in reachable code. One istanbul ignore comment was used for an unreachable default case.