### PR TITLE
Add `getState` action to BaseControllerV2

### DIFF
--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -87,6 +87,23 @@ describe('BaseController', () => {
     expect(controller.state).toStrictEqual({ count: 0 });
   });
 
+  it('should allow getting state via the getState action', () => {
+    const controllerMessenger = new ControllerMessenger<
+      CountControllerAction,
+      CountControllerEvent
+    >();
+    new CountController({
+      messenger: getCountMessenger(controllerMessenger),
+      name: countControllerName,
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+
+    expect(controllerMessenger.call('CountController:getState')).toStrictEqual({
+      count: 0,
+    });
+  });
+
   it('should set initial schema', () => {
     const controller = new CountController({
       messenger: getCountMessenger(),

--- a/src/BaseControllerV2.ts
+++ b/src/BaseControllerV2.ts
@@ -156,6 +156,11 @@ export class BaseController<
     this.name = name;
     this.internalState = state;
     this.metadata = metadata;
+
+    this.messagingSystem.registerActionHandler(
+      `${name}:getState`,
+      () => this.state,
+    );
   }
 
   /**


### PR DESCRIPTION
This allows getting the state of the controller via the controller messenger.