### PR TITLE
Remove ineffectual `| never` type unions

### DIFF
--- a/src/BaseControllerV2.ts
+++ b/src/BaseControllerV2.ts
@@ -125,8 +125,8 @@ export class BaseController<
     N,
     any,
     StateChangeEvent<N, S, any>,
-    string | never,
-    string | never
+    string,
+    string
   >;
 
   /**
@@ -158,8 +158,8 @@ export class BaseController<
       N,
       any,
       StateChangeEvent<N, S, any>,
-      string | never,
-      string | never
+      string,
+      string
     >;
     metadata: StateMetadata<S>;
     name: N;

--- a/src/ControllerMessenger.ts
+++ b/src/ControllerMessenger.ts
@@ -45,8 +45,8 @@ export class RestrictedControllerMessenger<
   N extends string,
   Action extends ActionConstraint,
   Event extends EventConstraint,
-  AllowedAction extends string | never,
-  AllowedEvent extends string | never
+  AllowedAction extends string,
+  AllowedEvent extends string
 > {
   private controllerMessenger: ControllerMessenger<Action, Event>;
 
@@ -440,8 +440,8 @@ export class ControllerMessenger<
    */
   getRestricted<
     N extends string,
-    AllowedAction extends string | never,
-    AllowedEvent extends string | never
+    AllowedAction extends string,
+    AllowedEvent extends string
   >({
     name,
     allowedActions,


### PR DESCRIPTION
Apparently `never` is never needed in a type union. You can pass in `never` as _any_ generic parameter without there being a type error. I had not understood that `never` worked this way.