### PR TITLE
Add changelog validation to CI

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -35,6 +35,12 @@ jobs:
       - run: yarn build
       - run: yarn lint
       - run: yarn test --maxWorkers=1
+      - name: Validate RC changelog
+        if: ${{ startsWith(github.ref, 'release/') }}
+        run: yarn auto-changelog validate --rc
+      - name: Validate changelog
+        if: ${{ !startsWith(github.ref, 'release/') }}
+        run: yarn auto-changelog validate
   all-jobs-pass:
     name: All jobs pass
     runs-on: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ First, `yarn build:link` in this repository, then link `@metamask/controllers` b
 
 The project follows the same release process as the other libraries in the MetaMask organization:
 
-1. Create a release branch
+1. Create a release branch named `release/v[version]` (e.g. `release/v10.0.0`)
    - For a typical release, this would be based on `main`
    - To update an older maintained major version, base the release branch on the major version branch (e.g. `1.x`)
 2. Update the changelog
@@ -287,7 +287,7 @@ The project follows the same release process as the other libraries in the MetaM
 4. Create a pull request targeting the base branch (e.g. `main` or `1.x`)
 5. Code review and QA
 6. Once approved, the PR is squashed & merged
-7. The commit on the base branch is tagged
+7. The commit on the base branch is tagged as `v[version]` (e.g. `v10.0.0`)
 8. The tag can be published as needed
 
 ## License

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/MetaMask/controllers#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/MetaMask/controllers.git"
+    "url": "https://github.com/MetaMask/controllers.git"
   },
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
The changelog is now validated during CI. The validation differs depending on whether the branch is a release branch or not, so the README was updated to clarify what naming convention we're now using for release branches.

The `repository` entry in `package.json` was updated to use HTTPS, because that is the format supported by `auto-changelog`.