### PR TITLE
Remove unused required controller

### DIFF
--- a/src/message-manager/TypedMessageManager.ts
+++ b/src/message-manager/TypedMessageManager.ts
@@ -79,11 +79,6 @@ export class TypedMessageManager extends AbstractMessageManager<
   name = 'TypedMessageManager';
 
   /**
-   * List of required sibling controllers this controller needs to function
-   */
-  requiredControllers = ['NetworkController'];
-
-  /**
    * Creates a new TypedMessage with an 'unapproved' status using the passed messageParams.
    * this.addMessage is called to add the new TypedMessage to this.messages, and to save the unapproved TypedMessages.
    *


### PR DESCRIPTION
The `NetworkController` is lised as a required controller of the `TypedMessageManager` controller, but it is not used. It has been removed.