### PR TITLE
bugfix/collectible detection by acccount

### DIFF
--- a/src/assets/AssetsDetectionController.test.ts
+++ b/src/assets/AssetsDetectionController.test.ts
@@ -130,6 +130,21 @@ describe('AssetsDetectionController', () => {
             token_id: '2574',
           },
         ],
+      })
+      .get(`${OPEN_SEA_PATH}/assets?owner=0x9&limit=300`)
+      .delay(800)
+      .reply(200, {
+        assets: [
+          {
+            asset_contract: {
+              address: '0xebE4e5E773AFD2bAc25De0cFafa084CFb3cBf1eD',
+            },
+            description: 'Description 2574',
+            image_url: 'image/2574.png',
+            name: 'ID 2574',
+            token_id: '2574',
+          },
+        ],
       });
   });
 
@@ -287,6 +302,20 @@ describe('AssetsDetectionController', () => {
   it('should not detect and add collectibles if there is no selectedAddress', async () => {
     assetsDetection.configure({ networkType: MAINNET });
     await assetsDetection.detectCollectibles();
+    expect(assets.state.collectibles).toStrictEqual([]);
+  });
+
+  it('should not detect and add collectibles to the wrong selectedAddress', async () => {
+    assetsDetection.configure({
+      networkType: MAINNET,
+      selectedAddress: '0x9',
+    });
+    assets.configure({ selectedAddress: '0x9' });
+    assetsDetection.detectCollectibles();
+    assetsDetection.configure({ selectedAddress: '0x12' });
+    assets.configure({ selectedAddress: '0x12' });
+    await new Promise((res) => setTimeout(() => res(true), 1000));
+    expect(assetsDetection.config.selectedAddress).toStrictEqual('0x12');
     expect(assets.state.collectibles).toStrictEqual([]);
   });
 

--- a/src/assets/AssetsDetectionController.ts
+++ b/src/assets/AssetsDetectionController.ts
@@ -355,9 +355,10 @@ export class AssetsDetectionController extends BaseController<
     if (!this.isMainnet()) {
       return;
     }
-    const { selectedAddress } = this.config;
+    const requestedSelectedAddress = this.config.selectedAddress;
+
     /* istanbul ignore else */
-    if (!selectedAddress) {
+    if (!requestedSelectedAddress) {
       return;
     }
     await safelyExecute(async () => {
@@ -395,8 +396,10 @@ export class AssetsDetectionController extends BaseController<
             });
           }
           /* istanbul ignore else */
-          if (!ignored) {
-            /* istanbul ignore next */
+          if (
+            !ignored &&
+            requestedSelectedAddress === this.config.selectedAddress
+          ) {
             const collectibleMetadata: CollectibleMetadata = Object.assign(
               {},
               { name },

--- a/src/assets/AssetsDetectionController.ts
+++ b/src/assets/AssetsDetectionController.ts
@@ -400,6 +400,7 @@ export class AssetsDetectionController extends BaseController<
             !ignored &&
             requestedSelectedAddress === this.config.selectedAddress
           ) {
+            /* istanbul ignore next */
             const collectibleMetadata: CollectibleMetadata = Object.assign(
               {},
               { name },


### PR DESCRIPTION
When auto detecting collectibles there are some cases where some collectibles were detected in the wrong account. One way I could reproduce that was in the following case

- Auto detection is triggered for address `0x9` and we're waiting for the response from API https://github.com/MetaMask/controllers/compare/bugfix/assets-detection-by-acccount?expand=1#diff-3202c2273084eb58dae3e0d4e23765dce262bb24c93eb3bf166c56d2d7bf02c8R365
- The account is changed to `0x12`
- The API response resolves the collectibles for `0x9` but they are added to `0x12`, so we have the wrong assets into the account.

I could repro that with tests, removing this check https://github.com/MetaMask/controllers/compare/bugfix/assets-detection-by-acccount?expand=1#diff-3202c2273084eb58dae3e0d4e23765dce262bb24c93eb3bf166c56d2d7bf02c8R401