### PR TITLE
Remove no-useless-escape lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,7 +52,6 @@ module.exports = {
     'no-new': 'off',
     'no-param-reassign': 'off',
     'no-prototype-builtins': 'off',
-    'no-useless-escape': 'off',
     radix: 'off',
     'require-atomic-updates': 'off',
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -453,8 +453,7 @@ export function normalizeEnsName(ensName: string): string | null {
       const normalized = ensNamehash.normalize(ensName.trim());
       // this regex is only sufficient with the above call to ensNamehash.normalize
       // TODO: change 7 in regex to 3 when shorter ENS domains are live
-      // eslint-disable-next-line require-unicode-regexp
-      if (normalized.match(/^(([\w\d\-]+)\.)*[\w\d\-]{7,}\.(eth|test)$/)) {
+      if (normalized.match(/^(([\w\d-]+)\.)*[\w\d-]{7,}\.(eth|test)$/u)) {
         return normalized;
       }
     } catch (_) {


### PR DESCRIPTION
This PR fixes one line that uses a "useless escape". I removed the escape character, as well as added the u flag, resolving two eslint issues. I then removed the disable for this rule in the eslint config. 