### PR TITLE
Add comment to explain why `camelcase` is disabled

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,12 @@ module.exports = {
     },
   ],
   rules: {
+    // Left disabled because various properties throughough this repo are snake_case because the
+    // names come from external sources or must comply with standards
+    // e.g. `txreceipt_status`, `signTypedData_v4`, `token_id`
     camelcase: 'off',
+
+    // TODO: re-enble most of these rules
     'function-paren-newline': 'off',
     'guard-for-in': 'off',
     'implicit-arrow-linebreak': 'off',


### PR DESCRIPTION
A comment now explains why the ESLint rule `camelcase` is disabled. A comment explaining that the other rules should probably be re-enabled has also been added.

As we continue to re-renable these lint rules, we should ensure any modifications or disabled rules have comments explaining why the change from the default config was necessary.