### PR TITLE
make more configurable

### DIFF
--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -2,7 +2,7 @@ import type { Patch } from 'immer';
 
 import EthQuery from 'eth-query';
 import { v1 as random } from 'uuid';
-import { addHexPrefix, isHexString } from 'ethereumjs-util';
+import { isHexString } from 'ethereumjs-util';
 import { BaseController } from '../BaseControllerV2';
 import { safelyExecute } from '../util';
 import type { RestrictedControllerMessenger } from '../ControllerMessenger';
@@ -256,7 +256,7 @@ export class GasFeeController extends BaseController<typeof name, GasFeeState> {
     getCurrentNetworkEIP1559Compatibility: () => Promise<boolean>;
     getCurrentNetworkLegacyGasAPICompatibility: () => boolean;
     getCurrentAccountEIP1559Compatibility?: () => boolean;
-    getChainId: () => `0x${string}` | number;
+    getChainId: () => `0x${string}` | `${number}` | number;
     getProvider: () => NetworkController['provider'];
     onNetworkStateChange: (listener: (state: NetworkState) => void) => void;
     legacyAPIEndpoint?: string;
@@ -316,7 +316,7 @@ export class GasFeeController extends BaseController<typeof name, GasFeeState> {
     const isLegacyGasAPICompatible = this.getCurrentNetworkLegacyGasAPICompatibility();
 
     let chainId = this.getChainId();
-    if (typeof chainId === 'string' && isHexString(addHexPrefix(chainId))) {
+    if (typeof chainId === 'string' && isHexString(chainId)) {
       chainId = parseInt(chainId, 16);
     }
     try {

--- a/src/gas/gas-util.test.ts
+++ b/src/gas/gas-util.test.ts
@@ -1,13 +1,10 @@
 import nock from 'nock';
-import {
-  EXTERNAL_GAS_PRICES_API_URL,
-  fetchLegacyGasPriceEstimates,
-} from './gas-util';
+import { fetchLegacyGasPriceEstimates } from './gas-util';
 
 describe('gas utils', () => {
   describe('fetchLegacyGasPriceEstimates', () => {
     it('should fetch external gasPrices and return high/medium/low', async () => {
-      const scope = nock(EXTERNAL_GAS_PRICES_API_URL)
+      const scope = nock('https://not-a-real-url/')
         .get(/.+/u)
         .reply(200, {
           SafeGasPrice: '22',
@@ -15,7 +12,9 @@ describe('gas utils', () => {
           FastGasPrice: '30',
         })
         .persist();
-      const result = await fetchLegacyGasPriceEstimates();
+      const result = await fetchLegacyGasPriceEstimates(
+        'https://not-a-real-url/',
+      );
       expect(result).toMatchObject({
         high: '30',
         medium: '25',

--- a/src/gas/gas-util.ts
+++ b/src/gas/gas-util.ts
@@ -8,20 +8,19 @@ import {
   LegacyGasPriceEstimate,
 } from './GasFeeController';
 
-const GAS_FEE_API = 'https://mock-gas-server.herokuapp.com/';
-export const EXTERNAL_GAS_PRICES_API_URL = `https://api.metaswap.codefi.network/gasPrices`;
-
-export async function fetchGasEstimates(): Promise<GasFeeEstimates> {
-  return await handleFetch(GAS_FEE_API);
+export async function fetchGasEstimates(url: string): Promise<GasFeeEstimates> {
+  return await handleFetch(url);
 }
 
 /**
  * Hit the legacy MetaSwaps gasPrices estimate api and return the low, medium
  * high values from that API.
  */
-export async function fetchLegacyGasPriceEstimates(): Promise<LegacyGasPriceEstimate> {
-  const result = await handleFetch(EXTERNAL_GAS_PRICES_API_URL, {
-    referrer: EXTERNAL_GAS_PRICES_API_URL,
+export async function fetchLegacyGasPriceEstimates(
+  url: string,
+): Promise<LegacyGasPriceEstimate> {
+  const result = await handleFetch(url, {
+    referrer: url,
     referrerPolicy: 'no-referrer-when-downgrade',
     method: 'GET',
     mode: 'cors',


### PR DESCRIPTION
This PR does the following:

1. renames 'getIsMainnet' to 'getCurrentNetworkLegacyGasAPICompatibility'
2. adds a 'getChainId' argument to the controller
3. adds support for providing API endpoint URLs int the controller
4. Supports replacing `<chain_id>` in provided URLs.

Goals:
1. Presumably if the API meets the spec put together in our mock data, we can swap out URLs without rebuilding/re-releasing
2. Support networks like Binance that has its own gas estimation API. 