### PR TITLE
Remove redundant type constraint in BaseControllerV2

### DIFF
--- a/src/BaseControllerV2.ts
+++ b/src/BaseControllerV2.ts
@@ -105,13 +105,6 @@ type Json =
   | Json[]
   | { [prop: string]: Json };
 
-type StateChangeEvent<N extends string, S, E> = E extends {
-  type: `${N}:stateChange`;
-  payload: [S, Patch[]];
-}
-  ? E
-  : never;
-
 /**
  * Controller class that provides state management, subscriptions, and state metadata
  */
@@ -124,7 +117,7 @@ export class BaseController<
   protected messagingSystem: RestrictedControllerMessenger<
     N,
     any,
-    StateChangeEvent<N, S, any>,
+    any,
     string,
     string
   >;
@@ -154,13 +147,7 @@ export class BaseController<
     name,
     state,
   }: {
-    messenger: RestrictedControllerMessenger<
-      N,
-      any,
-      StateChangeEvent<N, S, any>,
-      string,
-      string
-    >;
+    messenger: RestrictedControllerMessenger<N, any, any, string, string>;
     metadata: StateMetadata<S>;
     name: N;
     state: IsJsonable<S>;


### PR DESCRIPTION
The `StateChangeEvent` type constraint was completely broken - it was functionally equivalent to `any`. This is because it operates _statically_ on the generic type parameter given, which was always `any` for the parameter `E`. And of course `any extends ___` always evaluates to `true`.

The type has now been simplified to use `any` directly.