### PR TITLE
Re-enable `@typescript-eslint/no-non-null-assertion`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,9 +31,6 @@ module.exports = {
           'error',
           { vars: 'all', args: 'all', argsIgnorePattern: '[_]+', ignoreRestSiblings: true },
         ],
-
-        // TODO re-enable most of these rules
-        '@typescript-eslint/no-non-null-assertion': 'off',
       },
     },
   ],


### PR DESCRIPTION
The ESLint rule `@typescript-eslint/no-non-null-assertion` has been re-enabled. The last of the rule violations was removed in #406.