### PR TITLE
Simplify BaseControllerV2 tests

### DIFF
--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -11,12 +11,18 @@ import {
   RestrictedControllerMessenger,
 } from './ControllerMessenger';
 
+const countControllerName = 'CountController';
+
 type CountControllerState = {
   count: number;
 };
+type CountControllerAction = {
+  type: `${typeof countControllerName}:getState`;
+  handler: () => CountControllerState;
+};
 
 type CountControllerEvent = {
-  type: `CountController:stateChange`;
+  type: `${typeof countControllerName}:stateChange`;
   payload: [CountControllerState, Patch[]];
 };
 
@@ -27,8 +33,33 @@ const countControllerStateMetadata = {
   },
 };
 
+type CountMessenger = RestrictedControllerMessenger<
+  typeof countControllerName,
+  CountControllerAction,
+  CountControllerEvent,
+  never,
+  never
+>;
+
+function getCountMessenger(
+  controllerMessenger?: ControllerMessenger<
+    CountControllerAction,
+    CountControllerEvent
+  >,
+): CountMessenger {
+  if (!controllerMessenger) {
+    controllerMessenger = new ControllerMessenger<
+      CountControllerAction,
+      CountControllerEvent
+    >();
+  }
+  return controllerMessenger.getRestricted({
+    name: countControllerName,
+  });
+}
+
 class CountController extends BaseController<
-  'CountController',
+  typeof countControllerName,
   CountControllerState
 > {
   update(
@@ -46,17 +77,9 @@ class CountController extends BaseController<
 
 describe('BaseController', () => {
   it('should set initial state', () => {
-    const controllerMessenger = new ControllerMessenger<
-      never,
-      CountControllerEvent
-    >();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted({
-      name: 'CountController',
-      allowedEvents: ['CountController:stateChange'],
-    });
     const controller = new CountController({
-      messenger: restrictedControllerMessenger,
-      name: 'CountController',
+      messenger: getCountMessenger(),
+      name: countControllerName,
       state: { count: 0 },
       metadata: countControllerStateMetadata,
     });
@@ -65,16 +88,8 @@ describe('BaseController', () => {
   });
 
   it('should set initial schema', () => {
-    const controllerMessenger = new ControllerMessenger<
-      never,
-      CountControllerEvent
-    >();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted({
-      name: 'CountController',
-      allowedEvents: ['CountController:stateChange'],
-    });
     const controller = new CountController({
-      messenger: restrictedControllerMessenger,
+      messenger: getCountMessenger(),
       name: 'CountController',
       state: { count: 0 },
       metadata: countControllerStateMetadata,
@@ -84,16 +99,8 @@ describe('BaseController', () => {
   });
 
   it('should not allow mutating state directly', () => {
-    const controllerMessenger = new ControllerMessenger<
-      never,
-      CountControllerEvent
-    >();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted({
-      name: 'CountController',
-      allowedEvents: ['CountController:stateChange'],
-    });
     const controller = new CountController({
-      messenger: restrictedControllerMessenger,
+      messenger: getCountMessenger(),
       name: 'CountController',
       state: { count: 0 },
       metadata: countControllerStateMetadata,
@@ -107,16 +114,8 @@ describe('BaseController', () => {
   });
 
   it('should allow updating state by modifying draft', () => {
-    const controllerMessenger = new ControllerMessenger<
-      never,
-      CountControllerEvent
-    >();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted({
-      name: 'CountController',
-      allowedEvents: ['CountController:stateChange'],
-    });
     const controller = new CountController({
-      messenger: restrictedControllerMessenger,
+      messenger: getCountMessenger(),
       name: 'CountController',
       state: { count: 0 },
       metadata: countControllerStateMetadata,
@@ -130,16 +129,8 @@ describe('BaseController', () => {
   });
 
   it('should allow updating state by return a value', () => {
-    const controllerMessenger = new ControllerMessenger<
-      never,
-      CountControllerEvent
-    >();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted({
-      name: 'CountController',
-      allowedEvents: ['CountController:stateChange'],
-    });
     const controller = new CountController({
-      messenger: restrictedControllerMessenger,
+      messenger: getCountMessenger(),
       name: 'CountController',
       state: { count: 0 },
       metadata: countControllerStateMetadata,
@@ -153,16 +144,8 @@ describe('BaseController', () => {
   });
 
   it('should throw an error if update callback modifies draft and returns value', () => {
-    const controllerMessenger = new ControllerMessenger<
-      never,
-      CountControllerEvent
-    >();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted({
-      name: 'CountController',
-      allowedEvents: ['CountController:stateChange'],
-    });
     const controller = new CountController({
-      messenger: restrictedControllerMessenger,
+      messenger: getCountMessenger(),
       name: 'CountController',
       state: { count: 0 },
       metadata: countControllerStateMetadata,
@@ -183,12 +166,8 @@ describe('BaseController', () => {
       never,
       CountControllerEvent
     >();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted({
-      name: 'CountController',
-      allowedEvents: ['CountController:stateChange'],
-    });
     const controller = new CountController({
-      messenger: restrictedControllerMessenger,
+      messenger: getCountMessenger(controllerMessenger),
       name: 'CountController',
       state: { count: 0 },
       metadata: countControllerStateMetadata,
@@ -219,12 +198,8 @@ describe('BaseController', () => {
       never,
       CountControllerEvent
     >();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted({
-      name: 'CountController',
-      allowedEvents: ['CountController:stateChange'],
-    });
     const controller = new CountController({
-      messenger: restrictedControllerMessenger,
+      messenger: getCountMessenger(controllerMessenger),
       name: 'CountController',
       state: { count: 0 },
       metadata: countControllerStateMetadata,
@@ -250,12 +225,8 @@ describe('BaseController', () => {
       never,
       CountControllerEvent
     >();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted({
-      name: 'CountController',
-      allowedEvents: ['CountController:stateChange'],
-    });
     const controller = new CountController({
-      messenger: restrictedControllerMessenger,
+      messenger: getCountMessenger(controllerMessenger),
       name: 'CountController',
       state: { count: 0 },
       metadata: countControllerStateMetadata,
@@ -276,12 +247,8 @@ describe('BaseController', () => {
       never,
       CountControllerEvent
     >();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted({
-      name: 'CountController',
-      allowedEvents: ['CountController:stateChange'],
-    });
     const controller = new CountController({
-      messenger: restrictedControllerMessenger,
+      messenger: getCountMessenger(controllerMessenger),
       name: 'CountController',
       state: { count: 0 },
       metadata: countControllerStateMetadata,
@@ -303,12 +270,8 @@ describe('BaseController', () => {
       never,
       CountControllerEvent
     >();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted({
-      name: 'CountController',
-      allowedEvents: ['CountController:stateChange'],
-    });
     new CountController({
-      messenger: restrictedControllerMessenger,
+      messenger: getCountMessenger(controllerMessenger),
       name: 'CountController',
       state: { count: 0 },
       metadata: countControllerStateMetadata,
@@ -327,12 +290,8 @@ describe('BaseController', () => {
       never,
       CountControllerEvent
     >();
-    const restrictedControllerMessenger = controllerMessenger.getRestricted({
-      name: 'CountController',
-      allowedEvents: ['CountController:stateChange'],
-    });
     const controller = new CountController({
-      messenger: restrictedControllerMessenger,
+      messenger: getCountMessenger(controllerMessenger),
       name: 'CountController',
       state: { count: 0 },
       metadata: countControllerStateMetadata,
@@ -649,15 +608,17 @@ describe('getPersistentState', () => {
     // The 'VisitorOverflowController' monitors the 'VisitorController' to ensure the number of
     // visitors doesn't exceed the maximum capacity. If it does, it will clear out all visitors.
 
+    const visitorName = 'VisitorController';
+
     type VisitorControllerState = {
       visitors: string[];
     };
     type VisitorControllerAction = {
-      type: `VisitorController:clear`;
+      type: `${typeof visitorName}:clear`;
       handler: () => void;
     };
     type VisitorControllerEvent = {
-      type: `VisitorController:stateChange`;
+      type: `${typeof visitorName}:stateChange`;
       payload: [VisitorControllerState, Patch[]];
     };
 
@@ -668,23 +629,22 @@ describe('getPersistentState', () => {
       },
     };
 
+    type VisitorMessenger = RestrictedControllerMessenger<
+      typeof visitorName,
+      VisitorControllerAction | VisitorOverflowControllerAction,
+      VisitorControllerEvent | VisitorOverflowControllerEvent,
+      never,
+      never
+    >;
     class VisitorController extends BaseController<
-      'VisitorController',
+      typeof visitorName,
       VisitorControllerState
     > {
-      constructor(
-        messagingSystem: RestrictedControllerMessenger<
-          'VisitorController',
-          VisitorControllerAction | VisitorOverflowControllerAction,
-          VisitorControllerEvent | VisitorOverflowControllerEvent,
-          never,
-          never
-        >,
-      ) {
+      constructor(messagingSystem: VisitorMessenger) {
         super({
           messenger: messagingSystem,
           metadata: visitorControllerStateMetadata,
-          name: 'VisitorController',
+          name: visitorName,
           state: { visitors: [] },
         });
         messagingSystem.registerActionHandler(
@@ -710,15 +670,17 @@ describe('getPersistentState', () => {
       }
     }
 
+    const visitorOverflowName = 'VisitorOverflowController';
+
     type VisitorOverflowControllerState = {
       maxVisitors: number;
     };
     type VisitorOverflowControllerAction = {
-      type: `VisitorOverflowController:updateMax`;
+      type: `${typeof visitorOverflowName}:updateMax`;
       handler: (max: number) => void;
     };
     type VisitorOverflowControllerEvent = {
-      type: `VisitorOverflowController:stateChange`;
+      type: `${typeof visitorOverflowName}:stateChange`;
       payload: [VisitorOverflowControllerState, Patch[]];
     };
 
@@ -729,23 +691,23 @@ describe('getPersistentState', () => {
       },
     };
 
+    type VisitorOverflowMessenger = RestrictedControllerMessenger<
+      typeof visitorOverflowName,
+      VisitorControllerAction | VisitorOverflowControllerAction,
+      VisitorControllerEvent | VisitorOverflowControllerEvent,
+      `${typeof visitorName}:clear`,
+      `${typeof visitorName}:stateChange`
+    >;
+
     class VisitorOverflowController extends BaseController<
-      'VisitorOverflowController',
+      typeof visitorOverflowName,
       VisitorOverflowControllerState
     > {
-      constructor(
-        messagingSystem: RestrictedControllerMessenger<
-          'VisitorOverflowController',
-          VisitorControllerAction | VisitorOverflowControllerAction,
-          VisitorControllerEvent | VisitorOverflowControllerEvent,
-          'VisitorController:clear',
-          'VisitorController:stateChange'
-        >,
-      ) {
+      constructor(messagingSystem: VisitorOverflowMessenger) {
         super({
           messenger: messagingSystem,
           metadata: visitorOverflowControllerMetadata,
-          name: 'VisitorOverflowController',
+          name: visitorOverflowName,
           state: { maxVisitors: 5 },
         });
         messagingSystem.registerActionHandler(
@@ -781,18 +743,18 @@ describe('getPersistentState', () => {
         VisitorControllerEvent | VisitorOverflowControllerEvent
       >();
       const visitorControllerMessenger = controllerMessenger.getRestricted<
-        'VisitorController',
+        typeof visitorName,
         never,
         never
       >({
-        name: 'VisitorController',
+        name: visitorName,
       });
       const visitorController = new VisitorController(
         visitorControllerMessenger,
       );
       const visitorOverflowControllerMessenger = controllerMessenger.getRestricted(
         {
-          name: 'VisitorOverflowController',
+          name: visitorOverflowName,
           allowedActions: ['VisitorController:clear'],
           allowedEvents: ['VisitorController:stateChange'],
         },


### PR DESCRIPTION
The unit tests for BaseControllerV2 have been updated to be more concise and (hopefully) slightly easier to read. The restricted controller setup was moved to a helper function, and common elements of various types were extracted and re-used.

There were a few cases where I could have used the controller name variable in a string literal, but chose not to (for example, the `allowedActions` string literals). This is because of the poor state of type inference right now for string literal types in TypeScript. They would get inferred as type `string` each time, which resulted in a type error. The only way to get it to work was to follow it with `as '[the string literal type]', which is strictly worse than just using the string literal in the first place. There are some improvements planned here in TypeScript v4.3 though, so maybe we'll get to to deduplicate the controller name in more places soon!