### PR TITLE
Remove restricted matchers exceptions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,20 +15,8 @@ module.exports = {
       files: ['*.test.ts', '*.test.js'],
       extends: ['@metamask/eslint-config-jest'],
       rules: {
-        // TODO: Re-enable most of these rules
+        // TODO: Re-enable these
         'jest/no-conditional-expect': 'off',
-        'jest/no-restricted-matchers': [
-          'error',
-          {
-            resolves: 'Use `expect(await promise)` instead.',
-            toMatchSnapshot: 'Use `toMatchInlineSnapshot()` instead',
-            toThrowErrorMatchingSnapshot:
-              'Use `toThrowErrorMatchingInlineSnapshot()` instead',
-            // TODO: Re-enable these. Requires lots of manual fixes.
-            // 'toBeFalsy': 'Avoid `toBeFalsy`',
-            // 'toBeTruthy': 'Avoid `toBeTruthy`',
-          },
-        ],
         'jest/no-test-return-statement': 'off',
       },
     },

--- a/src/ControllerMessenger.test.ts
+++ b/src/ControllerMessenger.test.ts
@@ -157,7 +157,7 @@ describe('ControllerMessenger', () => {
     controllerMessenger.subscribe('message', handler);
     controllerMessenger.publish('message', 'hello');
 
-    expect(handler.calledWithExactly('hello')).toBeTruthy();
+    expect(handler.calledWithExactly('hello')).toStrictEqual(true);
     expect(handler.callCount).toStrictEqual(1);
   });
 
@@ -175,9 +175,9 @@ describe('ControllerMessenger', () => {
     controllerMessenger.publish('message', 'hello');
     controllerMessenger.publish('ping');
 
-    expect(messageHandler.calledWithExactly('hello')).toBeTruthy();
+    expect(messageHandler.calledWithExactly('hello')).toStrictEqual(true);
     expect(messageHandler.callCount).toStrictEqual(1);
-    expect(pingHandler.calledWithExactly()).toBeTruthy();
+    expect(pingHandler.calledWithExactly()).toStrictEqual(true);
     expect(pingHandler.callCount).toStrictEqual(1);
   });
 
@@ -189,7 +189,7 @@ describe('ControllerMessenger', () => {
     controllerMessenger.subscribe('ping', handler);
     controllerMessenger.publish('ping');
 
-    expect(handler.calledWithExactly()).toBeTruthy();
+    expect(handler.calledWithExactly()).toStrictEqual(true);
     expect(handler.callCount).toStrictEqual(1);
   });
 
@@ -201,7 +201,7 @@ describe('ControllerMessenger', () => {
     controllerMessenger.subscribe('message', handler);
     controllerMessenger.publish('message', 'hello', 'there');
 
-    expect(handler.calledWithExactly('hello', 'there')).toBeTruthy();
+    expect(handler.calledWithExactly('hello', 'there')).toStrictEqual(true);
     expect(handler.callCount).toStrictEqual(1);
   });
 
@@ -214,7 +214,7 @@ describe('ControllerMessenger', () => {
     controllerMessenger.subscribe('message', handler);
     controllerMessenger.publish('message', 'hello');
 
-    expect(handler.calledWithExactly('hello')).toBeTruthy();
+    expect(handler.calledWithExactly('hello')).toStrictEqual(true);
     expect(handler.callCount).toStrictEqual(1);
   });
 
@@ -228,9 +228,9 @@ describe('ControllerMessenger', () => {
     controllerMessenger.subscribe('message', handler2);
     controllerMessenger.publish('message', 'hello');
 
-    expect(handler1.calledWithExactly('hello')).toBeTruthy();
+    expect(handler1.calledWithExactly('hello')).toStrictEqual(true);
     expect(handler1.callCount).toStrictEqual(1);
-    expect(handler2.calledWithExactly('hello')).toBeTruthy();
+    expect(handler2.calledWithExactly('hello')).toStrictEqual(true);
     expect(handler2.callCount).toStrictEqual(1);
   });
 
@@ -521,7 +521,7 @@ describe('RestrictedControllerMessenger', () => {
     );
     restrictedControllerMessenger.publish('MessageController:message', 'hello');
 
-    expect(handler.calledWithExactly('hello')).toBeTruthy();
+    expect(handler.calledWithExactly('hello')).toStrictEqual(true);
     expect(handler.callCount).toStrictEqual(1);
   });
 
@@ -549,9 +549,9 @@ describe('RestrictedControllerMessenger', () => {
     restrictedControllerMessenger.publish('MessageController:message', 'hello');
     restrictedControllerMessenger.publish('MessageController:ping');
 
-    expect(messageHandler.calledWithExactly('hello')).toBeTruthy();
+    expect(messageHandler.calledWithExactly('hello')).toStrictEqual(true);
     expect(messageHandler.callCount).toStrictEqual(1);
-    expect(pingHandler.calledWithExactly()).toBeTruthy();
+    expect(pingHandler.calledWithExactly()).toStrictEqual(true);
     expect(pingHandler.callCount).toStrictEqual(1);
   });
 
@@ -567,7 +567,7 @@ describe('RestrictedControllerMessenger', () => {
     restrictedControllerMessenger.subscribe('PingController:ping', handler);
     restrictedControllerMessenger.publish('PingController:ping');
 
-    expect(handler.calledWithExactly()).toBeTruthy();
+    expect(handler.calledWithExactly()).toStrictEqual(true);
     expect(handler.callCount).toStrictEqual(1);
   });
 
@@ -593,7 +593,7 @@ describe('RestrictedControllerMessenger', () => {
       'there',
     );
 
-    expect(handler.calledWithExactly('hello', 'there')).toBeTruthy();
+    expect(handler.calledWithExactly('hello', 'there')).toStrictEqual(true);
     expect(handler.callCount).toStrictEqual(1);
   });
 
@@ -619,7 +619,7 @@ describe('RestrictedControllerMessenger', () => {
     );
     restrictedControllerMessenger.publish('MessageController:message', 'hello');
 
-    expect(handler.calledWithExactly('hello')).toBeTruthy();
+    expect(handler.calledWithExactly('hello')).toStrictEqual(true);
     expect(handler.callCount).toStrictEqual(1);
   });
 
@@ -646,9 +646,9 @@ describe('RestrictedControllerMessenger', () => {
     );
     restrictedControllerMessenger.publish('MessageController:message', 'hello');
 
-    expect(handler1.calledWithExactly('hello')).toBeTruthy();
+    expect(handler1.calledWithExactly('hello')).toStrictEqual(true);
     expect(handler1.callCount).toStrictEqual(1);
-    expect(handler2.calledWithExactly('hello')).toBeTruthy();
+    expect(handler2.calledWithExactly('hello')).toStrictEqual(true);
     expect(handler2.callCount).toStrictEqual(1);
   });
 
@@ -819,7 +819,7 @@ describe('RestrictedControllerMessenger', () => {
       'hello',
     );
 
-    expect(handler.calledWithExactly('hello')).toBeTruthy();
+    expect(handler.calledWithExactly('hello')).toStrictEqual(true);
     expect(handler.callCount).toStrictEqual(1);
   });
 

--- a/src/apis/crypto-compare.test.ts
+++ b/src/apis/crypto-compare.test.ts
@@ -67,7 +67,7 @@ describe('CryptoCompare', () => {
 
     const { usdConversionRate } = await fetchExchangeRate('CAD', 'ETH');
 
-    expect(usdConversionRate).toBeFalsy();
+    expect(usdConversionRate).toBeNaN();
   });
 
   it('should return USD conversion rate for USD even when includeUSD is disabled', async () => {

--- a/src/approval/ApprovalController.test.ts
+++ b/src/approval/ApprovalController.test.ts
@@ -45,7 +45,7 @@ describe('approval controller', () => {
       ).not.toThrow();
 
       const id = Object.keys(approvalController.state[STORE_KEY])[0];
-      expect(id && typeof id === 'string').toBeTruthy();
+      expect(id && typeof id === 'string').toStrictEqual(true);
     });
 
     it('adds correctly specified entry with request data', () => {

--- a/src/third-party/EnsController.test.ts
+++ b/src/third-party/EnsController.test.ts
@@ -87,7 +87,7 @@ describe('EnsController', () => {
   it('should not update an ENS entry if the address is the same (valid address) and return false', () => {
     const controller = new EnsController();
     expect(controller.set('1', name1, address1)).toStrictEqual(true);
-    expect(controller.set('1', name1, address1)).toBeFalsy();
+    expect(controller.set('1', name1, address1)).toStrictEqual(false);
     expect(controller.state).toStrictEqual({
       ensEntries: {
         1: {
@@ -104,7 +104,7 @@ describe('EnsController', () => {
   it('should not update an ENS entry if the address is the same (null) and return false', () => {
     const controller = new EnsController();
     expect(controller.set('1', name1, null)).toStrictEqual(true);
-    expect(controller.set('1', name1, null)).toBeFalsy();
+    expect(controller.set('1', name1, null)).toStrictEqual(false);
     expect(controller.state).toStrictEqual({
       ensEntries: {
         1: {
@@ -209,8 +209,8 @@ describe('EnsController', () => {
   it('should return false if an ENS entry was NOT deleted', () => {
     const controller = new EnsController();
     controller.set('1', name1, address1);
-    expect(controller.delete('1', 'bar')).toBeFalsy();
-    expect(controller.delete('2', 'bar')).toBeFalsy();
+    expect(controller.delete('1', 'bar')).toStrictEqual(false);
+    expect(controller.delete('2', 'bar')).toStrictEqual(false);
     expect(controller.state).toStrictEqual({
       ensEntries: {
         1: {

--- a/src/third-party/EnsController.test.ts
+++ b/src/third-party/EnsController.test.ts
@@ -20,7 +20,7 @@ describe('EnsController', () => {
 
   it('should add a new ENS entry and return true', () => {
     const controller = new EnsController();
-    expect(controller.set('1', name1, address1)).toBeTruthy();
+    expect(controller.set('1', name1, address1)).toStrictEqual(true);
     expect(controller.state).toStrictEqual({
       ensEntries: {
         1: {
@@ -36,7 +36,7 @@ describe('EnsController', () => {
 
   it('should add a new ENS entry with null address and return true', () => {
     const controller = new EnsController();
-    expect(controller.set('1', name1, null)).toBeTruthy();
+    expect(controller.set('1', name1, null)).toStrictEqual(true);
     expect(controller.state).toStrictEqual({
       ensEntries: {
         1: {
@@ -52,8 +52,8 @@ describe('EnsController', () => {
 
   it('should update an ENS entry and return true', () => {
     const controller = new EnsController();
-    expect(controller.set('1', name1, address1)).toBeTruthy();
-    expect(controller.set('1', name1, address2)).toBeTruthy();
+    expect(controller.set('1', name1, address1)).toStrictEqual(true);
+    expect(controller.set('1', name1, address2)).toStrictEqual(true);
     expect(controller.state).toStrictEqual({
       ensEntries: {
         1: {
@@ -69,8 +69,8 @@ describe('EnsController', () => {
 
   it('should update an ENS entry with null address and return true', () => {
     const controller = new EnsController();
-    expect(controller.set('1', name1, address1)).toBeTruthy();
-    expect(controller.set('1', name1, null)).toBeTruthy();
+    expect(controller.set('1', name1, address1)).toStrictEqual(true);
+    expect(controller.set('1', name1, null)).toStrictEqual(true);
     expect(controller.state).toStrictEqual({
       ensEntries: {
         1: {
@@ -86,7 +86,7 @@ describe('EnsController', () => {
 
   it('should not update an ENS entry if the address is the same (valid address) and return false', () => {
     const controller = new EnsController();
-    expect(controller.set('1', name1, address1)).toBeTruthy();
+    expect(controller.set('1', name1, address1)).toStrictEqual(true);
     expect(controller.set('1', name1, address1)).toBeFalsy();
     expect(controller.state).toStrictEqual({
       ensEntries: {
@@ -103,7 +103,7 @@ describe('EnsController', () => {
 
   it('should not update an ENS entry if the address is the same (null) and return false', () => {
     const controller = new EnsController();
-    expect(controller.set('1', name1, null)).toBeTruthy();
+    expect(controller.set('1', name1, null)).toStrictEqual(true);
     expect(controller.set('1', name1, null)).toBeFalsy();
     expect(controller.state).toStrictEqual({
       ensEntries: {
@@ -120,10 +120,10 @@ describe('EnsController', () => {
 
   it('should add multiple ENS entries and update without side effects', () => {
     const controller = new EnsController();
-    expect(controller.set('1', name1, address1)).toBeTruthy();
-    expect(controller.set('1', name2, address2)).toBeTruthy();
-    expect(controller.set('2', name1, address1)).toBeTruthy();
-    expect(controller.set('1', name1, address3)).toBeTruthy();
+    expect(controller.set('1', name1, address1)).toStrictEqual(true);
+    expect(controller.set('1', name2, address2)).toStrictEqual(true);
+    expect(controller.set('2', name1, address1)).toStrictEqual(true);
+    expect(controller.set('1', name1, address3)).toStrictEqual(true);
     expect(controller.state).toStrictEqual({
       ensEntries: {
         1: {
@@ -151,7 +151,7 @@ describe('EnsController', () => {
 
   it('should get ENS entry by chainId and ensName', () => {
     const controller = new EnsController();
-    expect(controller.set('1', name1, address1)).toBeTruthy();
+    expect(controller.set('1', name1, address1)).toStrictEqual(true);
     expect(controller.get('1', name1)).toStrictEqual({
       address: address1Checksum,
       chainId: '1',
@@ -161,13 +161,13 @@ describe('EnsController', () => {
 
   it('should return null when getting nonexistent name', () => {
     const controller = new EnsController();
-    expect(controller.set('1', name1, address1)).toBeTruthy();
+    expect(controller.set('1', name1, address1)).toStrictEqual(true);
     expect(controller.get('1', name2)).toBeNull();
   });
 
   it('should return null when getting nonexistent chainId', () => {
     const controller = new EnsController();
-    expect(controller.set('1', name1, address1)).toBeTruthy();
+    expect(controller.set('1', name1, address1)).toStrictEqual(true);
     expect(controller.get('2', name1)).toBeNull();
   });
 
@@ -201,8 +201,8 @@ describe('EnsController', () => {
 
   it('should remove an ENS entry and return true', () => {
     const controller = new EnsController();
-    expect(controller.set('1', name1, address1)).toBeTruthy();
-    expect(controller.delete('1', name1)).toBeTruthy();
+    expect(controller.set('1', name1, address1)).toStrictEqual(true);
+    expect(controller.delete('1', name1)).toStrictEqual(true);
     expect(controller.state).toStrictEqual({ ensEntries: {} });
   });
 
@@ -226,10 +226,10 @@ describe('EnsController', () => {
 
   it('should add multiple ENS entries and remove without side effects', () => {
     const controller = new EnsController();
-    expect(controller.set('1', name1, address1)).toBeTruthy();
-    expect(controller.set('1', name2, address2)).toBeTruthy();
-    expect(controller.set('2', name1, address1)).toBeTruthy();
-    expect(controller.delete('1', name1)).toBeTruthy();
+    expect(controller.set('1', name1, address1)).toStrictEqual(true);
+    expect(controller.set('1', name2, address2)).toStrictEqual(true);
+    expect(controller.set('2', name1, address1)).toStrictEqual(true);
+    expect(controller.delete('1', name1)).toStrictEqual(true);
     expect(controller.state).toStrictEqual({
       ensEntries: {
         1: {
@@ -252,9 +252,9 @@ describe('EnsController', () => {
 
   it('should clear all ENS entries', () => {
     const controller = new EnsController();
-    expect(controller.set('1', name1, address1)).toBeTruthy();
-    expect(controller.set('1', name2, address2)).toBeTruthy();
-    expect(controller.set('2', name1, address1)).toBeTruthy();
+    expect(controller.set('1', name1, address1)).toStrictEqual(true);
+    expect(controller.set('1', name2, address2)).toStrictEqual(true);
+    expect(controller.set('2', name1, address1)).toStrictEqual(true);
     controller.clear();
     expect(controller.state).toStrictEqual({ ensEntries: {} });
   });

--- a/src/user/AddressBookController.test.ts
+++ b/src/user/AddressBookController.test.ts
@@ -200,7 +200,7 @@ describe('AddressBookController', () => {
     const controller = new AddressBookController();
     expect(
       controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo'),
-    ).toBeTruthy();
+    ).toStrictEqual(true);
   });
 
   it('should return false to indicate an address book entry has NOT been added', () => {
@@ -213,7 +213,7 @@ describe('AddressBookController', () => {
     controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo');
     expect(
       controller.delete('1', '0x32Be343B94f860124dC4fEe278FDCBD38C102D88'),
-    ).toBeTruthy();
+    ).toStrictEqual(true);
   });
 
   it('should return false to indicate an address book entry has NOT been deleted', () => {

--- a/src/user/AddressBookController.test.ts
+++ b/src/user/AddressBookController.test.ts
@@ -205,7 +205,7 @@ describe('AddressBookController', () => {
 
   it('should return false to indicate an address book entry has NOT been added', () => {
     const controller = new AddressBookController();
-    expect(controller.set('1337', 'foo')).toBeFalsy();
+    expect(controller.set('1337', 'foo')).toStrictEqual(false);
   });
 
   it('should return true to indicate an address book entry has been deleted', () => {
@@ -219,7 +219,7 @@ describe('AddressBookController', () => {
   it('should return false to indicate an address book entry has NOT been deleted', () => {
     const controller = new AddressBookController();
     controller.set('0x32Be343B94f860124dC4fEe278FDCBD38C102D88', 'foo');
-    expect(controller.delete('1', 'bar')).toBeFalsy();
+    expect(controller.delete('1', 'bar')).toStrictEqual(false);
   });
 
   it('should normalize addresses so adding and removing entries work across casings', () => {


### PR DESCRIPTION
This PR removes the local `jest/no-restricted-matchers` config. This amounted to replacing instances of `toBeTruthy` and `toBeFalsy` with more specific matchers. The removal of the config and the replacement of each matcher were split into separate commits for ease-of-review.

Fun fact: Every instance of `toBeTruthy` was just replaced with `toStrictEqual(true)` in a single find-and-replace operation.

~Pending #449~