### PR TITLE
Restore `BN` export

### DIFF
--- a/src/assets/TokenBalancesController.test.ts
+++ b/src/assets/TokenBalancesController.test.ts
@@ -7,7 +7,7 @@ import { PreferencesController } from '../user/PreferencesController';
 import { AssetsController } from './AssetsController';
 import { Token } from './TokenRatesController';
 import { AssetsContractController } from './AssetsContractController';
-import TokenBalancesController from './TokenBalancesController';
+import { BN as exportedBn, TokenBalancesController } from './TokenBalancesController';
 
 const MAINNET_PROVIDER = new HttpProvider('https://mainnet.infura.io');
 
@@ -26,6 +26,10 @@ describe('TokenBalancesController', () => {
 
   afterEach(() => {
     sandbox.restore();
+  });
+
+  it('should re-export BN', () => {
+    expect(exportedBn).toEqual(BN);
   });
 
   it('should set default state', () => {

--- a/src/assets/TokenBalancesController.ts
+++ b/src/assets/TokenBalancesController.ts
@@ -5,6 +5,9 @@ import AssetsController from './AssetsController';
 import { Token } from './TokenRatesController';
 import { AssetsContractController } from './AssetsContractController';
 
+// TODO: Remove this export in the next major release
+export { BN };
+
 /**
  * @type TokenBalancesConfig
  *


### PR DESCRIPTION
The `BN` export was removed in #398. I hadn't anticipated at the time that this would constitute a breaking change. It turns out that this export was relied upon in mobile in one place.

It has been temporarily restored, along with a comment that suggests we remove it in the next major version.