### PR TITLE
Move Notification controller unit tests

### DIFF
--- a/src/notification/NotificationController.test.ts
+++ b/src/notification/NotificationController.test.ts
@@ -3,7 +3,7 @@ import {
   NotificationState,
   NotificationController,
   StateNotificationMap,
-} from '../src/notification/NotificationController';
+} from './NotificationController';
 
 const config1: NotificationConfig = {
   allNotifications: {


### PR DESCRIPTION
The notification controller unit tests are now alongside the controller. They had accidentally been left in the `test` directory, because the re-organization of our tests in #354 was done after the notification controller had been written.