### PR TITLE
Add messages to empty tothrow calls

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,7 +61,6 @@ module.exports = {
     'jest/no-test-return-statement': 'off',
     'jest/no-try-expect': 'off',
     'jest/prefer-strict-equal': 'off',
-    'jest/require-to-throw-message': 'off',
     'jest/valid-expect-in-promise': 'off',
   },
   settings: {

--- a/src/BaseController.test.ts
+++ b/src/BaseController.test.ts
@@ -73,6 +73,6 @@ describe('BaseController', () => {
     const controller = new TestController();
     expect(() => {
       new ComposableController([controller]);
-    }).toThrow();
+    }).toThrow('BaseController must be composed with Foo.');
   });
 });

--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -66,7 +66,7 @@ describe('BaseController', () => {
 
     expect(() => {
       controller.state = { count: 1 };
-    }).toThrow();
+    }).toThrow("Controller state cannot be directly mutated; use 'update' method instead.");
   });
 
   it('should allow updating state by modifying draft', () => {
@@ -115,7 +115,9 @@ describe('BaseController', () => {
         draft.count += 1;
         return { count: 10 };
       });
-    }).toThrow();
+    }).toThrow(
+      '[Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft.',
+    );
   });
 
   it('should inform subscribers of state changes', () => {
@@ -213,7 +215,7 @@ describe('BaseController', () => {
 
     expect(() => {
       controllerMessenger.unsubscribe('CountController:stateChange', listener1);
-    }).toThrow();
+    }).toThrow("Subscription not found for event: 'CountController:stateChange'");
   });
 
   it('should no longer update subscribers after being destroyed', () => {

--- a/src/ControllerMessenger.test.ts
+++ b/src/ControllerMessenger.test.ts
@@ -86,7 +86,7 @@ describe('ControllerMessenger', () => {
 
     expect(() => {
       controllerMessenger.registerActionHandler('ping', () => undefined);
-    }).toThrow();
+    }).toThrow('A handler for ping has already been registered');
   });
 
   it('should throw when calling unregistered action', () => {
@@ -95,7 +95,7 @@ describe('ControllerMessenger', () => {
 
     expect(() => {
       controllerMessenger.call('ping');
-    }).toThrow();
+    }).toThrow('A handler for ping has not been registered');
   });
 
   it('should throw when calling an action that has been unregistered', () => {
@@ -104,7 +104,7 @@ describe('ControllerMessenger', () => {
 
     expect(() => {
       controllerMessenger.call('ping');
-    }).toThrow();
+    }).toThrow('A handler for ping has not been registered');
 
     let pingCount = 0;
     controllerMessenger.registerActionHandler('ping', () => {
@@ -115,7 +115,7 @@ describe('ControllerMessenger', () => {
 
     expect(() => {
       controllerMessenger.call('ping');
-    }).toThrow();
+    }).toThrow('A handler for ping has not been registered');
     expect(pingCount).toEqual(0);
   });
 
@@ -125,7 +125,7 @@ describe('ControllerMessenger', () => {
 
     expect(() => {
       controllerMessenger.call('ping');
-    }).toThrow();
+    }).toThrow('A handler for ping has not been registered');
 
     let pingCount = 0;
     controllerMessenger.registerActionHandler('ping', () => {
@@ -136,7 +136,7 @@ describe('ControllerMessenger', () => {
 
     expect(() => {
       controllerMessenger.call('ping');
-    }).toThrow();
+    }).toThrow('A handler for ping has not been registered');
     expect(pingCount).toEqual(0);
   });
 
@@ -240,7 +240,9 @@ describe('ControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
 
     const handler = sinon.stub();
-    expect(() => controllerMessenger.unsubscribe('message', handler)).toThrow();
+    expect(() => controllerMessenger.unsubscribe('message', handler)).toThrow(
+      "Subscription not found for event: 'message'",
+    );
   });
 
   it('should throw when unsubscribing a handler that is not subscribed', () => {
@@ -251,7 +253,9 @@ describe('ControllerMessenger', () => {
     const handler2 = sinon.stub();
     controllerMessenger.subscribe('message', handler1);
 
-    expect(() => controllerMessenger.unsubscribe('message', handler2)).toThrow();
+    expect(() => controllerMessenger.unsubscribe('message', handler2)).toThrow(
+      "Subscription not found for event: 'message'",
+    );
   });
 
   it('should not call subscriber after clearing event subscriptions', () => {

--- a/src/assets/AccountTrackerController.test.ts
+++ b/src/assets/AccountTrackerController.test.ts
@@ -16,7 +16,7 @@ describe('AccountTrackerController', () => {
 
   it('should throw when provider property is accessed', () => {
     const controller = new AccountTrackerController();
-    expect(() => console.log(controller.provider)).toThrow();
+    expect(() => console.log(controller.provider)).toThrow('Property only used for setting');
   });
 
   it('should get real balance', async () => {

--- a/src/assets/AssetsContractController.test.ts
+++ b/src/assets/AssetsContractController.test.ts
@@ -20,7 +20,7 @@ describe('AssetsContractController', () => {
   });
 
   it('should throw when provider property is accessed', () => {
-    expect(() => console.log(assetsContract.provider)).toThrow();
+    expect(() => console.log(assetsContract.provider)).toThrow('Property only used for setting');
   });
 
   it('should determine if contract supports interface correctly', async () => {

--- a/src/assets/CurrencyRateController.test.ts
+++ b/src/assets/CurrencyRateController.test.ts
@@ -49,13 +49,13 @@ describe('CurrencyRateController', () => {
   it('should throw when currentCurrency property is accessed', () => {
     const fetchExchangeRateStub = stub();
     const controller = new CurrencyRateController({}, {}, fetchExchangeRateStub);
-    expect(() => console.log(controller.currentCurrency)).toThrow();
+    expect(() => console.log(controller.currentCurrency)).toThrow('Property only used for setting');
   });
 
   it('should throw when nativeCurrency property is accessed', () => {
     const fetchExchangeRateStub = stub();
     const controller = new CurrencyRateController({}, {}, fetchExchangeRateStub);
-    expect(() => console.log(controller.nativeCurrency)).toThrow();
+    expect(() => console.log(controller.nativeCurrency)).toThrow('Property only used for setting');
   });
 
   it('should poll and update rate in the right interval', async () => {

--- a/src/assets/TokenRatesController.test.ts
+++ b/src/assets/TokenRatesController.test.ts
@@ -51,7 +51,7 @@ describe('TokenRatesController', () => {
 
   it('should throw when tokens property is accessed', () => {
     const controller = new TokenRatesController();
-    expect(() => console.log(controller.tokens)).toThrow();
+    expect(() => console.log(controller.tokens)).toThrow('Property only used for setting');
   });
 
   it('should poll and update rate in the right interval', () => {

--- a/src/keyring/KeyringController.test.ts
+++ b/src/keyring/KeyringController.test.ts
@@ -86,14 +86,14 @@ describe('KeyringController', () => {
   it('should export seed phrase', () => {
     const seed = keyringController.exportSeedPhrase(password);
     expect(seed).not.toBe('');
-    expect(() => keyringController.exportSeedPhrase('')).toThrow();
+    expect(() => keyringController.exportSeedPhrase('')).toThrow('Invalid password');
   });
 
   it('should export account', async () => {
     const account = initialState.keyrings[0].accounts[0];
     const newPrivateKey = await keyringController.exportAccount(password, account);
     expect(newPrivateKey).not.toBe('');
-    expect(() => keyringController.exportAccount('', account)).toThrow();
+    expect(() => keyringController.exportAccount('', account)).toThrow('Invalid password');
   });
 
   it('should get accounts', async () => {
@@ -137,7 +137,7 @@ describe('KeyringController', () => {
     const somePassword = 'holachao123';
     await expect(
       keyringController.importAccountWithStrategy('junk' as AccountImportStrategy, [input, somePassword]),
-    ).rejects.toThrow();
+    ).rejects.toThrow("Unexpected import strategy: 'junk'");
   });
 
   it('should import account with strategy json wrong password', async () => {
@@ -188,7 +188,7 @@ describe('KeyringController', () => {
     const account = initialState.keyrings[0].accounts[0];
     await expect(
       keyringController.signTypedMessage({ data: typedMsgParams, from: account }, 'junk' as SignTypedDataVersion),
-    ).rejects.toThrow();
+    ).rejects.toThrow("Keyring Controller signTypedMessage: Error: Unexpected signTypedMessage version: 'junk'");
   });
 
   it('should sign typed message V1', async () => {

--- a/src/network/NetworkController.test.ts
+++ b/src/network/NetworkController.test.ts
@@ -18,7 +18,7 @@ describe('NetworkController', () => {
 
   it('should throw when providerConfig property is accessed', () => {
     const controller = new NetworkController();
-    expect(() => console.log(controller.providerConfig)).toThrow();
+    expect(() => console.log(controller.providerConfig)).toThrow('Property only used for setting');
   });
 
   it('should create a provider instance for default infura network', () => {
@@ -115,7 +115,7 @@ describe('NetworkController', () => {
 
   it('should throw when setting an unrecognized provider type', () => {
     const controller = new NetworkController();
-    expect(() => controller.setProviderType('junk' as NetworkType)).toThrow();
+    expect(() => controller.setProviderType('junk' as NetworkType)).toThrow("Unrecognized network type: 'junk'");
   });
 
   it('should verify the network on an error', async () => {

--- a/src/third-party/EnsController.test.ts
+++ b/src/third-party/EnsController.test.ts
@@ -175,7 +175,9 @@ describe('EnsController', () => {
     const controller = new EnsController();
     expect(() => {
       controller.set('a', name1, address1);
-    }).toThrow();
+    }).toThrow(
+      'Invalid ENS entry: { chainId:a, ensName:foobarb.eth, address:0x32Be343B94f860124dC4fEe278FDCBD38C102D88}',
+    );
     expect(controller.state).toEqual({ ensEntries: {} });
   });
 
@@ -183,7 +185,7 @@ describe('EnsController', () => {
     const controller = new EnsController();
     expect(() => {
       controller.set('1', 'foo.eth', address1);
-    }).toThrow();
+    }).toThrow('Invalid ENS name: foo.eth');
     expect(controller.state).toEqual({ ensEntries: {} });
   });
 
@@ -191,7 +193,7 @@ describe('EnsController', () => {
     const controller = new EnsController();
     expect(() => {
       controller.set('1', name1, 'foo');
-    }).toThrow();
+    }).toThrow('Invalid ENS entry: { chainId:1, ensName:foobarb.eth, address:foo}');
     expect(controller.state).toEqual({ ensEntries: {} });
   });
 

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -171,15 +171,21 @@ describe('util', () => {
 
   describe('validateTransaction', () => {
     it('should throw if no from address', () => {
-      expect(() => util.validateTransaction({} as any)).toThrow();
+      expect(() => util.validateTransaction({} as any)).toThrow(
+        'Invalid "from" address: undefined must be a valid string.',
+      );
     });
 
     it('should throw if non-string from address', () => {
-      expect(() => util.validateTransaction({ from: 1337 } as any)).toThrow();
+      expect(() => util.validateTransaction({ from: 1337 } as any)).toThrow(
+        'Invalid "from" address: 1337 must be a valid string.',
+      );
     });
 
     it('should throw if invalid from address', () => {
-      expect(() => util.validateTransaction({ from: '1337' } as any)).toThrow();
+      expect(() => util.validateTransaction({ from: '1337' } as any)).toThrow(
+        'Invalid "from" address: 1337 must be a valid string.',
+      );
     });
 
     it('should throw if no data', () => {
@@ -188,12 +194,12 @@ describe('util', () => {
           from: '0x3244e191f1b4903970224322180f1fbbc415696b',
           to: '0x',
         } as any),
-      ).toThrow();
+      ).toThrow('Invalid "to" address: 0x must be a valid string.');
       expect(() =>
         util.validateTransaction({
           from: '0x3244e191f1b4903970224322180f1fbbc415696b',
         } as any),
-      ).toThrow();
+      ).toThrow('Invalid "to" address: undefined must be a valid string.');
     });
 
     it('should delete data', () => {
@@ -212,7 +218,7 @@ describe('util', () => {
           from: '0x3244e191f1b4903970224322180f1fbbc415696b',
           to: '1337',
         } as any),
-      ).toThrow();
+      ).toThrow('Invalid "to" address: 1337 must be a valid string.');
     });
 
     it('should throw if value is invalid', () => {
@@ -222,28 +228,28 @@ describe('util', () => {
           to: '0x3244e191f1b4903970224322180f1fbbc415696b',
           value: '133-7',
         } as any),
-      ).toThrow();
+      ).toThrow('Invalid "value": 133-7 is not a positive number.');
       expect(() =>
         util.validateTransaction({
           from: '0x3244e191f1b4903970224322180f1fbbc415696b',
           to: '0x3244e191f1b4903970224322180f1fbbc415696b',
           value: '133.7',
         } as any),
-      ).toThrow();
+      ).toThrow('Invalid "value": 133.7 number must be denominated in wei.');
       expect(() =>
         util.validateTransaction({
           from: '0x3244e191f1b4903970224322180f1fbbc415696b',
           to: '0x3244e191f1b4903970224322180f1fbbc415696b',
           value: 'hello',
         } as any),
-      ).toThrow();
+      ).toThrow('Invalid "value": hello number must be a valid number.');
       expect(() =>
         util.validateTransaction({
           from: '0x3244e191f1b4903970224322180f1fbbc415696b',
           to: '0x3244e191f1b4903970224322180f1fbbc415696b',
           value: 'one million dollar$',
         } as any),
-      ).toThrow();
+      ).toThrow('Invalid "value": one million dollar$ number must be a valid number.');
       expect(() =>
         util.validateTransaction({
           from: '0x3244e191f1b4903970224322180f1fbbc415696b',
@@ -274,7 +280,7 @@ describe('util', () => {
         util.validateSignMessageData({
           data: '0x879a05',
         } as any),
-      ).toThrow();
+      ).toThrow('Invalid "from" address: undefined must be a valid string.');
     });
 
     it('should throw if invalid from address', () => {
@@ -283,7 +289,7 @@ describe('util', () => {
           data: '0x879a05',
           from: '3244e191f1b4903970224322180f1fbbc415696b',
         } as any),
-      ).toThrow();
+      ).toThrow('Invalid "from" address: 3244e191f1b4903970224322180f1fbbc415696b must be a valid string.');
     });
 
     it('should throw if invalid type from address', () => {
@@ -292,7 +298,7 @@ describe('util', () => {
           data: '0x879a05',
           from: 123,
         } as any),
-      ).toThrow();
+      ).toThrow('Invalid "from" address: 123 must be a valid string.');
     });
 
     it('should throw if no data', () => {
@@ -300,7 +306,7 @@ describe('util', () => {
         util.validateSignMessageData({
           data: '0x879a05',
         } as any),
-      ).toThrow();
+      ).toThrow('Invalid "from" address: undefined must be a valid string.');
     });
 
     it('should throw if invalid tyoe data', () => {
@@ -309,7 +315,7 @@ describe('util', () => {
           data: 123,
           from: '0x3244e191f1b4903970224322180f1fbbc415696b',
         } as any),
-      ).toThrow();
+      ).toThrow('Invalid message "data": 123 must be a valid string.');
     });
   });
 


### PR DESCRIPTION
This PR aims to remove the eslint exception involving empty tothrow messages by replacing .tothrow() calls with .tothrow('error message'). 

