### PR TITLE
Remove IsJsonable

### DIFF
--- a/src/BaseControllerV2.ts
+++ b/src/BaseControllerV2.ts
@@ -157,6 +157,7 @@ export class BaseController<
   protected update(callback: (state: Draft<S>) => void | S) {
     // We run into ts2589, "infinite type depth", if we don't cast
     // produceWithPatches here.
+    // The final, omitted member of the returned tuple are the inverse patches.
     const [nextState, patches] = ((produceWithPatches as unknown) as (
       state: S,
       cb: typeof callback,

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -60,13 +60,13 @@ export type GetTokenListState = {
   type: `${typeof name}:getState`;
   handler: () => TokenListState;
 };
-interface DataCache {
+type DataCache = {
   timestamp: number;
   data: TokenListToken[];
-}
-interface TokensChainsCache {
+};
+type TokensChainsCache = {
   [chainSlug: string]: DataCache;
-}
+};
 
 type TokenListMessenger = RestrictedControllerMessenger<
   typeof name,

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -57,10 +57,10 @@ export type GasEstimateType =
   | LegacyEstimateType
   | NoEstimateType;
 
-export interface EstimatedGasFeeTimeBounds {
+export type EstimatedGasFeeTimeBounds = {
   lowerTimeBound: number | null;
   upperTimeBound: number | unknownString;
-}
+};
 
 /**
  * @type EthGasPriceEstimate
@@ -72,9 +72,9 @@ export interface EstimatedGasFeeTimeBounds {
  * @property gasPrice - A GWEI dec string
  */
 
-export interface EthGasPriceEstimate {
+export type EthGasPriceEstimate = {
   gasPrice: string;
-}
+};
 
 /**
  * @type LegacyGasPriceEstimate
@@ -87,11 +87,11 @@ export interface EthGasPriceEstimate {
  * @property medium - gasPrice, in decimal gwei string format, suggested for avg inclusion
  * @property low - gasPrice, in decimal gwei string format, suggested for slow inclusion
  */
-export interface LegacyGasPriceEstimate {
+export type LegacyGasPriceEstimate = {
   high: string;
   medium: string;
   low: string;
-}
+};
 
 /**
  * @type Eip1559GasFee
@@ -104,12 +104,12 @@ export interface LegacyGasPriceEstimate {
  * @property suggestedMaxFeePerGas - A suggested max fee, the most a user will pay. a GWEI hex number
  */
 
-export interface Eip1559GasFee {
+export type Eip1559GasFee = {
   minWaitTimeEstimate: number; // a time duration in milliseconds
   maxWaitTimeEstimate: number; // a time duration in milliseconds
   suggestedMaxPriorityFeePerGas: string; // a GWEI decimal number
   suggestedMaxFeePerGas: string; // a GWEI decimal number
-}
+};
 
 /**
  * @type GasFeeEstimates
@@ -122,12 +122,12 @@ export interface Eip1559GasFee {
  * @property estimatedBaseFee - An estimate of what the base fee will be for the pending/next block. A GWEI dec number
  */
 
-export interface GasFeeEstimates {
+export type GasFeeEstimates = {
   low: Eip1559GasFee;
   medium: Eip1559GasFee;
   high: Eip1559GasFee;
   estimatedBaseFee: string;
-}
+};
 
 const metadata = {
   gasFeeEstimates: { persist: true, anonymous: false },
@@ -159,9 +159,9 @@ export type GasFeeStateNoEstimates = {
   gasEstimateType: NoEstimateType;
 };
 
-export interface FetchGasFeeEstimateOptions {
+export type FetchGasFeeEstimateOptions = {
   shouldUpdateState?: boolean;
-}
+};
 
 /**
  * @type GasFeeState

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,6 @@ export {
   BaseController as BaseControllerV2,
   getPersistentState,
   getAnonymizedState,
-  IsJsonable,
   Json,
   StateDeriver,
   StateMetadata,


### PR DESCRIPTION
This removes the `IsJsonable` utility type from `BaseControllerV2`. We can get away with just using the `Json` type, and requiring that state generics extend `Record<string, Json>`.

With this change, `BaseControllerV2` state types may not contain any interfaces. Controllers that were using interfaces have been updated.