### PR TITLE
Add metaswaps API and normalize all gas fee units to dec gwei

### DIFF
--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -309,9 +309,9 @@ export class GasFeeController extends BaseController<typeof name, GasFeeState> {
       try {
         estimates = await this.fetchEthGasPriceEstimate(this.ethQuery);
         gasEstimateType = GAS_ESTIMATE_TYPES.ETH_GASPRICE;
-      } catch (error2) {
+      } catch (error) {
         throw new Error(
-          `Gas fee/price estimation failed. Message: ${error2.message}`,
+          `Gas fee/price estimation failed. Message: ${error.message}`,
         );
       }
     }

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -305,7 +305,7 @@ export class GasFeeController extends BaseController<typeof name, GasFeeState> {
       } else {
         throw new Error('Main gas fee/price estimation failed. Use fallback');
       }
-    } catch (error) {
+    } catch {
       try {
         estimates = await this.fetchEthGasPriceEstimate(this.ethQuery);
         gasEstimateType = GAS_ESTIMATE_TYPES.ETH_GASPRICE;

--- a/src/gas/gas-util.test.ts
+++ b/src/gas/gas-util.test.ts
@@ -1,0 +1,28 @@
+import nock from 'nock';
+import {
+  EXTERNAL_GAS_PRICES_API_URL,
+  fetchLegacyGasPriceEstimates,
+} from './gas-util';
+
+describe('gas utils', () => {
+  describe('fetchLegacyGasPriceEstimates', () => {
+    it('should fetch external gasPrices and return high/medium/low', async () => {
+      const scope = nock(EXTERNAL_GAS_PRICES_API_URL)
+        .get(/.+/u)
+        .reply(200, {
+          SafeGasPrice: '22',
+          ProposeGasPrice: '25',
+          FastGasPrice: '30',
+        })
+        .persist();
+      const result = await fetchLegacyGasPriceEstimates();
+      expect(result).toMatchObject({
+        high: '30',
+        medium: '25',
+        low: '22',
+      });
+      scope.done();
+      nock.cleanAll();
+    });
+  });
+});


### PR DESCRIPTION
### Breaking changes
1. must supply new method 'getIsMainnet' that will be called when polling to determine if, in the absence of EIP-1559 compatibility, the metaswaps API should be hit for gas estimates.
2. the old `fetchLegacyGasPriceEstimate` has been renamed to `fetchEthGasPriceEstimate` because eth_gasPrice is not legacy, it is just a fall back.
3. a new `fetchLegacyGasPriceEstimates` (note plurality Estimate**s**) is the method that will return metaswaps API estimates.


### Non Breaking Changes
1. gasEstimateType will be returned in state as well, and can be any of 'none' | 'legacy' | 'fee-market' or 'eth_gasPrice'. A constant is exported to prevent issues with string typos. 
2. when receiving a gasPrice from eth_gasPrice the result will be returned in dec gwei instead of hex wei. 