### PR TITLE
Remove Lint Rule "no-prototype-builtins"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,7 +51,6 @@ module.exports = {
     'no-negated-condition': 'off',
     'no-new': 'off',
     'no-param-reassign': 'off',
-    // 'no-prototype-builtins': 'off',
     radix: 'off',
     'require-atomic-updates': 'off',
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,7 +51,7 @@ module.exports = {
     'no-negated-condition': 'off',
     'no-new': 'off',
     'no-param-reassign': 'off',
-    'no-prototype-builtins': 'off',
+    // 'no-prototype-builtins': 'off',
     radix: 'off',
     'require-atomic-updates': 'off',
 

--- a/src/assets/AssetsController.ts
+++ b/src/assets/AssetsController.ts
@@ -227,7 +227,9 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
     const assetsContract = this.context.AssetsContractController as AssetsContractController;
     const tokenURI = await assetsContract.getCollectibleTokenURI(contractAddress, tokenId);
     const object = await handleFetch(tokenURI);
-    const image = Object.prototype.hasOwnProperty.call(object, 'image') ? 'image' : /* istanbul ignore next */ 'image_url';
+    const image = Object.prototype.hasOwnProperty.call(object, 'image')
+      ? 'image'
+      : /* istanbul ignore next */ 'image_url';
     return { image: object[image], name: object.name };
   }
 

--- a/src/assets/AssetsController.ts
+++ b/src/assets/AssetsController.ts
@@ -227,7 +227,7 @@ export class AssetsController extends BaseController<AssetsConfig, AssetsState> 
     const assetsContract = this.context.AssetsContractController as AssetsContractController;
     const tokenURI = await assetsContract.getCollectibleTokenURI(contractAddress, tokenId);
     const object = await handleFetch(tokenURI);
-    const image = object.hasOwnProperty('image') ? 'image' : /* istanbul ignore next */ 'image_url';
+    const image = Object.prototype.hasOwnProperty.call(object, 'image') ? 'image' : /* istanbul ignore next */ 'image_url';
     return { image: object[image], name: object.name };
   }
 


### PR DESCRIPTION
The rules of this lint rule is outlined here: https://eslint.org/docs/rules/no-prototype-builtins 
I mimicked how they recommend we solve the lint issue. 
Simple two-liner! Removed lint rule from eslint config, refactored line that was causing the issue according to docs. 