### PR TITLE
RFC: Permit `undefined` in BaseControllerV2 state

### DIFF
--- a/src/BaseControllerV2.ts
+++ b/src/BaseControllerV2.ts
@@ -26,7 +26,7 @@ export type Listener<T> = (state: T, patches: Patch[]) => void;
 
 type primitive = null | boolean | number | string;
 
-type DefinitelyNotJsonable = ((...args: any[]) => any) | undefined;
+type DefinitelyNotJsonable = (...args: any[]) => any;
 
 // Credit to https://github.com/grant-dennison for this type
 // Source: https://github.com/Microsoft/TypeScript/issues/1897#issuecomment-710744173


### PR DESCRIPTION
This PR modifies the `IsJsonable` type guard to permit `undefined` values, even if they are not strictly JSON-able. Due to the current state of TypeScript (probably until the next major version, `^5.0.0`, see PR [here](https://github.com/microsoft/TypeScript/pull/43947)), this is the only way that we can support optional properties on objects in `BaseControllerV2` state.

While `undefined` is not a valid JSON value, calling `JSON.stringify` on an `undefined` value isn't dangerous or unsafe, since the value will simply be omitted. Regardless, we can avoid actually assigning `undefined` to values by convention.

The alternatives to this are either ugly ("missing" optional properties must be set to `null`) or unergonomic (properties are "optional" via union types with different properties that must be narrowed before they can be used), and always frustrating.