### PR TITLE
Remove ESLint jest/valid-expect-in-promise

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,7 +55,6 @@ module.exports = {
     'jest/no-restricted-matchers': 'off',
     'jest/no-try-expect': 'off',
     'jest/prefer-strict-equal': 'off',
-    'jest/valid-expect-in-promise': 'off',
   },
   settings: {
     'import/resolver': {

--- a/src/assets/AssetsController.test.ts
+++ b/src/assets/AssetsController.test.ts
@@ -470,10 +470,9 @@ describe('AssetsController', () => {
       'ERC20',
     );
     await assetsController.acceptWatchAsset(suggestedAssetMeta.id);
-    await result.then((res) => {
-      expect(assetsController.state.suggestedAssets).toHaveLength(0);
-      expect(res).toBe('0xe9f786dfdd9ae4d57e830acb52296837765f0e5b');
-    });
+    const res = await result;
+    expect(assetsController.state.suggestedAssets).toHaveLength(0);
+    expect(res).toBe('0xe9f786dfdd9ae4d57e830acb52296837765f0e5b');
   });
 
   it('should fail a valid suggested asset via watchAsset with wrong type', async () => {

--- a/src/assets/AssetsController.test.ts
+++ b/src/assets/AssetsController.test.ts
@@ -444,67 +444,54 @@ describe('AssetsController', () => {
   });
 
   it('should reject a valid suggested asset via watchAsset', async () => {
-    await new Promise(async (resolve) => {
-      const { result, suggestedAssetMeta } = await assetsController.watchAsset(
-        {
-          address: '0xe9f786dfdd9ae4d57e830acb52296837765f0e5b',
-          decimals: 18,
-          symbol: 'TKN',
-        },
-        'ERC20',
-      );
-      assetsController.rejectWatchAsset('foo');
-      assetsController.rejectWatchAsset(suggestedAssetMeta.id);
-      assetsController.hub.once(`${suggestedAssetMeta.id}:finished`, () => {
-        expect(assetsController.state.suggestedAssets).toHaveLength(0);
-      });
-      result.catch((error) => {
-        expect(error.message).toContain('User rejected to watch the asset.');
-        resolve('');
-      });
+    const { result, suggestedAssetMeta } = await assetsController.watchAsset(
+      {
+        address: '0xe9f786dfdd9ae4d57e830acb52296837765f0e5b',
+        decimals: 18,
+        symbol: 'TKN',
+      },
+      'ERC20',
+    );
+    assetsController.rejectWatchAsset('foo');
+    assetsController.rejectWatchAsset(suggestedAssetMeta.id);
+    assetsController.hub.once(`${suggestedAssetMeta.id}:finished`, () => {
+      expect(assetsController.state.suggestedAssets).toHaveLength(0);
     });
+    await expect(result).rejects.toThrow('User rejected to watch the asset.');
   });
 
   it('should accept a valid suggested asset via watchAsset', async () => {
-    await new Promise(async (resolve) => {
-      const { result, suggestedAssetMeta } = await assetsController.watchAsset(
-        {
-          address: '0xe9f786dfdd9ae4d57e830acb52296837765f0e5b',
-          decimals: 18,
-          symbol: 'TKN',
-        },
-        'ERC20',
-      );
-      result.then((res) => {
-        expect(assetsController.state.suggestedAssets).toHaveLength(0);
-        expect(res).toBe('0xe9f786dfdd9ae4d57e830acb52296837765f0e5b');
-        resolve('');
-      });
-      await assetsController.acceptWatchAsset(suggestedAssetMeta.id);
+    const { result, suggestedAssetMeta } = await assetsController.watchAsset(
+      {
+        address: '0xe9f786dfdd9ae4d57e830acb52296837765f0e5b',
+        decimals: 18,
+        symbol: 'TKN',
+      },
+      'ERC20',
+    );
+    await assetsController.acceptWatchAsset(suggestedAssetMeta.id);
+    await result.then((res) => {
+      expect(assetsController.state.suggestedAssets).toHaveLength(0);
+      expect(res).toBe('0xe9f786dfdd9ae4d57e830acb52296837765f0e5b');
     });
   });
 
   it('should fail a valid suggested asset via watchAsset with wrong type', async () => {
-    await new Promise(async (resolve) => {
-      const { result, suggestedAssetMeta } = await assetsController.watchAsset(
-        {
-          address: '0xe9f786dfdd9be4d57e830acb52296837765f0e5b',
-          decimals: 18,
-          symbol: 'TKN',
-        },
-        'ERC20',
-      );
-      const { suggestedAssets } = assetsController.state;
-      const index = suggestedAssets.findIndex(({ id }) => suggestedAssetMeta.id === id);
-      const newSuggestedAssetMeta = suggestedAssets[index];
-      suggestedAssetMeta.type = 'ERC721';
-      assetsController.update({ suggestedAssets: [...suggestedAssets, newSuggestedAssetMeta] });
-      await assetsController.acceptWatchAsset(suggestedAssetMeta.id);
-      result.catch((error) => {
-        expect(error.message).toContain('Asset of type ERC721 not supported');
-        resolve('');
-      });
-    });
+    const { result, suggestedAssetMeta } = await assetsController.watchAsset(
+      {
+        address: '0xe9f786dfdd9be4d57e830acb52296837765f0e5b',
+        decimals: 18,
+        symbol: 'TKN',
+      },
+      'ERC20',
+    );
+    const { suggestedAssets } = assetsController.state;
+    const index = suggestedAssets.findIndex(({ id }) => suggestedAssetMeta.id === id);
+    const newSuggestedAssetMeta = suggestedAssets[index];
+    suggestedAssetMeta.type = 'ERC721';
+    assetsController.update({ suggestedAssets: [...suggestedAssets, newSuggestedAssetMeta] });
+    await assetsController.acceptWatchAsset(suggestedAssetMeta.id);
+    await expect(result).rejects.toThrow('Asset of type ERC721 not supported');
   });
 
   it('should not add duplicate tokens to the ignoredToken list', async () => {

--- a/src/message-manager/MessageManager.test.ts
+++ b/src/message-manager/MessageManager.test.ts
@@ -75,9 +75,8 @@ describe('PersonalMessageManager', () => {
       expect(unapprovedMessages[keys[0]].status).toBe('signed');
     });
     controller.setMessageStatusSigned(keys[0], rawSig);
-    await result.then((sig) => {
-      expect(sig).toEqual(rawSig);
-    });
+    const sig = await result;
+    expect(sig).toBe(rawSig);
   });
 
   it('should throw when unapproved finishes', async () => {

--- a/src/message-manager/MessageManager.test.ts
+++ b/src/message-manager/MessageManager.test.ts
@@ -42,69 +42,56 @@ describe('PersonalMessageManager', () => {
   });
 
   it('should reject a message', async () => {
-    await new Promise<void>(async (resolve) => {
-      const controller = new MessageManager();
-      const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-      const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
-      const result = controller.addUnapprovedMessageAsync({
-        data,
-        from,
-      });
-      const unapprovedMessages = controller.getUnapprovedMessages();
-      const keys = Object.keys(unapprovedMessages);
-      controller.hub.once(`${keys[0]}:finished`, () => {
-        expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
-        expect(unapprovedMessages[keys[0]].status).toBe('rejected');
-      });
-      controller.rejectMessage(keys[0]);
-      result.catch((error) => {
-        expect(error.message).toContain('User denied message signature');
-        resolve();
-      });
+    const controller = new MessageManager();
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
+    const result = controller.addUnapprovedMessageAsync({
+      data,
+      from,
     });
+    const unapprovedMessages = controller.getUnapprovedMessages();
+    const keys = Object.keys(unapprovedMessages);
+    controller.hub.once(`${keys[0]}:finished`, () => {
+      expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
+      expect(unapprovedMessages[keys[0]].status).toBe('rejected');
+    });
+    controller.rejectMessage(keys[0]);
+    await expect(result).rejects.toThrow('User denied message signature');
   });
 
   it('should sign a message', async () => {
-    await new Promise<void>(async (resolve) => {
-      const controller = new MessageManager();
-      const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-      const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
-      const rawSig = '0x5f7a0';
-      const result = controller.addUnapprovedMessageAsync({
-        data,
-        from,
-      });
-      const unapprovedMessages = controller.getUnapprovedMessages();
-      const keys = Object.keys(unapprovedMessages);
-      controller.hub.once(`${keys[0]}:finished`, () => {
-        expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
-        expect(unapprovedMessages[keys[0]].status).toBe('signed');
-      });
-      controller.setMessageStatusSigned(keys[0], rawSig);
-      result.then((sig) => {
-        expect(sig).toEqual(rawSig);
-        resolve();
-      });
+    const controller = new MessageManager();
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
+    const rawSig = '0x5f7a0';
+    const result = controller.addUnapprovedMessageAsync({
+      data,
+      from,
+    });
+    const unapprovedMessages = controller.getUnapprovedMessages();
+    const keys = Object.keys(unapprovedMessages);
+    controller.hub.once(`${keys[0]}:finished`, () => {
+      expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
+      expect(unapprovedMessages[keys[0]].status).toBe('signed');
+    });
+    controller.setMessageStatusSigned(keys[0], rawSig);
+    await result.then((sig) => {
+      expect(sig).toEqual(rawSig);
     });
   });
 
   it('should throw when unapproved finishes', async () => {
-    await new Promise<void>(async (resolve) => {
-      const controller = new MessageManager();
-      const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-      const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
-      const result = controller.addUnapprovedMessageAsync({
-        data,
-        from,
-      });
-      const unapprovedMessages = controller.getUnapprovedMessages();
-      const keys = Object.keys(unapprovedMessages);
-      controller.hub.emit(`${keys[0]}:finished`, unapprovedMessages[keys[0]]);
-      result.catch((error) => {
-        expect(error.message).toContain('Unknown problem');
-        resolve();
-      });
+    const controller = new MessageManager();
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
+    const result = controller.addUnapprovedMessageAsync({
+      data,
+      from,
     });
+    const unapprovedMessages = controller.getUnapprovedMessages();
+    const keys = Object.keys(unapprovedMessages);
+    controller.hub.emit(`${keys[0]}:finished`, unapprovedMessages[keys[0]]);
+    await expect(result).rejects.toThrow('Unknown problem');
   });
 
   it('should add a valid unapproved message', async () => {

--- a/src/message-manager/PersonalMessageManager.test.ts
+++ b/src/message-manager/PersonalMessageManager.test.ts
@@ -42,69 +42,56 @@ describe('PersonalMessageManager', () => {
   });
 
   it('should reject a message', async () => {
-    await new Promise<void>(async (resolve) => {
-      const controller = new PersonalMessageManager();
-      const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-      const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
-      const result = controller.addUnapprovedMessageAsync({
-        data,
-        from,
-      });
-      const unapprovedMessages = controller.getUnapprovedMessages();
-      const keys = Object.keys(unapprovedMessages);
-      controller.hub.once(`${keys[0]}:finished`, () => {
-        expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
-        expect(unapprovedMessages[keys[0]].status).toBe('rejected');
-      });
-      controller.rejectMessage(keys[0]);
-      result.catch((error) => {
-        expect(error.message).toContain('User denied message signature');
-        resolve();
-      });
+    const controller = new PersonalMessageManager();
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
+    const result = controller.addUnapprovedMessageAsync({
+      data,
+      from,
     });
+    const unapprovedMessages = controller.getUnapprovedMessages();
+    const keys = Object.keys(unapprovedMessages);
+    controller.hub.once(`${keys[0]}:finished`, () => {
+      expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
+      expect(unapprovedMessages[keys[0]].status).toBe('rejected');
+    });
+    controller.rejectMessage(keys[0]);
+    await expect(result).rejects.toThrow('User denied message signature');
   });
 
   it('should sign a message', async () => {
-    await new Promise<void>(async (resolve) => {
-      const controller = new PersonalMessageManager();
-      const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-      const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
-      const rawSig = '0x5f7a0';
-      const result = controller.addUnapprovedMessageAsync({
-        data,
-        from,
-      });
-      const unapprovedMessages = controller.getUnapprovedMessages();
-      const keys = Object.keys(unapprovedMessages);
-      controller.hub.once(`${keys[0]}:finished`, () => {
-        expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
-        expect(unapprovedMessages[keys[0]].status).toBe('signed');
-      });
-      controller.setMessageStatusSigned(keys[0], rawSig);
-      result.then((sig) => {
-        expect(sig).toEqual(rawSig);
-        resolve();
-      });
+    const controller = new PersonalMessageManager();
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
+    const rawSig = '0x5f7a0';
+    const result = controller.addUnapprovedMessageAsync({
+      data,
+      from,
+    });
+    const unapprovedMessages = controller.getUnapprovedMessages();
+    const keys = Object.keys(unapprovedMessages);
+    controller.hub.once(`${keys[0]}:finished`, () => {
+      expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
+      expect(unapprovedMessages[keys[0]].status).toBe('signed');
+    });
+    controller.setMessageStatusSigned(keys[0], rawSig);
+    await result.then((sig) => {
+      expect(sig).toEqual(rawSig);
     });
   });
 
   it('should throw when unapproved finishes', async () => {
-    await new Promise<void>(async (resolve) => {
-      const controller = new PersonalMessageManager();
-      const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-      const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
-      const result = controller.addUnapprovedMessageAsync({
-        data,
-        from,
-      });
-      const unapprovedMessages = controller.getUnapprovedMessages();
-      const keys = Object.keys(unapprovedMessages);
-      controller.hub.emit(`${keys[0]}:finished`, unapprovedMessages[keys[0]]);
-      result.catch((error) => {
-        expect(error.message).toContain('Unknown problem');
-        resolve();
-      });
+    const controller = new PersonalMessageManager();
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    const data = '0x879a053d4800c6354e76c7985a865d2922c82fb5b';
+    const result = controller.addUnapprovedMessageAsync({
+      data,
+      from,
     });
+    const unapprovedMessages = controller.getUnapprovedMessages();
+    const keys = Object.keys(unapprovedMessages);
+    controller.hub.emit(`${keys[0]}:finished`, unapprovedMessages[keys[0]]);
+    await expect(result).rejects.toThrow('Unknown problem');
   });
 
   it('should add a valid unapproved message', async () => {

--- a/src/message-manager/PersonalMessageManager.test.ts
+++ b/src/message-manager/PersonalMessageManager.test.ts
@@ -75,9 +75,8 @@ describe('PersonalMessageManager', () => {
       expect(unapprovedMessages[keys[0]].status).toBe('signed');
     });
     controller.setMessageStatusSigned(keys[0], rawSig);
-    await result.then((sig) => {
-      expect(sig).toEqual(rawSig);
-    });
+    const sig = await result;
+    expect(sig).toBe(rawSig);
   });
 
   it('should throw when unapproved finishes', async () => {

--- a/src/message-manager/TypedMessageManager.test.ts
+++ b/src/message-manager/TypedMessageManager.test.ts
@@ -95,9 +95,8 @@ describe('TypedMessageManager', () => {
       expect(unapprovedMessages[keys[0]].status).toBe('signed');
     });
     controller.setMessageStatusSigned(keys[0], rawSig);
-    await result.then((sig) => {
-      expect(sig).toEqual(rawSig);
-    });
+    const sig = await result;
+    expect(sig).toBe(rawSig);
   });
 
   it("should set message status as 'errored'", async () => {

--- a/src/message-manager/TypedMessageManager.test.ts
+++ b/src/message-manager/TypedMessageManager.test.ts
@@ -54,108 +54,90 @@ describe('TypedMessageManager', () => {
   });
 
   it('should reject a message', async () => {
-    await new Promise<void>(async (resolve) => {
-      const controller = new TypedMessageManager();
-      const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-      const version = 'V1';
-      const messageData = typedMessage;
-      const result = controller.addUnapprovedMessageAsync(
-        {
-          data: messageData,
-          from,
-        },
-        version,
-      );
-      const unapprovedMessages = controller.getUnapprovedMessages();
-      const keys = Object.keys(unapprovedMessages);
-      controller.hub.once(`${keys[0]}:finished`, () => {
-        expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
-        expect(unapprovedMessages[keys[0]].status).toBe('rejected');
-      });
-      controller.rejectMessage(keys[0]);
-      result.catch((error) => {
-        expect(error.message).toContain('User denied message signature');
-        resolve();
-      });
+    const controller = new TypedMessageManager();
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    const version = 'V1';
+    const messageData = typedMessage;
+    const result = controller.addUnapprovedMessageAsync(
+      {
+        data: messageData,
+        from,
+      },
+      version,
+    );
+    const unapprovedMessages = controller.getUnapprovedMessages();
+    const keys = Object.keys(unapprovedMessages);
+    controller.hub.once(`${keys[0]}:finished`, () => {
+      expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
+      expect(unapprovedMessages[keys[0]].status).toBe('rejected');
     });
+    controller.rejectMessage(keys[0]);
+    await expect(result).rejects.toThrow('User denied message signature');
   });
 
   it('should sign a message', async () => {
-    await new Promise<void>(async (resolve) => {
-      const controller = new TypedMessageManager();
-      const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-      const version = 'V1';
-      const rawSig = '0x5f7a0';
-      const messageData = typedMessage;
-      const result = controller.addUnapprovedMessageAsync(
-        {
-          data: messageData,
-          from,
-        },
-        version,
-      );
-      const unapprovedMessages = controller.getUnapprovedMessages();
-      const keys = Object.keys(unapprovedMessages);
-      controller.hub.once(`${keys[0]}:finished`, () => {
-        expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
-        expect(unapprovedMessages[keys[0]].status).toBe('signed');
-      });
-      controller.setMessageStatusSigned(keys[0], rawSig);
-      result.then((sig) => {
-        expect(sig).toEqual(rawSig);
-        resolve();
-      });
+    const controller = new TypedMessageManager();
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    const version = 'V1';
+    const rawSig = '0x5f7a0';
+    const messageData = typedMessage;
+    const result = controller.addUnapprovedMessageAsync(
+      {
+        data: messageData,
+        from,
+      },
+      version,
+    );
+    const unapprovedMessages = controller.getUnapprovedMessages();
+    const keys = Object.keys(unapprovedMessages);
+    controller.hub.once(`${keys[0]}:finished`, () => {
+      expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
+      expect(unapprovedMessages[keys[0]].status).toBe('signed');
+    });
+    controller.setMessageStatusSigned(keys[0], rawSig);
+    await result.then((sig) => {
+      expect(sig).toEqual(rawSig);
     });
   });
 
   it("should set message status as 'errored'", async () => {
-    await new Promise<void>(async (resolve) => {
-      const controller = new TypedMessageManager();
-      const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-      const version = 'V1';
-      const messageData = typedMessage;
-      const result = controller.addUnapprovedMessageAsync(
-        {
-          data: messageData,
-          from,
-        },
-        version,
-      );
-      const unapprovedMessages = controller.getUnapprovedMessages();
-      const keys = Object.keys(unapprovedMessages);
-      controller.hub.once(`${keys[0]}:finished`, () => {
-        expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
-        expect(unapprovedMessages[keys[0]].status).toBe('errored');
-      });
-      controller.setMessageStatusErrored(keys[0], 'error message');
-      result.catch((error) => {
-        expect(error.message).toContain('MetaMask Typed Message Signature: error message');
-        resolve();
-      });
+    const controller = new TypedMessageManager();
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    const version = 'V1';
+    const messageData = typedMessage;
+    const result = controller.addUnapprovedMessageAsync(
+      {
+        data: messageData,
+        from,
+      },
+      version,
+    );
+    const unapprovedMessages = controller.getUnapprovedMessages();
+    const keys = Object.keys(unapprovedMessages);
+    controller.hub.once(`${keys[0]}:finished`, () => {
+      expect(unapprovedMessages[keys[0]].messageParams.from).toBe(from);
+      expect(unapprovedMessages[keys[0]].status).toBe('errored');
     });
+    controller.setMessageStatusErrored(keys[0], 'error message');
+    await expect(result).rejects.toThrow('MetaMask Typed Message Signature: error message');
   });
 
   it('should throw when unapproved finishes', async () => {
-    await new Promise<void>(async (resolve) => {
-      const controller = new TypedMessageManager();
-      const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-      const version = 'V1';
-      const messageData = typedMessage;
-      const result = controller.addUnapprovedMessageAsync(
-        {
-          data: messageData,
-          from,
-        },
-        version,
-      );
-      const unapprovedMessages = controller.getUnapprovedMessages();
-      const keys = Object.keys(unapprovedMessages);
-      controller.hub.emit(`${keys[0]}:finished`, unapprovedMessages[keys[0]]);
-      result.catch((error) => {
-        expect(error.message).toContain('Unknown problem');
-        resolve();
-      });
-    });
+    const controller = new TypedMessageManager();
+    const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    const version = 'V1';
+    const messageData = typedMessage;
+    const result = controller.addUnapprovedMessageAsync(
+      {
+        data: messageData,
+        from,
+      },
+      version,
+    );
+    const unapprovedMessages = controller.getUnapprovedMessages();
+    const keys = Object.keys(unapprovedMessages);
+    controller.hub.emit(`${keys[0]}:finished`, unapprovedMessages[keys[0]]);
+    await expect(result).rejects.toThrow('Unknown problem');
   });
 
   it('should add a valid unapproved message', async () => {

--- a/src/transaction/TransactionController.test.ts
+++ b/src/transaction/TransactionController.test.ts
@@ -661,25 +661,25 @@ describe('TransactionController', () => {
   });
 
   it('should fail to approve an invalid transaction', async () => {
-    const controller = new TransactionController({
-      provider: PROVIDER,
-      sign: () => {
-        throw new Error('foo');
-      },
-    });
-    controller.context = {
-      NetworkController: MOCK_NETWORK,
-    } as any;
-    controller.onComposed();
-    const from = '0xe6509775f3f3614576c0d83f8647752f87cd6659';
-    const to = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-    const { result } = await controller.addTransaction({ from, to });
-    const { transaction, status } = controller.state.transactions[0];
-    expect(transaction.from).toBe(from);
-    expect(transaction.to).toBe(to);
-    expect(status).toBe(TransactionStatus.unapproved);
-    await controller.approveTransaction(controller.state.transactions[0].id);
-    await expect(result).rejects.toThrow('foo');
+      const controller = new TransactionController({
+        provider: PROVIDER,
+        sign: () => {
+          throw new Error('foo');
+        },
+      });
+      controller.context = {
+        NetworkController: MOCK_NETWORK,
+      } as any;
+      controller.onComposed();
+      const from = '0xe6509775f3f3614576c0d83f8647752f87cd6659';
+      const to = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+      const { result } = await controller.addTransaction({ from, to });
+      await controller.approveTransaction(controller.state.transactions[0].id);
+      const { transaction, status } = controller.state.transactions[0];
+      expect(transaction.from).toBe(from);
+      expect(transaction.to).toBe(to);
+      expect(status).toBe(TransactionStatus.failed);
+      await expect(result).rejects.toThrow('foo');
   });
 
   it('should fail transaction if gas calculation fails', async () => {
@@ -714,11 +714,11 @@ describe('TransactionController', () => {
     const from = '0xe6509775f3f3614576c0d83f8647752f87cd6659';
     const to = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
     const { result } = await controller.addTransaction({ from, to });
+    await controller.approveTransaction(controller.state.transactions[0].id);
     const { transaction, status } = controller.state.transactions[0];
     expect(transaction.from).toBe(from);
     expect(transaction.to).toBe(to);
-    expect(status).toBe(TransactionStatus.unapproved);
-    await controller.approveTransaction(controller.state.transactions[0].id);
+    expect(status).toBe(TransactionStatus.failed);
     await expect(result).rejects.toThrow('No sign method defined');
   });
 
@@ -734,11 +734,11 @@ describe('TransactionController', () => {
     const from = '0xe6509775f3f3614576c0d83f8647752f87cd6659';
     const to = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
     const { result } = await controller.addTransaction({ from, to });
+    await controller.approveTransaction(controller.state.transactions[0].id);
     const { transaction, status } = controller.state.transactions[0];
     expect(transaction.from).toBe(from);
     expect(transaction.to).toBe(to);
-    expect(status).toBe(TransactionStatus.unapproved);
-    await controller.approveTransaction(controller.state.transactions[0].id);
+    expect(status).toBe(TransactionStatus.failed);
     await expect(result).rejects.toThrow('No chainId defined');
   });
 

--- a/src/transaction/TransactionController.test.ts
+++ b/src/transaction/TransactionController.test.ts
@@ -617,7 +617,7 @@ describe('TransactionController', () => {
       to: from,
     });
     controller.cancelTransaction('foo');
-    await new Promise(async (resolve) => {
+    const transactionListener = new Promise(async (resolve) => {
       controller.hub.once(`${controller.state.transactions[0].id}:finished`, () => {
         expect(controller.state.transactions[0].transaction.from).toBe(from);
         expect(controller.state.transactions[0].status).toBe(TransactionStatus.rejected);
@@ -626,6 +626,7 @@ describe('TransactionController', () => {
     });
     controller.cancelTransaction(controller.state.transactions[0].id);
     await expect(result).rejects.toThrow('User rejected the transaction');
+    await transactionListener;
   });
 
   it('should wipe transactions', async () => {


### PR DESCRIPTION
This PR refactors the way the tests catch errors. Currently they are wrapped in promises, but instead it can be refactored to use a jest trick of await expect(function).rejects.toThrow('error message'). Using this trick, we can remove this lint rule.