### PR TITLE
Resolve Jest "expect-expect" lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,7 +56,6 @@ module.exports = {
     radix: 'off',
     'require-atomic-updates': 'off',
 
-    'jest/expect-expect': 'off',
     'jest/no-conditional-expect': 'off',
     'jest/no-restricted-matchers': 'off',
     'jest/no-test-return-statement': 'off',

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -99,11 +99,12 @@ describe('util', () => {
   });
 
   describe('safelyExecute', () => {
-
     it('should swallow errors', async () => {
-      await expect(util.safelyExecute(() => {
-        throw new Error('ahh');
-      })).resolves.toBeUndefined();
+      await expect(
+        util.safelyExecute(() => {
+          throw new Error('ahh');
+        }),
+      ).resolves.toBeUndefined();
     });
 
     it('should call retry function', async () => {
@@ -123,9 +124,11 @@ describe('util', () => {
 
   describe('safelyExecuteWithTimeout', () => {
     it('should swallow errors', async () => {
-      await expect(util.safelyExecuteWithTimeout(() => {
-        throw new Error('ahh');
-      })).resolves.toBeUndefined();
+      await expect(
+        util.safelyExecuteWithTimeout(() => {
+          throw new Error('ahh');
+        }),
+      ).resolves.toBeUndefined();
     });
 
     it('should resolve', async () => {

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -99,30 +99,33 @@ describe('util', () => {
   });
 
   describe('safelyExecute', () => {
+
     it('should swallow errors', async () => {
-      await util.safelyExecute(() => {
+      await expect(util.safelyExecute(() => {
         throw new Error('ahh');
-      });
+      })).resolves.toBeUndefined();
     });
 
-    it('should call retry function', () => {
-      return new Promise((resolve) => {
+    it('should call retry function', async () => {
+      const mockRetry = jest.fn();
+      new Promise(() => {
         util.safelyExecute(
           () => {
             throw new Error('ahh');
           },
           false,
-          resolve,
+          mockRetry,
         );
       });
+      expect(mockRetry).toHaveBeenCalledWith(new Error('ahh'));
     });
   });
 
   describe('safelyExecuteWithTimeout', () => {
     it('should swallow errors', async () => {
-      await util.safelyExecuteWithTimeout(() => {
+      await expect(util.safelyExecuteWithTimeout(() => {
         throw new Error('ahh');
-      });
+      })).resolves.toBeUndefined();
     });
 
     it('should resolve', async () => {


### PR DESCRIPTION
This PR refactors 3 tests that do not use an expect statement. 

Two of such tests were checking if functions SafelyExecute and SafelyExecuteWithTimeout from utils would resolve even if an error was thrown. I refactored them by wrapping them in an await statement and expecting it to resolve. 

The last test aimed to make sure a parameterized function is called. It was done in a creative way that did not use expect. I refactored it by passing in a mocked function and checking that it was called correctly.