### PR TITLE
Mapping token address strings instead of Token objects while checking for new tokens

### DIFF
--- a/src/assets/AssetsDetectionController.test.ts
+++ b/src/assets/AssetsDetectionController.test.ts
@@ -1,6 +1,7 @@
 import { createSandbox, SinonStub, stub } from 'sinon';
 import nock from 'nock';
 import { BN } from 'ethereumjs-util';
+import contractMap from '@metamask/contract-metadata';
 import {
   NetworkController,
   NetworksChainId,
@@ -24,7 +25,8 @@ describe('AssetsDetectionController', () => {
   let assets: AssetsController;
   let assetsContract: AssetsContractController;
   let getBalancesInSingleCall: SinonStub<
-    [AssetsContractController['getBalancesInSingleCall']]
+    Parameters<AssetsContractController['getBalancesInSingleCall']>,
+    ReturnType<AssetsContractController['getBalancesInSingleCall']>
   >;
   const sandbox = createSandbox();
 
@@ -461,6 +463,34 @@ describe('AssetsDetectionController', () => {
         symbol: 'LINK',
       },
     ]);
+  });
+
+  it('should call getBalancesInSingle with token address that is not present on the asset state', async () => {
+    assetsDetection.configure({ networkType: MAINNET, selectedAddress: '0x1' });
+    getBalancesInSingleCall.resolves({
+      '0x6810e776880C02933D47DB1b9fc05908e5386b96': new BN(1),
+    });
+    const tokensToDetect: string[] = [];
+    for (const address in contractMap) {
+      const contract = contractMap[address];
+      if (contract.erc20) {
+        tokensToDetect.push(address);
+      }
+    }
+    await assetsDetection.detectTokens();
+    expect(getBalancesInSingleCall.calledWith('0x1', tokensToDetect)).toBe(
+      true,
+    );
+    getBalancesInSingleCall.resolves({
+      '0x514910771AF9Ca656af840dff83E8264EcF986CA': new BN(1),
+    });
+    const updatedTokensToDetect = tokensToDetect.filter(
+      (address) => address !== '0x6810e776880C02933D47DB1b9fc05908e5386b96',
+    );
+    await assetsDetection.detectTokens();
+    expect(
+      getBalancesInSingleCall.calledWith('0x1', updatedTokensToDetect),
+    ).toBe(true);
   });
 
   it('should not autodetect tokens that exist in the ignoreList', async () => {

--- a/src/assets/AssetsDetectionController.test.ts
+++ b/src/assets/AssetsDetectionController.test.ts
@@ -429,6 +429,40 @@ describe('AssetsDetectionController', () => {
     ]);
   });
 
+  it('should update the tokens list when new tokens are detected', async () => {
+    assetsDetection.configure({ networkType: MAINNET, selectedAddress: '0x1' });
+    getBalancesInSingleCall.resolves({
+      '0x6810e776880C02933D47DB1b9fc05908e5386b96': new BN(1),
+    });
+    await assetsDetection.detectTokens();
+    expect(assets.state.tokens).toStrictEqual([
+      {
+        address: '0x6810e776880C02933D47DB1b9fc05908e5386b96',
+        decimals: 18,
+        image: undefined,
+        symbol: 'GNO',
+      },
+    ]);
+    getBalancesInSingleCall.resolves({
+      '0x514910771AF9Ca656af840dff83E8264EcF986CA': new BN(1),
+    });
+    await assetsDetection.detectTokens();
+    expect(assets.state.tokens).toStrictEqual([
+      {
+        address: '0x6810e776880C02933D47DB1b9fc05908e5386b96',
+        decimals: 18,
+        image: undefined,
+        symbol: 'GNO',
+      },
+      {
+        address: '0x514910771AF9Ca656af840dff83E8264EcF986CA',
+        decimals: 18,
+        image: undefined,
+        symbol: 'LINK',
+      },
+    ]);
+  });
+
   it('should not autodetect tokens that exist in the ignoreList', async () => {
     assetsDetection.configure({ networkType: MAINNET, selectedAddress: '0x1' });
     getBalancesInSingleCall.resolves({

--- a/src/assets/AssetsDetectionController.ts
+++ b/src/assets/AssetsDetectionController.ts
@@ -301,13 +301,13 @@ export class AssetsDetectionController extends BaseController<
     if (!this.isMainnet()) {
       return;
     }
-    const tokensAddresses = this.config.tokens.filter(
+    const tokensAddresses = this.config.tokens.map(
       /* istanbul ignore next*/ (token) => token.address,
     );
     const tokensToDetect: string[] = [];
     for (const address in contractMap) {
       const contract = contractMap[address];
-      if (contract.erc20 && !(address in tokensAddresses)) {
+      if (contract.erc20 && !(tokensAddresses.includes(address))) {
         tokensToDetect.push(address);
       }
     }

--- a/src/assets/AssetsDetectionController.ts
+++ b/src/assets/AssetsDetectionController.ts
@@ -307,7 +307,7 @@ export class AssetsDetectionController extends BaseController<
     const tokensToDetect: string[] = [];
     for (const address in contractMap) {
       const contract = contractMap[address];
-      if (contract.erc20 && !(tokensAddresses.includes(address))) {
+      if (contract.erc20 && !tokensAddresses.includes(address)) {
         tokensToDetect.push(address);
       }
     }


### PR DESCRIPTION
In `detectTokens()` of AssetsDetectionController, the check for the address value in the `Asset.state.tokens` list was defaulting to `false` as tokenAddress list is a list of `Token objects` instead of `address strings`, thereby sending all the tokens addresses in the contractMap for balance check even if it is already present in `Asset.state.tokens`.

The fix will be to map the `address string` to tokenAddresses list instead of `Token objects` and also check if the address from the contractMap is included in the tokenAddresses list while looping through each object in contractMap.