### PR TITLE
Improve restricted messenger types for controllers

### DIFF
--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -53,7 +53,7 @@ function getCountMessenger(
       CountControllerEvent
     >();
   }
-  return controllerMessenger.getRestricted({
+  return controllerMessenger.getRestricted<'CountController', never, never>({
     name: countControllerName,
   });
 }

--- a/src/ControllerMessenger.ts
+++ b/src/ControllerMessenger.ts
@@ -38,6 +38,18 @@ export type Namespaced<Name extends string, T> = T extends `${Name}:${string}`
   ? T
   : never;
 
+type NarrowToNamespace<T, Namespace extends string> = T extends {
+  type: `${Namespace}:${string}`;
+}
+  ? T
+  : never;
+
+type NarrowToAllowed<T, Allowed extends string> = T extends {
+  type: Allowed;
+}
+  ? T
+  : never;
+
 /**
  * A restricted controller messenger.
  *
@@ -59,7 +71,10 @@ export class RestrictedControllerMessenger<
   AllowedAction extends string,
   AllowedEvent extends string
 > {
-  private controllerMessenger: ControllerMessenger<Action, Event>;
+  private controllerMessenger: ControllerMessenger<
+    ActionConstraint,
+    EventConstraint
+  >;
 
   private controllerName: N;
 
@@ -91,7 +106,7 @@ export class RestrictedControllerMessenger<
     allowedActions,
     allowedEvents,
   }: {
-    controllerMessenger: ControllerMessenger<Action, Event>;
+    controllerMessenger: ControllerMessenger<ActionConstraint, EventConstraint>;
     name: N;
     allowedActions?: AllowedAction[];
     allowedEvents?: AllowedEvent[];
@@ -483,11 +498,17 @@ export class ControllerMessenger<
     name: N;
     allowedActions?: Extract<Action['type'], AllowedAction>[];
     allowedEvents?: Extract<Event['type'], AllowedEvent>[];
-  }) {
+  }): RestrictedControllerMessenger<
+    N,
+    NarrowToNamespace<Action, N> | NarrowToAllowed<Action, AllowedAction>,
+    NarrowToNamespace<Event, N> | NarrowToAllowed<Event, AllowedEvent>,
+    AllowedAction,
+    AllowedEvent
+  > {
     return new RestrictedControllerMessenger<
       N,
-      Action,
-      Event,
+      NarrowToNamespace<Action, N> | NarrowToAllowed<Action, AllowedAction>,
+      NarrowToNamespace<Event, N> | NarrowToAllowed<Event, AllowedEvent>,
       AllowedAction,
       AllowedEvent
     >({

--- a/src/assets/CurrencyRateController.test.ts
+++ b/src/assets/CurrencyRateController.test.ts
@@ -1,17 +1,31 @@
 import { stub } from 'sinon';
+import type { Patch } from 'immer';
 import nock from 'nock';
 import { ControllerMessenger } from '../ControllerMessenger';
 import {
   CurrencyRateController,
   CurrencyRateStateChange,
+  GetCurrencyRateState,
 } from './CurrencyRateController';
 
 const name = 'CurrencyRateController';
 
+type OtherStateChange = {
+  type: `OtherController:stateChange`;
+  payload: [{ stuff: string }, Patch[]];
+};
+
+type GetOtherState = {
+  type: `OtherController:getState`;
+  handler: () => { stuff: string };
+};
+
 function getRestrictedMessenger() {
+  // The 'Other' types are included to demonstrate that this all works with a
+  // controller messenger that includes types from other controllers.
   const controllerMessenger = new ControllerMessenger<
-    any,
-    CurrencyRateStateChange
+    GetCurrencyRateState | GetOtherState,
+    CurrencyRateStateChange | OtherStateChange
   >();
   const messenger = controllerMessenger.getRestricted<
     'CurrencyRateController',

--- a/src/assets/CurrencyRateController.ts
+++ b/src/assets/CurrencyRateController.ts
@@ -35,6 +35,11 @@ export type CurrencyRateStateChange = {
   payload: [CurrencyRateState, Patch[]];
 };
 
+export type GetCurrencyRateState = {
+  type: `${typeof name}:getState`;
+  handler: () => CurrencyRateState;
+};
+
 const metadata = {
   conversionDate: { persist: true, anonymous: true },
   conversionRate: { persist: true, anonymous: true },
@@ -94,8 +99,8 @@ export class CurrencyRateController extends BaseController<
     interval?: number;
     messenger: RestrictedControllerMessenger<
       typeof name,
-      any,
-      any,
+      GetCurrencyRateState,
+      CurrencyRateStateChange,
       never,
       never
     >;


### PR DESCRIPTION
The `getRestricted` method has been improved to further narrow the types of the restricted messaging controller. This allows BaseControllerV2-based controllers to have full type safety for their usage of the controller messenger.

The BaseController itself still doesn't have a type-safe controller messenger; that will be dealt with in a later PR (if we ever get it working).