### PR TITLE
Use exception helpers instead of try catch 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,7 +53,6 @@ module.exports = {
 
     'jest/no-conditional-expect': 'off',
     'jest/no-restricted-matchers': 'off',
-    'jest/no-test-return-statement': 'off',
     'jest/no-try-expect': 'off',
     'jest/prefer-strict-equal': 'off',
     'jest/valid-expect-in-promise': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,7 +53,7 @@ module.exports = {
 
     'jest/no-conditional-expect': 'off',
     'jest/no-restricted-matchers': 'off',
-    'jest/no-try-expect': 'off',
+    'jest/no-test-return-statement': 'off',
     'jest/prefer-strict-equal': 'off',
     'jest/valid-expect-in-promise': 'off',
   },

--- a/src/assets/AccountTrackerController.test.ts
+++ b/src/assets/AccountTrackerController.test.ts
@@ -52,8 +52,8 @@ describe('AccountTrackerController', () => {
     expect((controller.refresh as any).called).toBe(true);
   });
 
-  it('should call refresh every ten seconds', () => {
-    return new Promise<void>((resolve) => {
+  it('should call refresh every ten seconds', async () => {
+    await new Promise<void>((resolve) => {
       const preferences = new PreferencesController();
       const controller = new AccountTrackerController({ provider, interval: 100 });
       stub(controller, 'refresh');

--- a/src/assets/AssetsController.test.ts
+++ b/src/assets/AssetsController.test.ts
@@ -426,7 +426,7 @@ describe('AssetsController', () => {
   });
 
   it('should fail an invalid type suggested asset via watchAsset', async () => {
-    return new Promise(async (resolve) => {
+    await new Promise(async (resolve) => {
       await assetsController
         .watchAsset(
           {
@@ -443,8 +443,8 @@ describe('AssetsController', () => {
     });
   });
 
-  it('should reject a valid suggested asset via watchAsset', () => {
-    return new Promise(async (resolve) => {
+  it('should reject a valid suggested asset via watchAsset', async () => {
+    await new Promise(async (resolve) => {
       const { result, suggestedAssetMeta } = await assetsController.watchAsset(
         {
           address: '0xe9f786dfdd9ae4d57e830acb52296837765f0e5b',
@@ -465,8 +465,8 @@ describe('AssetsController', () => {
     });
   });
 
-  it('should accept a valid suggested asset via watchAsset', () => {
-    return new Promise(async (resolve) => {
+  it('should accept a valid suggested asset via watchAsset', async () => {
+    await new Promise(async (resolve) => {
       const { result, suggestedAssetMeta } = await assetsController.watchAsset(
         {
           address: '0xe9f786dfdd9ae4d57e830acb52296837765f0e5b',
@@ -484,8 +484,8 @@ describe('AssetsController', () => {
     });
   });
 
-  it('should fail a valid suggested asset via watchAsset with wrong type', () => {
-    return new Promise(async (resolve) => {
+  it('should fail a valid suggested asset via watchAsset with wrong type', async () => {
+    await new Promise(async (resolve) => {
       const { result, suggestedAssetMeta } = await assetsController.watchAsset(
         {
           address: '0xe9f786dfdd9be4d57e830acb52296837765f0e5b',

--- a/src/assets/AssetsDetectionController.test.ts
+++ b/src/assets/AssetsDetectionController.test.ts
@@ -118,8 +118,8 @@ describe('AssetsDetectionController', () => {
     });
   });
 
-  it('should poll and detect assets on interval while on mainnet', () => {
-    return new Promise((resolve) => {
+  it('should poll and detect assets on interval while on mainnet', async () => {
+    await new Promise((resolve) => {
       const mockTokens = stub(AssetsDetectionController.prototype, 'detectTokens');
       const mockCollectibles = stub(AssetsDetectionController.prototype, 'detectCollectibles');
       new AssetsDetectionController({ interval: 10 });
@@ -142,8 +142,8 @@ describe('AssetsDetectionController', () => {
     expect(assetsDetection.isMainnet()).toEqual(false);
   });
 
-  it('should not autodetect while not on mainnet', () => {
-    return new Promise((resolve) => {
+  it('should not autodetect while not on mainnet', async () => {
+    await new Promise((resolve) => {
       const mockTokens = stub(AssetsDetectionController.prototype, 'detectTokens');
       const mockCollectibles = stub(AssetsDetectionController.prototype, 'detectCollectibles');
       new AssetsDetectionController({ interval: 10, networkType: ROPSTEN });

--- a/src/assets/CurrencyRateController.test.ts
+++ b/src/assets/CurrencyRateController.test.ts
@@ -80,11 +80,11 @@ describe('CurrencyRateController', () => {
     expect(fetchExchangeRateStub.called).toBe(false);
   });
 
-  it('should clear previous interval', () => {
+  it('should clear previous interval', async () => {
     const fetchExchangeRateStub = stub();
     const mock = stub(global, 'clearTimeout');
     const controller = new CurrencyRateController({ interval: 1337 }, {}, fetchExchangeRateStub);
-    return new Promise<void>((resolve) => {
+    await new Promise<void>((resolve) => {
       setTimeout(() => {
         controller.poll(1338);
         expect(mock.called).toBe(true);

--- a/src/assets/TokenBalancesController.test.ts
+++ b/src/assets/TokenBalancesController.test.ts
@@ -39,8 +39,8 @@ describe('TokenBalancesController', () => {
     });
   });
 
-  it('should poll and update balances in the right interval', () => {
-    return new Promise<void>((resolve) => {
+  it('should poll and update balances in the right interval', async () => {
+    await new Promise<void>((resolve) => {
       const mock = stub(TokenBalancesController.prototype, 'updateBalances');
       new TokenBalancesController({ interval: 10 });
       expect(mock.called).toBe(true);
@@ -63,10 +63,10 @@ describe('TokenBalancesController', () => {
     expect(mock.called).toBe(false);
   });
 
-  it('should clear previous interval', () => {
+  it('should clear previous interval', async () => {
     const mock = stub(global, 'clearTimeout');
     const controller = new TokenBalancesController({ interval: 1337 });
-    return new Promise<void>((resolve) => {
+    await new Promise<void>((resolve) => {
       setTimeout(() => {
         controller.poll(1338);
         expect(mock.called).toBe(true);

--- a/src/assets/TokenRatesController.test.ts
+++ b/src/assets/TokenRatesController.test.ts
@@ -54,8 +54,8 @@ describe('TokenRatesController', () => {
     expect(() => console.log(controller.tokens)).toThrow('Property only used for setting');
   });
 
-  it('should poll and update rate in the right interval', () => {
-    return new Promise<void>((resolve) => {
+  it('should poll and update rate in the right interval', async () => {
+    await new Promise<void>((resolve) => {
       const mock = stub(TokenRatesController.prototype, 'fetchExchangeRate');
       new TokenRatesController({
         interval: 10,
@@ -81,10 +81,10 @@ describe('TokenRatesController', () => {
     expect((controller.fetchExchangeRate as any).called).toBe(false);
   });
 
-  it('should clear previous interval', () => {
+  it('should clear previous interval', async () => {
     const mock = stub(global, 'clearTimeout');
     const controller = new TokenRatesController({ interval: 1337 });
-    return new Promise<void>((resolve) => {
+    await new Promise<void>((resolve) => {
       setTimeout(() => {
         controller.poll(1338);
         expect(mock.called).toBe(true);

--- a/src/message-manager/MessageManager.test.ts
+++ b/src/message-manager/MessageManager.test.ts
@@ -41,8 +41,8 @@ describe('PersonalMessageManager', () => {
     }
   });
 
-  it('should reject a message', () => {
-    return new Promise<void>(async (resolve) => {
+  it('should reject a message', async () => {
+    await new Promise<void>(async (resolve) => {
       const controller = new MessageManager();
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
@@ -64,8 +64,8 @@ describe('PersonalMessageManager', () => {
     });
   });
 
-  it('should sign a message', () => {
-    return new Promise<void>(async (resolve) => {
+  it('should sign a message', async () => {
+    await new Promise<void>(async (resolve) => {
       const controller = new MessageManager();
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
@@ -88,8 +88,8 @@ describe('PersonalMessageManager', () => {
     });
   });
 
-  it('should throw when unapproved finishes', () => {
-    return new Promise<void>(async (resolve) => {
+  it('should throw when unapproved finishes', async () => {
+    await new Promise<void>(async (resolve) => {
       const controller = new MessageManager();
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
@@ -128,10 +128,10 @@ describe('PersonalMessageManager', () => {
     }
   });
 
-  it('should throw when adding invalid message', () => {
+  it('should throw when adding invalid message', async () => {
     const from = 'foo';
     const messageData = '0x123';
-    return new Promise<void>(async (resolve) => {
+    await new Promise<void>(async (resolve) => {
       const controller = new MessageManager();
       try {
         await controller.addUnapprovedMessageAsync({

--- a/src/message-manager/MessageManager.test.ts
+++ b/src/message-manager/MessageManager.test.ts
@@ -131,18 +131,13 @@ describe('PersonalMessageManager', () => {
   it('should throw when adding invalid message', async () => {
     const from = 'foo';
     const messageData = '0x123';
-    await new Promise<void>(async (resolve) => {
-      const controller = new MessageManager();
-      try {
-        await controller.addUnapprovedMessageAsync({
-          data: messageData,
-          from,
-        });
-      } catch (error) {
-        expect(error.message).toContain('Invalid "from" address:');
-        resolve();
-      }
-    });
+    const controller = new MessageManager();
+    await expect(
+      controller.addUnapprovedMessageAsync({
+        data: messageData,
+        from,
+      }),
+    ).rejects.toThrow('Invalid "from" address:');
   });
 
   it('should get correct unapproved messages', () => {

--- a/src/message-manager/PersonalMessageManager.test.ts
+++ b/src/message-manager/PersonalMessageManager.test.ts
@@ -131,18 +131,13 @@ describe('PersonalMessageManager', () => {
   it('should throw when adding invalid message', async () => {
     const from = 'foo';
     const messageData = '0x123';
-    await new Promise<void>(async (resolve) => {
-      const controller = new PersonalMessageManager();
-      try {
-        await controller.addUnapprovedMessageAsync({
-          data: messageData,
-          from,
-        });
-      } catch (error) {
-        expect(error.message).toContain('Invalid "from" address:');
-        resolve();
-      }
-    });
+    const controller = new PersonalMessageManager();
+    await expect(
+      controller.addUnapprovedMessageAsync({
+        data: messageData,
+        from,
+      }),
+    ).rejects.toThrow('Invalid "from" address:');
   });
 
   it('should get correct unapproved messages', () => {

--- a/src/message-manager/PersonalMessageManager.test.ts
+++ b/src/message-manager/PersonalMessageManager.test.ts
@@ -41,8 +41,8 @@ describe('PersonalMessageManager', () => {
     }
   });
 
-  it('should reject a message', () => {
-    return new Promise<void>(async (resolve) => {
+  it('should reject a message', async () => {
+    await new Promise<void>(async (resolve) => {
       const controller = new PersonalMessageManager();
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
@@ -64,8 +64,8 @@ describe('PersonalMessageManager', () => {
     });
   });
 
-  it('should sign a message', () => {
-    return new Promise<void>(async (resolve) => {
+  it('should sign a message', async () => {
+    await new Promise<void>(async (resolve) => {
       const controller = new PersonalMessageManager();
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
@@ -88,8 +88,8 @@ describe('PersonalMessageManager', () => {
     });
   });
 
-  it('should throw when unapproved finishes', () => {
-    return new Promise<void>(async (resolve) => {
+  it('should throw when unapproved finishes', async () => {
+    await new Promise<void>(async (resolve) => {
       const controller = new PersonalMessageManager();
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
@@ -128,10 +128,10 @@ describe('PersonalMessageManager', () => {
     }
   });
 
-  it('should throw when adding invalid message', () => {
+  it('should throw when adding invalid message', async () => {
     const from = 'foo';
     const messageData = '0x123';
-    return new Promise<void>(async (resolve) => {
+    await new Promise<void>(async (resolve) => {
       const controller = new PersonalMessageManager();
       try {
         await controller.addUnapprovedMessageAsync({

--- a/src/message-manager/TypedMessageManager.test.ts
+++ b/src/message-manager/TypedMessageManager.test.ts
@@ -185,42 +185,32 @@ describe('TypedMessageManager', () => {
     const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
     const messageData = '0x879';
     const version = 'V1';
-    await new Promise<void>(async (resolve) => {
-      const controller = new TypedMessageManager();
-      try {
-        await controller.addUnapprovedMessageAsync(
-          {
-            data: messageData,
-            from,
-          },
-          version,
-        );
-      } catch (error) {
-        expect(error.message).toContain('Invalid message "data":');
-        resolve();
-      }
-    });
+    const controller = new TypedMessageManager();
+    await expect(
+      controller.addUnapprovedMessageAsync(
+        {
+          data: messageData,
+          from,
+        },
+        version,
+      ),
+    ).rejects.toThrow('Invalid message "data":');
   });
 
   it('should throw when adding invalid typed message', async () => {
     const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
     const messageData = typedMessage;
     const version = 'V3';
-    await new Promise<void>(async (resolve) => {
-      const controller = new TypedMessageManager();
-      try {
-        await controller.addUnapprovedMessageAsync(
-          {
-            data: messageData,
-            from,
-          },
-          version,
-        );
-      } catch (error) {
-        expect(error.message).toContain('Invalid message "data":');
-        resolve();
-      }
-    });
+    const controller = new TypedMessageManager();
+    await expect(
+      controller.addUnapprovedMessageAsync(
+        {
+          data: messageData,
+          from,
+        },
+        version,
+      ),
+    ).rejects.toThrow('Invalid message "data":');
   });
 
   it('should get correct unapproved messages', () => {

--- a/src/message-manager/TypedMessageManager.test.ts
+++ b/src/message-manager/TypedMessageManager.test.ts
@@ -53,8 +53,8 @@ describe('TypedMessageManager', () => {
     }
   });
 
-  it('should reject a message', () => {
-    return new Promise<void>(async (resolve) => {
+  it('should reject a message', async () => {
+    await new Promise<void>(async (resolve) => {
       const controller = new TypedMessageManager();
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       const version = 'V1';
@@ -80,8 +80,8 @@ describe('TypedMessageManager', () => {
     });
   });
 
-  it('should sign a message', () => {
-    return new Promise<void>(async (resolve) => {
+  it('should sign a message', async () => {
+    await new Promise<void>(async (resolve) => {
       const controller = new TypedMessageManager();
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       const version = 'V1';
@@ -108,8 +108,8 @@ describe('TypedMessageManager', () => {
     });
   });
 
-  it("should set message status as 'errored'", () => {
-    return new Promise<void>(async (resolve) => {
+  it("should set message status as 'errored'", async () => {
+    await new Promise<void>(async (resolve) => {
       const controller = new TypedMessageManager();
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       const version = 'V1';
@@ -135,8 +135,8 @@ describe('TypedMessageManager', () => {
     });
   });
 
-  it('should throw when unapproved finishes', () => {
-    return new Promise<void>(async (resolve) => {
+  it('should throw when unapproved finishes', async () => {
+    await new Promise<void>(async (resolve) => {
       const controller = new TypedMessageManager();
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       const version = 'V1';
@@ -181,11 +181,11 @@ describe('TypedMessageManager', () => {
     }
   });
 
-  it('should throw when adding invalid legacy typed message', () => {
+  it('should throw when adding invalid legacy typed message', async () => {
     const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
     const messageData = '0x879';
     const version = 'V1';
-    return new Promise<void>(async (resolve) => {
+    await new Promise<void>(async (resolve) => {
       const controller = new TypedMessageManager();
       try {
         await controller.addUnapprovedMessageAsync(
@@ -202,11 +202,11 @@ describe('TypedMessageManager', () => {
     });
   });
 
-  it('should throw when adding invalid typed message', () => {
+  it('should throw when adding invalid typed message', async () => {
     const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
     const messageData = typedMessage;
     const version = 'V3';
-    return new Promise<void>(async (resolve) => {
+    await new Promise<void>(async (resolve) => {
       const controller = new TypedMessageManager();
       try {
         await controller.addUnapprovedMessageAsync(

--- a/src/network/NetworkController.test.ts
+++ b/src/network/NetworkController.test.ts
@@ -129,8 +129,8 @@ describe('NetworkController', () => {
     expect((controller.lookupNetwork as any).called).toBe(true);
   });
 
-  it('should look up the network', () => {
-    return new Promise((resolve) => {
+  it('should look up the network', async () => {
+    await new Promise((resolve) => {
       const testConfig = {
         // This test needs a real project ID as it makes a test
         // `eth_version` call; https://github.com/MetaMask/controllers/issues/1

--- a/src/third-party/PhishingController.test.ts
+++ b/src/third-party/PhishingController.test.ts
@@ -20,8 +20,8 @@ describe('PhishingController', () => {
     expect(controller.config).toEqual({ interval: 3_600_000 });
   });
 
-  it('should poll and update rate in the right interval', () => {
-    return new Promise<void>((resolve) => {
+  it('should poll and update rate in the right interval', async () => {
+    await new Promise<void>((resolve) => {
       const mock = stub(PhishingController.prototype, 'updatePhishingLists');
       new PhishingController({ interval: 10 });
       expect(mock.called).toBe(true);
@@ -34,10 +34,10 @@ describe('PhishingController', () => {
     });
   });
 
-  it('should clear previous interval', () => {
+  it('should clear previous interval', async () => {
     const mock = stub(global, 'clearTimeout');
     const controller = new PhishingController({ interval: 1337 });
-    return new Promise<void>((resolve) => {
+    await new Promise<void>((resolve) => {
       setTimeout(() => {
         controller.poll(1338);
         expect(mock.called).toBe(true);

--- a/src/transaction/TransactionController.test.ts
+++ b/src/transaction/TransactionController.test.ts
@@ -577,15 +577,8 @@ describe('TransactionController', () => {
   });
 
   it('should throw when adding invalid transaction', async () => {
-    await new Promise(async (resolve) => {
-      const controller = new TransactionController();
-      try {
-        await controller.addTransaction({ from: 'foo' } as any);
-      } catch (error) {
-        expect(error.message).toContain('Invalid "from" address');
-        resolve('');
-      }
-    });
+    const controller = new TransactionController();
+    await expect(controller.addTransaction({ from: 'foo' } as any)).rejects.toThrow('Invalid "from" address');
   });
 
   it('should add a valid transaction', async () => {
@@ -693,24 +686,19 @@ describe('TransactionController', () => {
   });
 
   it('should fail transaction if gas calculation fails', async () => {
-    await new Promise(async (resolve) => {
-      const controller = new TransactionController({ provider: PROVIDER });
-      const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-      controller.context = {
-        NetworkController: MOCK_NETWORK,
-      } as any;
-      controller.onComposed();
-      mockFlags.estimateGas = 'Uh oh';
-      try {
-        await controller.addTransaction({
-          from,
-          to: from,
-        });
-      } catch (error) {
-        expect(error.message).toContain('Uh oh');
-        resolve('');
-      }
-    });
+    const controller = new TransactionController({ provider: PROVIDER });
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    controller.context = {
+      NetworkController: MOCK_NETWORK,
+    } as any;
+    controller.onComposed();
+    mockFlags.estimateGas = 'Uh oh';
+    await expect(
+      controller.addTransaction({
+        from,
+        to: from,
+      }),
+    ).rejects.toThrow('Uh oh');
   });
 
   it('should fail if no sign method defined', async () => {
@@ -991,25 +979,20 @@ describe('TransactionController', () => {
   });
 
   it('should fail to stop a transaction if no sign method', async () => {
-    await new Promise(async (resolve) => {
-      const controller = new TransactionController({
-        provider: PROVIDER,
-      });
-      controller.context = {
-        NetworkController: MOCK_NETWORK,
-      } as any;
-      controller.onComposed();
-      const from = '0xe6509775f3f3614576c0d83f8647752f87cd6659';
-      const to = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-      await controller.addTransaction({ from, to });
-      try {
-        controller.stopTransaction('nonexistent');
-        await controller.stopTransaction(controller.state.transactions[0].id);
-      } catch (error) {
-        expect(error.message).toContain('No sign method defined');
-        resolve('');
-      }
+    const controller = new TransactionController({
+      provider: PROVIDER,
     });
+    controller.context = {
+      NetworkController: MOCK_NETWORK,
+    } as any;
+    controller.onComposed();
+    const from = '0xe6509775f3f3614576c0d83f8647752f87cd6659';
+    const to = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    await controller.addTransaction({ from, to });
+    controller.stopTransaction('nonexistent');
+    await expect(controller.stopTransaction(controller.state.transactions[0].id)).rejects.toThrow(
+      'No sign method defined',
+    );
   });
 
   it('should speed up a transaction', async () => {

--- a/src/transaction/TransactionController.test.ts
+++ b/src/transaction/TransactionController.test.ts
@@ -537,8 +537,8 @@ describe('TransactionController', () => {
     });
   });
 
-  it('should poll and update transaction statuses in the right interval', () => {
-    return new Promise((resolve) => {
+  it('should poll and update transaction statuses in the right interval', async () => {
+    await new Promise((resolve) => {
       const mock = stub(TransactionController.prototype, 'queryTransactionStatuses');
       new TransactionController({ interval: 10 });
       expect(mock.called).toBe(true);
@@ -551,10 +551,10 @@ describe('TransactionController', () => {
     });
   });
 
-  it('should clear previous interval', () => {
+  it('should clear previous interval', async () => {
     const mock = stub(global, 'clearTimeout');
     const controller = new TransactionController({ interval: 1337 });
-    return new Promise((resolve) => {
+    await new Promise((resolve) => {
       setTimeout(() => {
         controller.poll(1338);
         expect(mock.called).toBe(true);
@@ -564,8 +564,8 @@ describe('TransactionController', () => {
     });
   });
 
-  it('should not update the state if there are no updates on transaction statuses', () => {
-    return new Promise((resolve) => {
+  it('should not update the state if there are no updates on transaction statuses', async () => {
+    await new Promise((resolve) => {
       const controller = new TransactionController({ interval: 10 });
       const func = stub(controller, 'update');
       setTimeout(() => {
@@ -576,8 +576,8 @@ describe('TransactionController', () => {
     });
   });
 
-  it('should throw when adding invalid transaction', () => {
-    return new Promise(async (resolve) => {
+  it('should throw when adding invalid transaction', async () => {
+    await new Promise(async (resolve) => {
       const controller = new TransactionController();
       try {
         await controller.addTransaction({ from: 'foo' } as any);
@@ -605,8 +605,8 @@ describe('TransactionController', () => {
     expect(controller.state.transactions[0].status).toBe(TransactionStatus.unapproved);
   });
 
-  it('should cancel a transaction', () => {
-    return new Promise(async (resolve) => {
+  it('should cancel a transaction', async () => {
+    await new Promise(async (resolve) => {
       const controller = new TransactionController({ provider: PROVIDER });
       controller.context = {
         NetworkController: MOCK_NETWORK,
@@ -665,8 +665,8 @@ describe('TransactionController', () => {
     expect(controller.state.transactions).toHaveLength(0);
   });
 
-  it('should fail to approve an invalid transaction', () => {
-    return new Promise(async (resolve) => {
+  it('should fail to approve an invalid transaction', async () => {
+    await new Promise(async (resolve) => {
       const controller = new TransactionController({
         provider: PROVIDER,
         sign: () => {
@@ -692,8 +692,8 @@ describe('TransactionController', () => {
     });
   });
 
-  it('should fail transaction if gas calculation fails', () => {
-    return new Promise(async (resolve) => {
+  it('should fail transaction if gas calculation fails', async () => {
+    await new Promise(async (resolve) => {
       const controller = new TransactionController({ provider: PROVIDER });
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       controller.context = {
@@ -713,8 +713,8 @@ describe('TransactionController', () => {
     });
   });
 
-  it('should fail if no sign method defined', () => {
-    return new Promise(async (resolve) => {
+  it('should fail if no sign method defined', async () => {
+    await new Promise(async (resolve) => {
       const controller = new TransactionController({
         provider: PROVIDER,
       });
@@ -737,8 +737,8 @@ describe('TransactionController', () => {
     });
   });
 
-  it('should fail if no chainId defined', () => {
-    return new Promise(async (resolve) => {
+  it('should fail if no chainId defined', async () => {
+    await new Promise(async (resolve) => {
       const controller = new TransactionController({
         provider: PROVIDER,
         sign: async (transaction: any) => transaction,
@@ -762,8 +762,8 @@ describe('TransactionController', () => {
     });
   });
 
-  it('should approve a transaction', () => {
-    return new Promise(async (resolve) => {
+  it('should approve a transaction', async () => {
+    await new Promise(async (resolve) => {
       const controller = new TransactionController({
         provider: PROVIDER,
         sign: async (transaction: any) => transaction,
@@ -790,8 +790,8 @@ describe('TransactionController', () => {
     });
   });
 
-  it('should query transaction statuses', () => {
-    return new Promise((resolve) => {
+  it('should query transaction statuses', async () => {
+    await new Promise((resolve) => {
       const controller = new TransactionController({
         provider: PROVIDER,
         sign: async (transaction: any) => transaction,
@@ -819,8 +819,8 @@ describe('TransactionController', () => {
   });
 
   // This tests the fallback to networkID only when there is no chainId present. Should be removed when networkID is completely removed.
-  it('should query transaction statuses with networkID only when there is no chainId', () => {
-    return new Promise((resolve) => {
+  it('should query transaction statuses with networkID only when there is no chainId', async () => {
+    await new Promise((resolve) => {
       const controller = new TransactionController({
         provider: PROVIDER,
         sign: async (transaction: any) => transaction,
@@ -965,7 +965,7 @@ describe('TransactionController', () => {
   });
 
   it('should stop a transaction', async () => {
-    return new Promise(async (resolve) => {
+    await new Promise(async (resolve) => {
       const controller = new TransactionController({
         provider: PROVIDER,
         sign: async (transaction: any) => transaction,
@@ -991,7 +991,7 @@ describe('TransactionController', () => {
   });
 
   it('should fail to stop a transaction if no sign method', async () => {
-    return new Promise(async (resolve) => {
+    await new Promise(async (resolve) => {
       const controller = new TransactionController({
         provider: PROVIDER,
       });
@@ -1013,7 +1013,7 @@ describe('TransactionController', () => {
   });
 
   it('should speed up a transaction', async () => {
-    return new Promise(async (resolve) => {
+    await new Promise(async (resolve) => {
       const controller = new TransactionController({
         provider: PROVIDER,
         sign: async (transaction: any) => transaction,

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -138,14 +138,12 @@ describe('util', () => {
       expect(response).toEqual('response');
     });
 
-    it('should timeout', () => {
-      try {
+    it('should timeout', async () => {
+      await expect(
         util.safelyExecuteWithTimeout(() => {
           return new Promise((res) => setTimeout(res, 800));
-        });
-      } catch (e) {
-        expect(e.message).toContain('timeout');
-      }
+        }),
+      ).resolves.toBeUndefined();
     });
   });
 
@@ -679,11 +677,7 @@ describe('util', () => {
     it('should query and reject if error', async () => {
       const ethQuery = new EthQuery(PROVIDER);
       mockFlags.gasPrice = 'Uh oh';
-      try {
-        await util.query(ethQuery, 'gasPrice', []);
-      } catch (error) {
-        expect(error.message).toContain('Uh oh');
-      }
+      await expect(util.query(ethQuery, 'gasPrice', [])).rejects.toThrow('Uh oh');
     });
   });
 });


### PR DESCRIPTION
This PR adopts this pattern for async tests when testing exceptions: 
`await expect(yourFunction()).rejects.toThrow()`



