### PR TITLE
Enable jest/no-conditional-expect

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,8 +15,7 @@ module.exports = {
       files: ['*.test.ts', '*.test.js'],
       extends: ['@metamask/eslint-config-jest'],
       rules: {
-        // TODO: Re-enable most of these rules
-        'jest/no-conditional-expect': 'off',
+        // TODO: Re-enable these rules
         'jest/no-restricted-matchers': [
           'error',
           {

--- a/src/message-manager/AbstractMessageManager.test.ts
+++ b/src/message-manager/AbstractMessageManager.test.ts
@@ -68,7 +68,9 @@ describe('AbstractTestManager', () => {
       type: messageType,
     });
     const message = controller.getMessage(messageId);
-    expect(message).not.toBeUndefined();
+    if (!message) {
+      throw new Error('"message" is undefined');
+    }
     expect(message.id).toBe(messageId);
     expect(message.messageParams.from).toBe(from);
     expect(message.messageParams.data).toBe(messageData);
@@ -91,7 +93,9 @@ describe('AbstractTestManager', () => {
     });
     controller.rejectMessage(messageId);
     const message = controller.getMessage(messageId);
-    expect(message).not.toBeUndefined();
+    if (!message) {
+      throw new Error('"message" is undefined');
+    }
     expect(message.status).toBe('rejected');
   });
 
@@ -109,7 +113,9 @@ describe('AbstractTestManager', () => {
     });
     controller.setMessageStatusSigned(messageId, 'rawSig');
     const message = controller.getMessage(messageId);
-    expect(message).not.toBeUndefined();
+    if (!message) {
+      throw new Error('"message" is undefined');
+    }
     expect(message.status).toBe('signed');
     expect(message.rawSig).toBe('rawSig');
   });
@@ -181,7 +187,9 @@ describe('AbstractTestManager', () => {
     });
     const message = controller.getMessage(messageId);
     expect(messageParams).toStrictEqual(firstMessage);
-    expect(message).not.toBeUndefined();
+    if (!message) {
+      throw new Error('"message" is undefined');
+    }
     expect(message.status).toStrictEqual('approved');
   });
 

--- a/src/message-manager/AbstractMessageManager.test.ts
+++ b/src/message-manager/AbstractMessageManager.test.ts
@@ -69,7 +69,7 @@ describe('AbstractTestManager', () => {
     });
     const message = controller.getMessage(messageId);
     if (!message) {
-      throw new Error('"message" is undefined');
+      throw new Error('"message" is falsy');
     }
     expect(message.id).toBe(messageId);
     expect(message.messageParams.from).toBe(from);
@@ -94,7 +94,7 @@ describe('AbstractTestManager', () => {
     controller.rejectMessage(messageId);
     const message = controller.getMessage(messageId);
     if (!message) {
-      throw new Error('"message" is undefined');
+      throw new Error('"message" is falsy');
     }
     expect(message.status).toBe('rejected');
   });
@@ -114,7 +114,7 @@ describe('AbstractTestManager', () => {
     controller.setMessageStatusSigned(messageId, 'rawSig');
     const message = controller.getMessage(messageId);
     if (!message) {
-      throw new Error('"message" is undefined');
+      throw new Error('"message" is falsy');
     }
     expect(message.status).toBe('signed');
     expect(message.rawSig).toBe('rawSig');
@@ -188,7 +188,7 @@ describe('AbstractTestManager', () => {
     const message = controller.getMessage(messageId);
     expect(messageParams).toStrictEqual(firstMessage);
     if (!message) {
-      throw new Error('"message" is undefined');
+      throw new Error('"message" is falsy');
     }
     expect(message.status).toStrictEqual('approved');
   });

--- a/src/message-manager/AbstractMessageManager.test.ts
+++ b/src/message-manager/AbstractMessageManager.test.ts
@@ -69,14 +69,12 @@ describe('AbstractTestManager', () => {
     });
     const message = controller.getMessage(messageId);
     expect(message).not.toBeUndefined();
-    if (message) {
-      expect(message.id).toBe(messageId);
-      expect(message.messageParams.from).toBe(from);
-      expect(message.messageParams.data).toBe(messageData);
-      expect(message.time).toBe(messageTime);
-      expect(message.status).toBe(messageStatus);
-      expect(message.type).toBe(messageType);
-    }
+    expect(message.id).toBe(messageId);
+    expect(message.messageParams.from).toBe(from);
+    expect(message.messageParams.data).toBe(messageData);
+    expect(message.time).toBe(messageTime);
+    expect(message.status).toBe(messageStatus);
+    expect(message.type).toBe(messageType);
   });
 
   it('should reject a message', () => {
@@ -94,9 +92,7 @@ describe('AbstractTestManager', () => {
     controller.rejectMessage(messageId);
     const message = controller.getMessage(messageId);
     expect(message).not.toBeUndefined();
-    if (message) {
-      expect(message.status).toBe('rejected');
-    }
+    expect(message.status).toBe('rejected');
   });
 
   it('should sign a message', () => {
@@ -114,10 +110,8 @@ describe('AbstractTestManager', () => {
     controller.setMessageStatusSigned(messageId, 'rawSig');
     const message = controller.getMessage(messageId);
     expect(message).not.toBeUndefined();
-    if (message) {
-      expect(message.status).toBe('signed');
-      expect(message.rawSig).toBe('rawSig');
-    }
+    expect(message.status).toBe('signed');
+    expect(message.rawSig).toBe('rawSig');
   });
 
   it('should get correct unapproved messages', () => {
@@ -188,9 +182,7 @@ describe('AbstractTestManager', () => {
     const message = controller.getMessage(messageId);
     expect(messageParams).toStrictEqual(firstMessage);
     expect(message).not.toBeUndefined();
-    if (message) {
-      expect(message.status).toStrictEqual('approved');
-    }
+    expect(message.status).toStrictEqual('approved');
   });
 
   describe('setMessageStatus', () => {

--- a/src/message-manager/MessageManager.test.ts
+++ b/src/message-manager/MessageManager.test.ts
@@ -33,7 +33,9 @@ describe('PersonalMessageManager', () => {
       type: messageType,
     });
     const message = controller.getMessage(messageId);
-    expect(message).not.toBeUndefined();
+    if (!message) {
+      throw new Error('"message" is undefined');
+    }
     expect(message.id).toBe(messageId);
     expect(message.messageParams.from).toBe(from);
     expect(message.messageParams.data).toBe(messageData);
@@ -109,6 +111,9 @@ describe('PersonalMessageManager', () => {
     );
     expect(messageId).not.toBeUndefined();
     const message = controller.getMessage(messageId);
+    if (!message) {
+      throw new Error('"message" is undefined');
+    }
     expect(message.messageParams.from).toBe(messageParams.from);
     expect(message.messageParams.data).toBe(messageParams.data);
     expect(message.time).not.toBeUndefined();
@@ -163,7 +168,9 @@ describe('PersonalMessageManager', () => {
     });
     const message = controller.getMessage(messageId);
     expect(messageParams).toStrictEqual(firstMessage);
-    expect(message).not.toBeUndefined();
+    if (!message) {
+      throw new Error('"message" is undefined');
+    }
     expect(message.status).toStrictEqual('approved');
   });
 
@@ -175,7 +182,9 @@ describe('PersonalMessageManager', () => {
 
     controller.setMessageStatusSigned(messageId, rawSig);
     const message = controller.getMessage(messageId);
-    expect(message).not.toBeUndefined();
+    if (!message) {
+      throw new Error('"message" is undefined');
+    }
     expect(message.rawSig).toStrictEqual(rawSig);
     expect(message.status).toStrictEqual('signed');
   });
@@ -186,7 +195,9 @@ describe('PersonalMessageManager', () => {
     const messageId = controller.addUnapprovedMessage(firstMessage);
     controller.rejectMessage(messageId);
     const message = controller.getMessage(messageId);
-    expect(message).not.toBeUndefined();
+    if (!message) {
+      throw new Error('"message" is undefined');
+    }
     expect(message.status).toStrictEqual('rejected');
   });
 });

--- a/src/message-manager/MessageManager.test.ts
+++ b/src/message-manager/MessageManager.test.ts
@@ -34,14 +34,12 @@ describe('PersonalMessageManager', () => {
     });
     const message = controller.getMessage(messageId);
     expect(message).not.toBeUndefined();
-    if (message) {
-      expect(message.id).toBe(messageId);
-      expect(message.messageParams.from).toBe(from);
-      expect(message.messageParams.data).toBe(messageData);
-      expect(message.time).toBe(messageTime);
-      expect(message.status).toBe(messageStatus);
-      expect(message.type).toBe(messageType);
-    }
+    expect(message.id).toBe(messageId);
+    expect(message.messageParams.from).toBe(from);
+    expect(message.messageParams.data).toBe(messageData);
+    expect(message.time).toBe(messageTime);
+    expect(message.status).toBe(messageStatus);
+    expect(message.type).toBe(messageType);
   });
 
   it('should reject a message', async () => {
@@ -111,13 +109,11 @@ describe('PersonalMessageManager', () => {
     );
     expect(messageId).not.toBeUndefined();
     const message = controller.getMessage(messageId);
-    if (message) {
-      expect(message.messageParams.from).toBe(messageParams.from);
-      expect(message.messageParams.data).toBe(messageParams.data);
-      expect(message.time).not.toBeUndefined();
-      expect(message.status).toBe(messageStatus);
-      expect(message.type).toBe(messageType);
-    }
+    expect(message.messageParams.from).toBe(messageParams.from);
+    expect(message.messageParams.data).toBe(messageParams.data);
+    expect(message.time).not.toBeUndefined();
+    expect(message.status).toBe(messageStatus);
+    expect(message.type).toBe(messageType);
   });
 
   it('should throw when adding invalid message', async () => {
@@ -168,9 +164,7 @@ describe('PersonalMessageManager', () => {
     const message = controller.getMessage(messageId);
     expect(messageParams).toStrictEqual(firstMessage);
     expect(message).not.toBeUndefined();
-    if (message) {
-      expect(message.status).toStrictEqual('approved');
-    }
+    expect(message.status).toStrictEqual('approved');
   });
 
   it('should set message status signed', () => {
@@ -182,10 +176,8 @@ describe('PersonalMessageManager', () => {
     controller.setMessageStatusSigned(messageId, rawSig);
     const message = controller.getMessage(messageId);
     expect(message).not.toBeUndefined();
-    if (message) {
-      expect(message.rawSig).toStrictEqual(rawSig);
-      expect(message.status).toStrictEqual('signed');
-    }
+    expect(message.rawSig).toStrictEqual(rawSig);
+    expect(message.status).toStrictEqual('signed');
   });
 
   it('should reject message', () => {
@@ -195,8 +187,6 @@ describe('PersonalMessageManager', () => {
     controller.rejectMessage(messageId);
     const message = controller.getMessage(messageId);
     expect(message).not.toBeUndefined();
-    if (message) {
-      expect(message.status).toStrictEqual('rejected');
-    }
+    expect(message.status).toStrictEqual('rejected');
   });
 });

--- a/src/message-manager/MessageManager.test.ts
+++ b/src/message-manager/MessageManager.test.ts
@@ -34,7 +34,7 @@ describe('PersonalMessageManager', () => {
     });
     const message = controller.getMessage(messageId);
     if (!message) {
-      throw new Error('"message" is undefined');
+      throw new Error('"message" is falsy');
     }
     expect(message.id).toBe(messageId);
     expect(message.messageParams.from).toBe(from);
@@ -112,7 +112,7 @@ describe('PersonalMessageManager', () => {
     expect(messageId).not.toBeUndefined();
     const message = controller.getMessage(messageId);
     if (!message) {
-      throw new Error('"message" is undefined');
+      throw new Error('"message" is falsy');
     }
     expect(message.messageParams.from).toBe(messageParams.from);
     expect(message.messageParams.data).toBe(messageParams.data);
@@ -169,7 +169,7 @@ describe('PersonalMessageManager', () => {
     const message = controller.getMessage(messageId);
     expect(messageParams).toStrictEqual(firstMessage);
     if (!message) {
-      throw new Error('"message" is undefined');
+      throw new Error('"message" is falsy');
     }
     expect(message.status).toStrictEqual('approved');
   });
@@ -183,7 +183,7 @@ describe('PersonalMessageManager', () => {
     controller.setMessageStatusSigned(messageId, rawSig);
     const message = controller.getMessage(messageId);
     if (!message) {
-      throw new Error('"message" is undefined');
+      throw new Error('"message" is falsy');
     }
     expect(message.rawSig).toStrictEqual(rawSig);
     expect(message.status).toStrictEqual('signed');
@@ -196,7 +196,7 @@ describe('PersonalMessageManager', () => {
     controller.rejectMessage(messageId);
     const message = controller.getMessage(messageId);
     if (!message) {
-      throw new Error('"message" is undefined');
+      throw new Error('"message" is falsy');
     }
     expect(message.status).toStrictEqual('rejected');
   });

--- a/src/message-manager/PersonalMessageManager.test.ts
+++ b/src/message-manager/PersonalMessageManager.test.ts
@@ -33,7 +33,9 @@ describe('PersonalMessageManager', () => {
       type: messageType,
     });
     const message = controller.getMessage(messageId);
-    expect(message).not.toBeUndefined();
+    if (!message) {
+      throw new Error('"message" is undefined');
+    }
     expect(message.id).toBe(messageId);
     expect(message.messageParams.from).toBe(from);
     expect(message.messageParams.data).toBe(messageData);
@@ -109,6 +111,9 @@ describe('PersonalMessageManager', () => {
     );
     expect(messageId).not.toBeUndefined();
     const message = controller.getMessage(messageId);
+    if (!message) {
+      throw new Error('"message" is undefined');
+    }
     expect(message.messageParams.from).toBe(messageParams.from);
     expect(message.messageParams.data).toBe(messageParams.data);
     expect(message.time).not.toBeUndefined();
@@ -163,7 +168,9 @@ describe('PersonalMessageManager', () => {
     });
     const message = controller.getMessage(messageId);
     expect(messageParams).toStrictEqual(firstMessage);
-    expect(message).not.toBeUndefined();
+    if (!message) {
+      throw new Error('"message" is undefined');
+    }
     expect(message.status).toStrictEqual('approved');
   });
 
@@ -175,7 +182,9 @@ describe('PersonalMessageManager', () => {
 
     controller.setMessageStatusSigned(messageId, rawSig);
     const message = controller.getMessage(messageId);
-    expect(message).not.toBeUndefined();
+    if (!message) {
+      throw new Error('"message" is undefined');
+    }
     expect(message.rawSig).toStrictEqual(rawSig);
     expect(message.status).toStrictEqual('signed');
   });
@@ -186,7 +195,9 @@ describe('PersonalMessageManager', () => {
     const messageId = controller.addUnapprovedMessage(firstMessage);
     controller.rejectMessage(messageId);
     const message = controller.getMessage(messageId);
-    expect(message).not.toBeUndefined();
+    if (!message) {
+      throw new Error('"message" is undefined');
+    }
     expect(message.status).toStrictEqual('rejected');
   });
 });

--- a/src/message-manager/PersonalMessageManager.test.ts
+++ b/src/message-manager/PersonalMessageManager.test.ts
@@ -34,14 +34,12 @@ describe('PersonalMessageManager', () => {
     });
     const message = controller.getMessage(messageId);
     expect(message).not.toBeUndefined();
-    if (message) {
-      expect(message.id).toBe(messageId);
-      expect(message.messageParams.from).toBe(from);
-      expect(message.messageParams.data).toBe(messageData);
-      expect(message.time).toBe(messageTime);
-      expect(message.status).toBe(messageStatus);
-      expect(message.type).toBe(messageType);
-    }
+    expect(message.id).toBe(messageId);
+    expect(message.messageParams.from).toBe(from);
+    expect(message.messageParams.data).toBe(messageData);
+    expect(message.time).toBe(messageTime);
+    expect(message.status).toBe(messageStatus);
+    expect(message.type).toBe(messageType);
   });
 
   it('should reject a message', async () => {
@@ -111,13 +109,11 @@ describe('PersonalMessageManager', () => {
     );
     expect(messageId).not.toBeUndefined();
     const message = controller.getMessage(messageId);
-    if (message) {
-      expect(message.messageParams.from).toBe(messageParams.from);
-      expect(message.messageParams.data).toBe(messageParams.data);
-      expect(message.time).not.toBeUndefined();
-      expect(message.status).toBe(messageStatus);
-      expect(message.type).toBe(messageType);
-    }
+    expect(message.messageParams.from).toBe(messageParams.from);
+    expect(message.messageParams.data).toBe(messageParams.data);
+    expect(message.time).not.toBeUndefined();
+    expect(message.status).toBe(messageStatus);
+    expect(message.type).toBe(messageType);
   });
 
   it('should throw when adding invalid message', async () => {
@@ -168,9 +164,7 @@ describe('PersonalMessageManager', () => {
     const message = controller.getMessage(messageId);
     expect(messageParams).toStrictEqual(firstMessage);
     expect(message).not.toBeUndefined();
-    if (message) {
-      expect(message.status).toStrictEqual('approved');
-    }
+    expect(message.status).toStrictEqual('approved');
   });
 
   it('should set message status signed', () => {
@@ -182,10 +176,8 @@ describe('PersonalMessageManager', () => {
     controller.setMessageStatusSigned(messageId, rawSig);
     const message = controller.getMessage(messageId);
     expect(message).not.toBeUndefined();
-    if (message) {
-      expect(message.rawSig).toStrictEqual(rawSig);
-      expect(message.status).toStrictEqual('signed');
-    }
+    expect(message.rawSig).toStrictEqual(rawSig);
+    expect(message.status).toStrictEqual('signed');
   });
 
   it('should reject message', () => {
@@ -195,8 +187,6 @@ describe('PersonalMessageManager', () => {
     controller.rejectMessage(messageId);
     const message = controller.getMessage(messageId);
     expect(message).not.toBeUndefined();
-    if (message) {
-      expect(message.status).toStrictEqual('rejected');
-    }
+    expect(message.status).toStrictEqual('rejected');
   });
 });

--- a/src/message-manager/PersonalMessageManager.test.ts
+++ b/src/message-manager/PersonalMessageManager.test.ts
@@ -34,7 +34,7 @@ describe('PersonalMessageManager', () => {
     });
     const message = controller.getMessage(messageId);
     if (!message) {
-      throw new Error('"message" is undefined');
+      throw new Error('"message" is falsy');
     }
     expect(message.id).toBe(messageId);
     expect(message.messageParams.from).toBe(from);
@@ -112,7 +112,7 @@ describe('PersonalMessageManager', () => {
     expect(messageId).not.toBeUndefined();
     const message = controller.getMessage(messageId);
     if (!message) {
-      throw new Error('"message" is undefined');
+      throw new Error('"message" is falsy');
     }
     expect(message.messageParams.from).toBe(messageParams.from);
     expect(message.messageParams.data).toBe(messageParams.data);
@@ -169,7 +169,7 @@ describe('PersonalMessageManager', () => {
     const message = controller.getMessage(messageId);
     expect(messageParams).toStrictEqual(firstMessage);
     if (!message) {
-      throw new Error('"message" is undefined');
+      throw new Error('"message" is falsy');
     }
     expect(message.status).toStrictEqual('approved');
   });
@@ -183,7 +183,7 @@ describe('PersonalMessageManager', () => {
     controller.setMessageStatusSigned(messageId, rawSig);
     const message = controller.getMessage(messageId);
     if (!message) {
-      throw new Error('"message" is undefined');
+      throw new Error('"message" is falsy');
     }
     expect(message.rawSig).toStrictEqual(rawSig);
     expect(message.status).toStrictEqual('signed');
@@ -196,7 +196,7 @@ describe('PersonalMessageManager', () => {
     controller.rejectMessage(messageId);
     const message = controller.getMessage(messageId);
     if (!message) {
-      throw new Error('"message" is undefined');
+      throw new Error('"message" is falsy');
     }
     expect(message.status).toStrictEqual('rejected');
   });

--- a/src/message-manager/TypedMessageManager.test.ts
+++ b/src/message-manager/TypedMessageManager.test.ts
@@ -45,7 +45,9 @@ describe('TypedMessageManager', () => {
       type: messageType,
     });
     const message = controller.getMessage(messageId);
-    expect(message).not.toBeUndefined();
+    if (!message) {
+      throw new Error('"message" is undefined');
+    }
     expect(message.id).toBe(messageId);
     expect(message.messageParams.from).toBe(from);
     expect(message.messageParams.data).toBe(messageData);
@@ -160,6 +162,9 @@ describe('TypedMessageManager', () => {
     );
     expect(messageId).not.toBeUndefined();
     const message = controller.getMessage(messageId);
+    if (!message) {
+      throw new Error('"message" is undefined');
+    }
     expect(message.messageParams.from).toBe(messageParams.from);
     expect(message.messageParams.data).toBe(messageParams.data);
     expect(message.time).not.toBeUndefined();
@@ -261,7 +266,9 @@ describe('TypedMessageManager', () => {
     });
     const message = controller.getMessage(messageId);
     expect(messageParams).toStrictEqual(firstMessage);
-    expect(message).not.toBeUndefined();
+    if (!message) {
+      throw new Error('"message" is undefined');
+    }
     expect(message.status).toStrictEqual('approved');
   });
 
@@ -274,7 +281,9 @@ describe('TypedMessageManager', () => {
     const messageId = controller.addUnapprovedMessage(firstMessage, version);
     controller.setMessageStatusSigned(messageId, rawSig);
     const message = controller.getMessage(messageId);
-    expect(message).not.toBeUndefined();
+    if (!message) {
+      throw new Error('"message" is undefined');
+    }
     expect(message.rawSig).toStrictEqual(rawSig);
     expect(message.status).toStrictEqual('signed');
   });
@@ -287,7 +296,9 @@ describe('TypedMessageManager', () => {
     const messageId = controller.addUnapprovedMessage(firstMessage, version);
     controller.rejectMessage(messageId);
     const message = controller.getMessage(messageId);
-    expect(message).not.toBeUndefined();
+    if (!message) {
+      throw new Error('"message" is undefined');
+    }
     expect(message.status).toStrictEqual('rejected');
   });
 
@@ -299,7 +310,9 @@ describe('TypedMessageManager', () => {
     const messageId = controller.addUnapprovedMessage(firstMessage, version);
     controller.setMessageStatusErrored(messageId, 'errored');
     const message = controller.getMessage(messageId);
-    expect(message).not.toBeUndefined();
+    if (!message) {
+      throw new Error('"message" is undefined');
+    }
     expect(message.status).toStrictEqual('errored');
   });
 });

--- a/src/message-manager/TypedMessageManager.test.ts
+++ b/src/message-manager/TypedMessageManager.test.ts
@@ -46,7 +46,7 @@ describe('TypedMessageManager', () => {
     });
     const message = controller.getMessage(messageId);
     if (!message) {
-      throw new Error('"message" is undefined');
+      throw new Error('"message" is falsy');
     }
     expect(message.id).toBe(messageId);
     expect(message.messageParams.from).toBe(from);
@@ -163,7 +163,7 @@ describe('TypedMessageManager', () => {
     expect(messageId).not.toBeUndefined();
     const message = controller.getMessage(messageId);
     if (!message) {
-      throw new Error('"message" is undefined');
+      throw new Error('"message" is falsy');
     }
     expect(message.messageParams.from).toBe(messageParams.from);
     expect(message.messageParams.data).toBe(messageParams.data);
@@ -267,7 +267,7 @@ describe('TypedMessageManager', () => {
     const message = controller.getMessage(messageId);
     expect(messageParams).toStrictEqual(firstMessage);
     if (!message) {
-      throw new Error('"message" is undefined');
+      throw new Error('"message" is falsy');
     }
     expect(message.status).toStrictEqual('approved');
   });
@@ -282,7 +282,7 @@ describe('TypedMessageManager', () => {
     controller.setMessageStatusSigned(messageId, rawSig);
     const message = controller.getMessage(messageId);
     if (!message) {
-      throw new Error('"message" is undefined');
+      throw new Error('"message" is falsy');
     }
     expect(message.rawSig).toStrictEqual(rawSig);
     expect(message.status).toStrictEqual('signed');
@@ -297,7 +297,7 @@ describe('TypedMessageManager', () => {
     controller.rejectMessage(messageId);
     const message = controller.getMessage(messageId);
     if (!message) {
-      throw new Error('"message" is undefined');
+      throw new Error('"message" is falsy');
     }
     expect(message.status).toStrictEqual('rejected');
   });
@@ -311,7 +311,7 @@ describe('TypedMessageManager', () => {
     controller.setMessageStatusErrored(messageId, 'errored');
     const message = controller.getMessage(messageId);
     if (!message) {
-      throw new Error('"message" is undefined');
+      throw new Error('"message" is falsy');
     }
     expect(message.status).toStrictEqual('errored');
   });

--- a/src/message-manager/TypedMessageManager.test.ts
+++ b/src/message-manager/TypedMessageManager.test.ts
@@ -46,14 +46,12 @@ describe('TypedMessageManager', () => {
     });
     const message = controller.getMessage(messageId);
     expect(message).not.toBeUndefined();
-    if (message) {
-      expect(message.id).toBe(messageId);
-      expect(message.messageParams.from).toBe(from);
-      expect(message.messageParams.data).toBe(messageData);
-      expect(message.time).toBe(messageTime);
-      expect(message.status).toBe(messageStatus);
-      expect(message.type).toBe(messageType);
-    }
+    expect(message.id).toBe(messageId);
+    expect(message.messageParams.from).toBe(from);
+    expect(message.messageParams.data).toBe(messageData);
+    expect(message.time).toBe(messageTime);
+    expect(message.status).toBe(messageStatus);
+    expect(message.type).toBe(messageType);
   });
 
   it('should reject a message', async () => {
@@ -162,13 +160,11 @@ describe('TypedMessageManager', () => {
     );
     expect(messageId).not.toBeUndefined();
     const message = controller.getMessage(messageId);
-    if (message) {
-      expect(message.messageParams.from).toBe(messageParams.from);
-      expect(message.messageParams.data).toBe(messageParams.data);
-      expect(message.time).not.toBeUndefined();
-      expect(message.status).toBe(messageStatus);
-      expect(message.type).toBe(messageType);
-    }
+    expect(message.messageParams.from).toBe(messageParams.from);
+    expect(message.messageParams.data).toBe(messageParams.data);
+    expect(message.time).not.toBeUndefined();
+    expect(message.status).toBe(messageStatus);
+    expect(message.type).toBe(messageType);
   });
 
   it('should throw when adding invalid legacy typed message', async () => {
@@ -266,9 +262,7 @@ describe('TypedMessageManager', () => {
     const message = controller.getMessage(messageId);
     expect(messageParams).toStrictEqual(firstMessage);
     expect(message).not.toBeUndefined();
-    if (message) {
-      expect(message.status).toStrictEqual('approved');
-    }
+    expect(message.status).toStrictEqual('approved');
   });
 
   it('should set message status signed', () => {
@@ -281,10 +275,8 @@ describe('TypedMessageManager', () => {
     controller.setMessageStatusSigned(messageId, rawSig);
     const message = controller.getMessage(messageId);
     expect(message).not.toBeUndefined();
-    if (message) {
-      expect(message.rawSig).toStrictEqual(rawSig);
-      expect(message.status).toStrictEqual('signed');
-    }
+    expect(message.rawSig).toStrictEqual(rawSig);
+    expect(message.status).toStrictEqual('signed');
   });
 
   it('should reject message', () => {
@@ -296,9 +288,7 @@ describe('TypedMessageManager', () => {
     controller.rejectMessage(messageId);
     const message = controller.getMessage(messageId);
     expect(message).not.toBeUndefined();
-    if (message) {
-      expect(message.status).toStrictEqual('rejected');
-    }
+    expect(message.status).toStrictEqual('rejected');
   });
 
   it('should set message status errored', () => {
@@ -310,8 +300,6 @@ describe('TypedMessageManager', () => {
     controller.setMessageStatusErrored(messageId, 'errored');
     const message = controller.getMessage(messageId);
     expect(message).not.toBeUndefined();
-    if (message) {
-      expect(message.status).toStrictEqual('errored');
-    }
+    expect(message.status).toStrictEqual('errored');
   });
 });


### PR DESCRIPTION
Following the closure of #423, this PR enables `jest/no-conditional-expect` and fixes all related errors.

I had to add manual type guards in some places per @Gudahtt's suggestion, since TypeScript does not understand that `expect(value).not.toBeUndefined()` guarantees that `value` is not undefined.