### PR TITLE
Normalize CHANGELOG format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,54 +1,42 @@
 # Changelog
-
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 ## [8.0.0] - 2021-04-15
-
 ### Added
-
 - Add restricted controller messenger ([#378](https://github.com/MetaMask/controllers/pull/378))
 
 ### Changed
-
 - **BREAKING:** Update minimum Node.js version to v12 ([#441](https://github.com/MetaMask/controllers/pull/441))
 - **BREAKING:** Replace controller context ([#387](https://github.com/MetaMask/controllers/pull/387))
 - Bump @metamask/contract-metadata from 1.23.0 to 1.24.0 ([#440](https://github.com/MetaMask/controllers/pull/440))
 - Update lint rules ([#442](https://github.com/MetaMask/controllers/pull/442), [#426](https://github.com/MetaMask/controllers/pull/426))
 
 ### Fixed
-
 - Don't remove collectibles during auto detection ([#439](https://github.com/MetaMask/controllers/pull/439))
 
 ## [7.0.0] - 2021-04-06
-
 ### Added
-
 - Ability to indicate if a transaction was added from the users local device and account creation time ([#436](https://github.com/MetaMask/controllers/pull/436))
 
 ### Changed
-
 - **BREAKING:** Organize assets by chainid ([#435](https://github.com/MetaMask/controllers/pull/435))
 - Support longer token symbols via wallet_watchAsset ([#433](https://github.com/MetaMask/controllers/pull/433))
 
 ## [6.2.1] - 2021-03-23
-
 ### Fixed
-
 - Restore BN export ([#428](https://github.com/MetaMask/controllers/pull/428))
 
 ## [6.2.0] - 2021-03-23 [WITHDRAWN]
-
 ### Added
-
 - Add the Notification Controller (to support "what's new" type announcements in-app) ([#329](https://github.com/MetaMask/controllers/pull/329))
 - Add support for specifying a custom nonce ([#381](https://github.com/MetaMask/controllers/pull/381))
 
 ### Changed
-
 - Explicitly add ethereumjs-tx as a package.json dependency ([#392](https://github.com/MetaMask/controllers/pull/392))
 - Add `types` manifest field to package.json ([#391](https://github.com/MetaMask/controllers/pull/391))
 - Use "options bag" for parameters for BaseControllerV2 constructor ([#388](https://github.com/MetaMask/controllers/pull/388))
@@ -62,31 +50,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add descriptive error messages to empty `toThrow` call ([#422](https://github.com/MetaMask/controllers/pull/422))
 
 ### Fixed
-
 - Fix `signTransaction` transaction parameter type ([#400](https://github.com/MetaMask/controllers/pull/400))
 - [BREAKING] Consistently use BN type for token balances ([#398](https://github.com/MetaMask/controllers/pull/398))
 
 ## [6.1.1] - 2021-03-12
-
 ### Added
-
 - Add controller messaging system ([#377](https://github.com/MetaMask/controllers/pull/377))
 
 ### Fixed
-
 - bugfix/dont modify current transactions ([#386](https://github.com/MetaMask/controllers/pull/386))
 - Fix `format` commands ([#385](https://github.com/MetaMask/controllers/pull/385))
 
 ## [6.1.0] - 2021-03-10
-
 ### Added
-
 - Add Base Controller v2 ([#358](https://github.com/MetaMask/controllers/pull/358))
 - Add `babel-runtime` dependency required by `ethjs-query` ([#341](https://github.com/MetaMask/controllers/pull/341))
 - Add Dependabot config ([#343](https://github.com/MetaMask/controllers/pull/343))
 
 ### Changed
-
 - Add chainId to every transaction ([#349](https://github.com/MetaMask/controllers/pull/349))
 - Add normalizeTokenTx for incoming transactions ([#380](https://github.com/MetaMask/controllers/pull/380))
 - Bump elliptic from 6.5.3 to 6.5.4 ([#383](https://github.com/MetaMask/controllers/pull/383))
@@ -118,117 +99,86 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Update `eth-json-rpc-filters` in lockfile ([#336](https://github.com/MetaMask/controllers/pull/336))
 
 ### Fixed
-
 - Fix AbstractMessageManager error ([#367](https://github.com/MetaMask/controllers/pull/367))
 - Enforce the usage of `chainId` instead of `networkId` in `NetworkController` ([#324](https://github.com/MetaMask/controllers/pull/324))
 
 ## [6.0.1] - 2021-02-05
-
 ### Changed
-
 - Update `typedoc` from v0.15 to v20.20 ([#333](https://github.com/MetaMask/controllers/pull/333))
 - Update `@metamask/contract-metadata` from v1.19 to v1.22 ([#332](https://github.com/MetaMask/controllers/pull/332))
 - Bump node-notifier from 8.0.0 to 8.0.1 ([#323](https://github.com/MetaMask/controllers/pull/323))
 
 ### Fixed
-
 - Add `safelyExecuteWithTimeout` for `accountTracker.refresh` ([#331](https://github.com/MetaMask/controllers/pull/331))
 - Add try/catch for `assetsContract.getBalanceOf` ([#328](https://github.com/MetaMask/controllers/pull/328))
 
 ## [6.0.0] - 2021-01-19
-
 ### Changed
-
 - Remove default approval controller type ([#321](https://github.com/MetaMask/controllers/pull/321))
 
 ### Fixed
-
 - Enforce the usage of `chainId` instead of `networkId` in `NetworkController` ([#324](https://github.com/MetaMask/controllers/pull/324))
 
 ## [5.1.0] - 2020-12-02
-
 ### Changed
-
 - Updated automatically detected assets ([#318](https://github.com/MetaMask/controllers/pull/318))
 
 ### Fixed
-
 - Robustified `wallet_watchAssets` params validation, and improved errors ([#317](https://github.com/MetaMask/controllers/pull/317))
 
 ## [5.0.0] - 2020-11-19
-
 ### Added
-
 - `ApprovalController` ([#309](https://github.com/MetaMask/controllers/pull/309))
   - Add user-defined default type
   - Add `Date.now()` timestamps to request (`approval.time`)
   - Enable `has` lookups by `type` only
 
 ### Changed
-
 - **Breaking:** `ApprovalController`: Require types for all requests ([#309](https://github.com/MetaMask/controllers/pull/309))
 - `ApprovalController`: Rename `ApprovalInfo` interface to `Approval` ([#309](https://github.com/MetaMask/controllers/pull/309))
 - `PhishingController`: Make `no-cache` fetch option explicit ([#297](https://github.com/MetaMask/controllers/pull/297))
 - Make package compatible with Node 12 ([#287](https://github.com/MetaMask/controllers/pull/287))
 
 ### Fixed
-
 - `ApprovalController`: Fix faulty `origin` parameter type check ([#309](https://github.com/MetaMask/controllers/pull/309))
   - The type check was too loose, and would've permitted some invalid origins.
 
 ## [4.2.0] - 2020-11-13
-
 ### Added
-
 - Expose `ApprovalController` count state ([#306](https://github.com/MetaMask/controllers/pull/306))
 - `KeyringController` `onLock`/`onUnlock` event handlers ([#307](https://github.com/MetaMask/controllers/pull/307))
 
 ### Fixed
-
 - Properly initialize `ApprovalController` ([#306](https://github.com/MetaMask/controllers/pull/306))
 
 ## [4.1.0] - 2020-11-10
-
 ### Added
-
 - `ApprovalController` approval count methods ([#304](https://github.com/MetaMask/controllers/pull/304))
 
 ## [4.0.2] - 2020-11-09
-
 ### Changed
-
 - Unpin `eth-sig-util` dependency ([#302](https://github.com/MetaMask/controllers/pull/302))
 
 ## [4.0.1] - 2020-11-09
-
 ### Fixed
-
 - Fix `ApprovalController` export ([#300](https://github.com/MetaMask/controllers/pull/300))
 
 ## [4.0.0] - 2020-11-09
-
 ### Added
-
 - Add `ApprovalController` ([#289](https://github.com/MetaMask/controllers/pull/289))
 
 ### Changed
-
 - Allow configuring `CurrencyController` to always fetch USD rate ([#292](https://github.com/MetaMask/controllers/pull/292))
 
 ### Removed
-
 - **BREAKING:** Remove `NetworkStatusController` ([#298](https://github.com/MetaMask/controllers/pull/298))
 
 ## [3.2.0] - 2020-10-21
-
 ### Added
-
 - Add `addNewAccountWithoutUpdate` method ([#288](https://github.com/MetaMask/controllers/pull/288))
 
 ## [3.1.0] - 2020-09-23
-
 ### Changed
-
 - Update various dependencies
   - eth-rpc-errors@3.0.0 ([#284](https://github.com/MetaMask/controllers/pull/284))
   - web3-provider-engine@16.0.1 ([#283](https://github.com/MetaMask/controllers/pull/283))
@@ -236,83 +186,66 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - eth-json-rpc-infura@5.1.0 ([#281](https://github.com/MetaMask/controllers/pull/281))
 
 ## [3.0.1] - 2020-09-15
-
 ### Changed
-
 - Remove `If-None-Match` header from phishing config requests ([#277](https://github.com/MetaMask/controllers/pull/277))
 
 ## [3.0.0] - 2020-09-11
-
 ### Changed
-
 - Use Infura v3 API ([#267](https://github.com/MetaMask/controllers/pull/267))
 
 ## [2.0.5] - 2020-08-18
-
 ### Changed
-
 - Add prepublishOnly build script (#260)
 
 ## [2.0.4] - 2020-08-18
-
 ### Changed
-
 - Use jsDelivr instead of the GitHub API for content (#256)
 - Lower phishing config poll rate to 1 req/hr (#257)
 - Use renamed `eth-rpc-error` package (#252)
 
 ## [2.0.3] - 2020-07-27
-
 ### Added
-
 - TransactionsController: Bugfix cancel / speedup transactions (#248)
 
 ## [2.0.2] - 2020-07-14
-
 ### Added
-
 - TransactionsController: Fetch incoming token transactions (#247)
 
 ## [2.0.1] - 2020-06-18
-
 ### Changed
-
 - Update `PhishingController` endpoint to use GitHub API (#244)
 
 ## [2.0.0] - 2020-05-07
-
 ### Changed
-
 - Rebrand as `@metamask/controllers` (#226)
 - Use yarn & drop `npm-shrinkwrap.json` (#193)
 
 ## Removed
-
 - Remove shapeshift controller (#209)
 
-[Unreleased]:https://github.com/MetaMask/controllers/compare/v8.0.0...HEAD
-[8.0.0]:https://github.com/MetaMask/controllers/compare/v7.0.0...v8.0.0
-[7.0.0]:https://github.com/MetaMask/controllers/compare/v6.2.1...v7.0.0
-[6.2.1]:https://github.com/MetaMask/controllers/compare/v6.2.0...v6.2.1
-[6.2.0]:https://github.com/MetaMask/controllers/compare/v6.1.1...v6.2.0
-[6.1.1]:https://github.com/MetaMask/controllers/compare/v6.1.0...v6.1.1
-[6.1.0]:https://github.com/MetaMask/controllers/compare/v6.0.1...v6.1.0
-[6.0.1]:https://github.com/MetaMask/controllers/compare/v6.0.0...v6.0.1
-[6.0.0]:https://github.com/MetaMask/controllers/compare/v5.1.0...v6.0.0
-[5.1.0]:https://github.com/MetaMask/controllers/compare/v5.0.0...v5.1.0
-[5.0.0]:https://github.com/MetaMask/controllers/compare/v4.2.0...v5.0.0
-[4.2.0]:https://github.com/MetaMask/controllers/compare/v4.1.0...v4.2.0
-[4.1.0]:https://github.com/MetaMask/controllers/compare/v4.0.2...v4.1.0
-[4.0.2]:https://github.com/MetaMask/controllers/compare/v4.0.1...v4.0.2
-[4.0.1]:https://github.com/MetaMask/controllers/compare/v4.0.0...v4.0.1
-[4.0.0]:https://github.com/MetaMask/controllers/compare/v3.2.0...v4.0.0
-[3.2.0]:https://github.com/MetaMask/controllers/compare/v3.1.0...v3.2.0
-[3.1.0]:https://github.com/MetaMask/controllers/compare/v3.0.1...v3.1.0
-[3.0.1]:https://github.com/MetaMask/controllers/compare/v3.0.0...v3.0.1
-[3.0.0]:https://github.com/MetaMask/controllers/compare/v2.0.5...v3.0.0
-[2.0.5]:https://github.com/MetaMask/controllers/compare/v2.0.4...v2.0.5
-[2.0.4]:https://github.com/MetaMask/controllers/compare/v2.0.3...v2.0.4
-[2.0.3]:https://github.com/MetaMask/controllers/compare/v2.0.2...v2.0.3
-[2.0.2]:https://github.com/MetaMask/controllers/compare/v2.0.1...v2.0.2
-[2.0.1]:https://github.com/MetaMask/controllers/compare/v2.0.0...v2.0.1
-[2.0.0]:https://github.com/MetaMask/controllers/tree/v2.0.0
+[Unreleased]: https://github.com/MetaMask/controllers/compare/v8.0.0...HEAD
+[8.0.0]: https://github.com/MetaMask/controllers/compare/v7.0.0...v8.0.0
+[7.0.0]: https://github.com/MetaMask/controllers/compare/v6.2.1...v7.0.0
+[6.2.1]: https://github.com/MetaMask/controllers/compare/v6.2.0...v6.2.1
+[6.2.0]: https://github.com/MetaMask/controllers/compare/v6.1.1...v6.2.0
+[6.1.1]: https://github.com/MetaMask/controllers/compare/v6.1.0...v6.1.1
+[6.1.0]: https://github.com/MetaMask/controllers/compare/v6.0.1...v6.1.0
+[6.0.1]: https://github.com/MetaMask/controllers/compare/v6.0.0...v6.0.1
+[6.0.0]: https://github.com/MetaMask/controllers/compare/v5.1.0...v6.0.0
+[5.1.0]: https://github.com/MetaMask/controllers/compare/v5.0.0...v5.1.0
+[5.0.0]: https://github.com/MetaMask/controllers/compare/v4.2.0...v5.0.0
+[4.2.0]: https://github.com/MetaMask/controllers/compare/v4.1.0...v4.2.0
+[4.1.0]: https://github.com/MetaMask/controllers/compare/v4.0.2...v4.1.0
+[4.0.2]: https://github.com/MetaMask/controllers/compare/v4.0.1...v4.0.2
+[4.0.1]: https://github.com/MetaMask/controllers/compare/v4.0.0...v4.0.1
+[4.0.0]: https://github.com/MetaMask/controllers/compare/v3.2.0...v4.0.0
+[3.2.0]: https://github.com/MetaMask/controllers/compare/v3.1.0...v3.2.0
+[3.1.0]: https://github.com/MetaMask/controllers/compare/v3.0.1...v3.1.0
+[3.0.1]: https://github.com/MetaMask/controllers/compare/v3.0.0...v3.0.1
+[3.0.0]: https://github.com/MetaMask/controllers/compare/v2.0.5...v3.0.0
+[2.0.5]: https://github.com/MetaMask/controllers/compare/v2.0.4...v2.0.5
+[2.0.4]: https://github.com/MetaMask/controllers/compare/v2.0.3...v2.0.4
+[2.0.3]: https://github.com/MetaMask/controllers/compare/v2.0.2...v2.0.3
+[2.0.2]: https://github.com/MetaMask/controllers/compare/v2.0.1...v2.0.2
+[2.0.1]: https://github.com/MetaMask/controllers/compare/v2.0.0...v2.0.1
+[2.0.0]: https://github.com/MetaMask/controllers/releases/tag/v2.0.0

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "web3-provider-engine": "^16.0.1"
   },
   "devDependencies": {
+    "@metamask/auto-changelog": "^1.0.0",
     "@metamask/eslint-config": "^6.0.0",
     "@metamask/eslint-config-jest": "^6.0.0",
     "@metamask/eslint-config-nodejs": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -658,6 +658,16 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@metamask/auto-changelog@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/auto-changelog/-/auto-changelog-1.0.0.tgz#ca6a71d1b983cf08b715bdcd8e240d746974d0c7"
+  integrity sha512-3Bcm+JsEmNllPi7kRtzS6EAjYTzz+Isa4QFq2DQ4DFwIsv2HUxdR+KNU2GJ1BdX4lbPcQTrpTdaPgBZ9G4NhLA==
+  dependencies:
+    cross-spawn "^7.0.3"
+    diff "^5.0.0"
+    semver "^7.3.5"
+    yargs "^17.0.1"
+
 "@metamask/contract-metadata@^1.25.0":
   version "1.25.0"
   resolved "https://registry.yarnpkg.com/@metamask/contract-metadata/-/contract-metadata-1.25.0.tgz#442ace91fb40165310764b68d8096d0017bb0492"
@@ -1758,6 +1768,15 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
 clone@^2.0.0, clone@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
@@ -1922,7 +1941,7 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cross-spawn@^7.0.2:
+cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -2083,6 +2102,11 @@ diff@^4.0.2:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
+diff@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
+  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
+
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
@@ -2238,6 +2262,11 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -3236,7 +3265,7 @@ gensync@^1.0.0-beta.1:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"
   integrity sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -6011,6 +6040,13 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@~5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
@@ -6961,6 +6997,15 @@ wrap-ansi@^6.2.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -7042,6 +7087,11 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
   integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
 
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
 yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
@@ -7065,6 +7115,11 @@ yargs-parser@^18.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^20.2.2:
+  version "20.2.7"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a"
+  integrity sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
+
 yargs@^15.3.1:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
@@ -7081,3 +7136,16 @@ yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.0.1.tgz#6a1ced4ed5ee0b388010ba9fd67af83b9362e0bb"
+  integrity sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"


### PR DESCRIPTION
The CHANGELOG is now using the KeepAChangelog format exactly, as required by our `@metamask/auto-changelog` tool. It has also been added as a dev dependency to make updating the changelog easier.

This can be tested by running the command: `yarn auto-changelog validate --repo https://github.com/MetaMask/controllers`