### PR TITLE
use ethjs-unit for unit conversions

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "eth-sig-util": "^3.0.0",
     "ethereumjs-util": "^7.0.10",
     "ethereumjs-wallet": "^1.0.1",
+    "ethjs-unit": "^0.1.6",
     "ethjs-util": "^0.1.6",
     "human-standard-collectible-abi": "^1.0.2",
     "human-standard-token-abi": "^2.0.0",

--- a/src/dependencies.d.ts
+++ b/src/dependencies.d.ts
@@ -18,6 +18,8 @@ declare module 'ethjs-provider-http';
 
 declare module 'ethjs-util';
 
+declare module 'ethjs-unit';
+
 declare module 'human-standard-collectible-abi';
 
 declare module 'human-standard-token-abi';

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -141,6 +141,35 @@ describe('util', () => {
     });
   });
 
+  describe('hexWei', () => {
+    it('should convert a whole number to WEI', () => {
+      const numbersInGwei = [1, 123, 101, 1234];
+      numbersInGwei.forEach((gweiDec) => {
+        expect(
+          util.weiHexToGweiDec(util.gweiDecToWEIBN(gweiDec).toString(16)),
+        ).toBe(gweiDec.toString());
+      });
+    });
+
+    it('should convert a number with a decimal part to WEI', () => {
+      const numbersInGwei = [1.1, 123.01, 101.001, 1234.567];
+      numbersInGwei.forEach((gweiDec) => {
+        expect(
+          util.weiHexToGweiDec(util.gweiDecToWEIBN(gweiDec).toString(16)),
+        ).toBe(gweiDec.toString());
+      });
+    });
+
+    it('should convert a number < 1 to WEI', () => {
+      const numbersInGwei = [0.1, 0.01, 0.001, 0.567];
+      numbersInGwei.forEach((gweiDec) => {
+        expect(
+          util.weiHexToGweiDec(util.gweiDecToWEIBN(gweiDec).toString(16)),
+        ).toBe(gweiDec.toString());
+      });
+    });
+  });
+
   describe('safelyExecute', () => {
     it('should swallow errors', async () => {
       expect(

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,6 +7,7 @@ import {
   toChecksumAddress,
 } from 'ethereumjs-util';
 import { stripHexPrefix } from 'ethjs-util';
+import { fromWei, toWei } from 'ethjs-unit';
 import { ethErrors } from 'eth-rpc-errors';
 import ensNamehash from 'eth-ens-namehash';
 import { TYPED_MESSAGE_SCHEMA, typedSignatureHash } from 'eth-sig-util';
@@ -62,8 +63,6 @@ export function fractionBN(
   return targetBN.mul(numBN).div(denomBN);
 }
 
-const BN_1GWEI_IN_WEI = new BN(1000000000, 10);
-
 /**
  * Used to convert a base-10 number from GWEI to WEI. Can handle numbers with decimal parts
  *
@@ -71,16 +70,20 @@ const BN_1GWEI_IN_WEI = new BN(1000000000, 10);
  * @returns - The number in WEI, as a BN
  */
 export function gweiDecToWEIBN(n: number | string) {
-  const wholePart = Math.floor(Number(n));
-  const decimalPartMatch = Number(n)
-    .toFixed(9)
-    .match(/\.(\d+)/u);
-  const decimalPart = decimalPartMatch ? decimalPartMatch[1] : '0';
+  if (Number.isNaN(n)) {
+    return new BN(0);
+  }
+  return toWei(n.toString(), 'gwei');
+}
 
-  const wholePartAsWEI = new BN(wholePart, 10).mul(BN_1GWEI_IN_WEI);
-  const decimalPartAsWEI = new BN(decimalPart, 10);
-
-  return wholePartAsWEI.add(decimalPartAsWEI);
+/**
+ * Used to convert values from wei hex format to dec gwei format
+ * @param hex - value in hex wei
+ * @returns - value in dec gwei as string
+ */
+export function weiHexToGweiDec(hex: string) {
+  const hexWei = new BN(hex, 16);
+  return fromWei(hexWei, 'gwei').toString(10);
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3036,7 +3036,7 @@ ethjs-schema@0.2.1:
   resolved "https://registry.yarnpkg.com/ethjs-schema/-/ethjs-schema-0.2.1.tgz#47e138920421453617069034684642e26bb310f4"
   integrity sha512-DXd8lwNrhT9sjsh/Vd2Z+4pfyGxhc0POVnLBUfwk5udtdoBzADyq+sK39dcb48+ZU+2VgtwHxtGWnLnCfmfW5g==
 
-ethjs-unit@0.1.6:
+ethjs-unit@0.1.6, ethjs-unit@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ethjs-unit/-/ethjs-unit-0.1.6.tgz#c665921e476e87bce2a9d588a6fe0405b2c41699"
   integrity sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=


### PR DESCRIPTION
I needed a hex wei to dec gwei conversion utility and i didn't see one existed. I also saw we already have ethjs-unit included as dependency of a dependency, this is what web3.js uses for its .toWei/.fromWei functions...

It uses BN under the hood but is far more robust than our utilities. 