### PR TITLE
Support longer token symbols via `wallet_watchAsset`

### DIFF
--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -498,6 +498,36 @@ describe('util', () => {
       ).toThrow('Invalid symbol: not a string.');
     });
 
+    it('should throw if symbol is an empty string', () => {
+      expect(() =>
+        util.validateTokenToWatch({
+          address: '0xe9f786dfdd9be4d57e830acb52296837765f0e5b',
+          decimals: 0,
+          symbol: '',
+        } as any),
+      ).toThrow('Must specify address, symbol, and decimals.');
+    });
+
+    it('should not throw if symbol is exactly 1 character long', () => {
+      expect(() =>
+        util.validateTokenToWatch({
+          address: '0xe9f786dfdd9be4d57e830acb52296837765f0e5b',
+          decimals: 0,
+          symbol: 'T',
+        } as any),
+      ).not.toThrow();
+    });
+
+    it('should not throw if symbol is exactly 11 characters long', () => {
+      expect(() =>
+        util.validateTokenToWatch({
+          address: '0xe9f786dfdd9be4d57e830acb52296837765f0e5b',
+          decimals: 0,
+          symbol: 'TKNTKNTKNTK',
+        } as any),
+      ).not.toThrow();
+    });
+
     it('should throw if symbol is more than 11 characters long', () => {
       expect(() =>
         util.validateTokenToWatch({

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -498,14 +498,14 @@ describe('util', () => {
       ).toThrow('Invalid symbol: not a string.');
     });
 
-    it('should throw if symbol is more than 6 characters long', () => {
+    it('should throw if symbol is more than 11 characters long', () => {
       expect(() =>
         util.validateTokenToWatch({
           address: '0xe9f786dfdd9be4d57e830acb52296837765f0e5b',
           decimals: 0,
-          symbol: 'TKNTKNTKN',
+          symbol: 'TKNTKNTKNTKN',
         } as any),
-      ).toThrow('Invalid symbol "TKNTKNTKN": longer than 6 characters.');
+      ).toThrow('Invalid symbol "TKNTKNTKNTKN": longer than 11 characters.');
     });
 
     it('should throw if invalid decimals', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -365,8 +365,8 @@ export function validateTokenToWatch(token: Token) {
   if (typeof symbol !== 'string') {
     throw ethErrors.rpc.invalidParams(`Invalid symbol: not a string.`);
   }
-  if (symbol.length > 6) {
-    throw ethErrors.rpc.invalidParams(`Invalid symbol "${symbol}": longer than 6 characters.`);
+  if (symbol.length > 11) {
+    throw ethErrors.rpc.invalidParams(`Invalid symbol "${symbol}": longer than 11 characters.`);
   }
   const numDecimals = parseInt((decimals as unknown) as string, 10);
   if (isNaN(numDecimals) || numDecimals > 36 || numDecimals < 0) {


### PR DESCRIPTION
This increases the maximum token length that can be suggested via `wallet_watchAsset` from 6 to 11, which matches the maximum symbol length for custom tokens added on the MetaMask extension.