### PR TITLE
Optional AllowedEvents/AllowedActions

### DIFF
--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -52,7 +52,6 @@ describe('BaseController', () => {
     >();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
-      allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
     const controller = new CountController({
@@ -72,7 +71,6 @@ describe('BaseController', () => {
     >();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
-      allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
     const controller = new CountController({
@@ -92,7 +90,6 @@ describe('BaseController', () => {
     >();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
-      allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
     const controller = new CountController({
@@ -116,7 +113,6 @@ describe('BaseController', () => {
     >();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
-      allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
     const controller = new CountController({
@@ -140,7 +136,6 @@ describe('BaseController', () => {
     >();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
-      allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
     const controller = new CountController({
@@ -164,7 +159,6 @@ describe('BaseController', () => {
     >();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
-      allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
     const controller = new CountController({
@@ -191,7 +185,6 @@ describe('BaseController', () => {
     >();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
-      allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
     const controller = new CountController({
@@ -228,7 +221,6 @@ describe('BaseController', () => {
     >();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
-      allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
     const controller = new CountController({
@@ -260,7 +252,6 @@ describe('BaseController', () => {
     >();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
-      allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
     const controller = new CountController({
@@ -287,7 +278,6 @@ describe('BaseController', () => {
     >();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
-      allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
     const controller = new CountController({
@@ -315,7 +305,6 @@ describe('BaseController', () => {
     >();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
-      allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
     new CountController({
@@ -340,7 +329,6 @@ describe('BaseController', () => {
     >();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
-      allowedActions: [],
       allowedEvents: ['CountController:stateChange'],
     });
     const controller = new CountController({
@@ -792,10 +780,12 @@ describe('getPersistentState', () => {
         VisitorControllerAction | VisitorOverflowControllerAction,
         VisitorControllerEvent | VisitorOverflowControllerEvent
       >();
-      const visitorControllerMessenger = controllerMessenger.getRestricted({
+      const visitorControllerMessenger = controllerMessenger.getRestricted<
+        'VisitorController',
+        never,
+        never
+      >({
         name: 'VisitorController',
-        allowedActions: [],
-        allowedEvents: [],
       });
       const visitorController = new VisitorController(
         visitorControllerMessenger,

--- a/src/BaseControllerV2.ts
+++ b/src/BaseControllerV2.ts
@@ -125,8 +125,8 @@ export class BaseController<
     N,
     any,
     StateChangeEvent<N, S, any>,
-    string,
-    string
+    string | never,
+    string | never
   >;
 
   private name: N;
@@ -153,8 +153,8 @@ export class BaseController<
       N,
       any,
       StateChangeEvent<N, S, any>,
-      string,
-      string
+      string | never,
+      string | never
     >;
     metadata: StateMetadata<S>;
     name: N;

--- a/src/ControllerMessenger.test.ts
+++ b/src/ControllerMessenger.test.ts
@@ -313,7 +313,6 @@ describe('RestrictedControllerMessenger', () => {
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
       allowedActions: ['CountController:count'],
-      allowedEvents: [],
     });
 
     let count = 0;
@@ -339,7 +338,6 @@ describe('RestrictedControllerMessenger', () => {
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
       allowedActions: ['MessageController:reset', 'MessageController:concat'],
-      allowedEvents: [],
     });
 
     let message = '';
@@ -374,7 +372,6 @@ describe('RestrictedControllerMessenger', () => {
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
       allowedActions: ['CountController:increment'],
-      allowedEvents: [],
     });
 
     let count = 0;
@@ -398,7 +395,6 @@ describe('RestrictedControllerMessenger', () => {
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
       allowedActions: ['MessageController:message'],
-      allowedEvents: [],
     });
 
     const messages: Record<string, string> = {};
@@ -426,7 +422,6 @@ describe('RestrictedControllerMessenger', () => {
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MathController',
       allowedActions: ['MathController:add'],
-      allowedEvents: [],
     });
 
     restrictedControllerMessenger.registerActionHandler(
@@ -450,7 +445,6 @@ describe('RestrictedControllerMessenger', () => {
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'PingController',
       allowedActions: ['PingController:ping'],
-      allowedEvents: [],
     });
 
     restrictedControllerMessenger.registerActionHandler(
@@ -472,7 +466,6 @@ describe('RestrictedControllerMessenger', () => {
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'PingController',
       allowedActions: ['PingController:ping'],
-      allowedEvents: [],
     });
 
     expect(() => {
@@ -486,7 +479,6 @@ describe('RestrictedControllerMessenger', () => {
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'PingController',
       allowedActions: ['PingController:ping'],
-      allowedEvents: [],
     });
 
     expect(() => {
@@ -519,7 +511,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedActions: [],
       allowedEvents: ['MessageController:message'],
     });
 
@@ -541,7 +532,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedActions: [],
       allowedEvents: ['MessageController:message', 'MessageController:ping'],
     });
 
@@ -570,7 +560,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, PingEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'PingController',
-      allowedActions: [],
       allowedEvents: ['PingController:ping'],
     });
 
@@ -590,7 +579,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedActions: [],
       allowedEvents: ['MessageController:message'],
     });
 
@@ -617,7 +605,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedActions: [],
       allowedEvents: ['MessageController:message'],
     });
 
@@ -644,7 +631,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedActions: [],
       allowedEvents: ['MessageController:message'],
     });
 
@@ -674,7 +660,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedActions: [],
       allowedEvents: ['MessageController:message'],
     });
 
@@ -700,7 +685,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedActions: [],
       allowedEvents: ['MessageController:message'],
     });
 
@@ -721,7 +705,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedActions: [],
       allowedEvents: ['MessageController:message'],
     });
 
@@ -748,7 +731,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedActions: [],
       allowedEvents: ['MessageController:message'],
     });
 
@@ -773,7 +755,6 @@ describe('RestrictedControllerMessenger', () => {
     const controllerMessenger = new ControllerMessenger<never, MessageEvent>();
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedActions: [],
       allowedEvents: ['MessageController:message'],
     });
 
@@ -793,14 +774,11 @@ describe('RestrictedControllerMessenger', () => {
     const externalRestrictedControllerMessenger = controllerMessenger.getRestricted(
       {
         name: 'CountController',
-        allowedActions: [],
-        allowedEvents: [],
       },
     );
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'OtherController',
       allowedActions: ['CountController:count'],
-      allowedEvents: [],
     });
 
     let count = 0;
@@ -824,13 +802,10 @@ describe('RestrictedControllerMessenger', () => {
     const externalRestrictedControllerMessenger = controllerMessenger.getRestricted(
       {
         name: 'MessageController',
-        allowedActions: [],
-        allowedEvents: [],
       },
     );
     const restrictedControllerMessenger = controllerMessenger.getRestricted({
       name: 'OtherController',
-      allowedActions: [],
       allowedEvents: ['MessageController:message'],
     });
 
@@ -867,12 +842,9 @@ describe('RestrictedControllerMessenger', () => {
     const messageControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
       allowedActions: ['MessageController:reset', 'CountController:count'],
-      allowedEvents: [],
     });
     const countControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
-      allowedActions: [],
-      allowedEvents: [],
     });
 
     let count = 0;
@@ -916,13 +888,10 @@ describe('RestrictedControllerMessenger', () => {
 
     const messageControllerMessenger = controllerMessenger.getRestricted({
       name: 'MessageController',
-      allowedActions: [],
       allowedEvents: ['MessageController:ping', 'CountController:update'],
     });
     const countControllerMessenger = controllerMessenger.getRestricted({
       name: 'CountController',
-      allowedActions: [],
-      allowedEvents: [],
     });
 
     let pings = 0;

--- a/src/ControllerMessenger.ts
+++ b/src/ControllerMessenger.ts
@@ -82,8 +82,8 @@ export class RestrictedControllerMessenger<
   }: {
     controllerMessenger: ControllerMessenger<Action, Event>;
     name: N;
-    allowedActions?: AllowedAction[] | never;
-    allowedEvents?: AllowedEvent[] | never;
+    allowedActions?: AllowedAction[];
+    allowedEvents?: AllowedEvent[];
   }) {
     this.controllerMessenger = controllerMessenger;
     this.controllerName = name;
@@ -448,8 +448,8 @@ export class ControllerMessenger<
     allowedEvents,
   }: {
     name: N;
-    allowedActions?: Extract<Action['type'], AllowedAction>[] | never;
-    allowedEvents?: Extract<Event['type'], AllowedEvent>[] | never;
+    allowedActions?: Extract<Action['type'], AllowedAction>[];
+    allowedEvents?: Extract<Event['type'], AllowedEvent>[];
   }) {
     return new RestrictedControllerMessenger<
       N,


### PR DESCRIPTION
The restricted controller messenger now allows omitting allowedActions and allowedEvents. Technically it already allowed this, but it required setting the type of the allowed actions/events to an empty string. Now the type is `never` if no actions/events are used.