### PR TITLE
Restore ComposableController compatibility between different BaseControllers

### DIFF
--- a/src/BaseControllerV2.ts
+++ b/src/BaseControllerV2.ts
@@ -132,6 +132,14 @@ export class BaseController<
   public readonly metadata: StateMetadata<S>;
 
   /**
+   * The existence of the `subscribe` property is how the ComposableController detects whether a
+   * controller extends the old BaseController or the new one. We set it to `never` here to ensure
+   * this property is never used for new BaseController-based controllers, to ensure the
+   * ComposableController never mistakes them for an older style controller.
+   */
+  public readonly subscribe: never;
+
+  /**
    * Creates a BaseController instance.
    *
    * @param options

--- a/src/ComposableController.ts
+++ b/src/ComposableController.ts
@@ -62,8 +62,8 @@ export class ComposableController extends BaseController<never, any> {
     this.messagingSystem = messenger;
     this.controllers.forEach((controller) => {
       const { name } = controller;
-      if (controller instanceof BaseController) {
-        controller.subscribe((state) => {
+      if ((controller as BaseController<any, any>).subscribe !== undefined) {
+        (controller as BaseController<any, any>).subscribe((state) => {
           this.update({ [name]: state });
         });
       } else if (this.messagingSystem) {


### PR DESCRIPTION
When adding support for BaseControllerV2 to the ComposableController in #447, we accidentally removed support for using two different versions of the BaseController in the same ComposableController. This is because we used the `instanceof` operator to check whether a controller was extended from BaseController.

The `instanceof` check has been replaced by a check for the `subscribe` function. It seems unlikely that a BaseControllerV2 controller will ever have a `subscribe` function because the controller messenger will be used for all events.