### PR TITLE
Add new publishing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,21 +270,15 @@ $ npm link @metamask/controllers
 The project follows the same release process as the other libraries in the MetaMask organization:
 
 1. Create a release branch
-    - For a typical release, this would be based on `master`
-    - To update an older maintained major version, base the release branch on the major version branch (e.g. `1.x`)
+   - For a typical release, this would be based on `main`
+   - To update an older maintained major version, base the release branch on the major version branch (e.g. `1.x`)
 2. Update the changelog
 3. Update version in package.json file (e.g. `yarn version --minor --no-git-tag-version`)
-4. Create a pull request targeting the base branch (e.g. master or 1.x)
+4. Create a pull request targeting the base branch (e.g. `main` or `1.x`)
 5. Code review and QA
 6. Once approved, the PR is squashed & merged
 7. The commit on the base branch is tagged
 8. The tag can be published as needed
-
-## API documentation
-
-API documentation is auto-generated for the `@metamask/controllers` package on every commit to the `master` branch.
-
-[View API documentation](https://metamask.github.io/@metamask/controllers/)
 
 ## License
 


### PR DESCRIPTION
Updates the readme instructions for publishing following the deletion of the `master` branch and renaming `develop` to `main`. Also removes the reference and link to the auto docs for this package, which was already broken before we deleted the `gh-pages` branch.