### PR TITLE
Export `BaseControllerV2` `Json` type

### DIFF
--- a/src/BaseControllerV2.ts
+++ b/src/BaseControllerV2.ts
@@ -97,7 +97,7 @@ export interface StatePropertyMetadata<T> {
   anonymous: boolean | StateDeriver<T>;
 }
 
-type Json =
+export type Json =
   | null
   | boolean
   | number

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export {
   getPersistentState,
   getAnonymizedState,
   IsJsonable,
+  Json,
   StateDeriver,
   StateMetadata,
   StatePropertyMetadata,


### PR DESCRIPTION
Since `BaseControllerV2` states can't contain `unknown` values because of its stringent type checking, we should export the `Json` type that is defined in that module. Consumers will have to use something very much like it if they require something similar to `unknown` (i.e., a generic type that must be narrowed).