### PR TITLE
Re-enable `consistent-return` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,6 @@ module.exports = {
   rules: {
     'accessor-pairs': 'off',
     camelcase: 'off',
-    'consistent-return': 'off',
     'function-paren-newline': 'off',
     'guard-for-in': 'off',
     'implicit-arrow-linebreak': 'off',

--- a/src/assets/CurrencyRateController.ts
+++ b/src/assets/CurrencyRateController.ts
@@ -139,7 +139,7 @@ export class CurrencyRateController extends BaseController<CurrencyRateConfig, C
    */
   async updateExchangeRate(): Promise<CurrencyRateState | void> {
     if (this.disabled || !this.activeCurrency || !this.activeNativeCurrency) {
-      return;
+      return undefined;
     }
     const releaseLock = await this.mutex.acquire();
     try {

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -784,7 +784,7 @@ export class TransactionController extends BaseController<TransactionConfig, Tra
     const supportedNetworkIds = ['1', '3', '4', '42'];
     /* istanbul ignore next */
     if (supportedNetworkIds.indexOf(currentNetworkID) === -1) {
-      return;
+      return undefined;
     }
 
     const [etherscanTxResponse, etherscanTokenResponse] = await handleTransactionFetch(networkType, address, opt);

--- a/src/util.ts
+++ b/src/util.ts
@@ -203,6 +203,7 @@ export async function safelyExecute(operation: () => Promise<any>, logError = fa
       console.error(error);
     }
     retry?.(error);
+    return undefined;
   }
 }
 
@@ -230,6 +231,7 @@ export async function safelyExecuteWithTimeout(operation: () => Promise<any>, lo
     if (logError) {
       console.error(error);
     }
+    return undefined;
   }
 }
 


### PR DESCRIPTION
The `consistent-return` ESLint rule has been re-enabled, and all rule violations have been fixed. Mostly this consisted of explicitly returning `undefined` in a few places, to reassure ESLint that it was intentional to return `undefined` in some branches but not others.