### PR TITLE
Enable jest/no-test-return-statement

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,6 @@ module.exports = {
             // 'toBeTruthy': 'Avoid `toBeTruthy`',
           },
         ],
-        'jest/no-test-return-statement': 'off',
       },
     },
     {


### PR DESCRIPTION
Enables `jest/no-test-return-statement`. There were no violations of this rule.