### PR TITLE
Adding a fallback for tokenList API service based on user preference

### DIFF
--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -142,6 +142,7 @@ describe('ComposableController', () => {
           ipfsGateway: 'https://ipfs.io/ipfs/',
           lostIdentities: {},
           selectedAddress: '',
+          useStaticTokenList: false,
         },
       });
     });
@@ -192,6 +193,7 @@ describe('ComposableController', () => {
         properties: { isEIP1559Compatible: false },
         provider: { type: 'mainnet', chainId: NetworksChainId.mainnet },
         selectedAddress: '',
+        useStaticTokenList: false,
         suggestedAssets: [],
         tokens: [],
       });

--- a/src/assets/AssetsDetectionController.test.ts
+++ b/src/assets/AssetsDetectionController.test.ts
@@ -132,7 +132,7 @@ describe('AssetsDetectionController', () => {
     const messenger = getTokenListMessenger();
     tokenList = new TokenListController({
       chainId: NetworksChainId.mainnet,
-      useDynamicTokenList: true,
+      useStaticTokenList: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       messenger,

--- a/src/assets/AssetsDetectionController.test.ts
+++ b/src/assets/AssetsDetectionController.test.ts
@@ -132,7 +132,9 @@ describe('AssetsDetectionController', () => {
     const messenger = getTokenListMessenger();
     tokenList = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      useDynamicTokenList: true,
       onNetworkStateChange: (listener) => network.subscribe(listener),
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       messenger,
     });
     await tokenList.start();

--- a/src/assets/TokenListController.test.ts
+++ b/src/assets/TokenListController.test.ts
@@ -907,7 +907,7 @@ describe('TokenListController', () => {
     controller.destroy();
   });
 
-it('should use static token list when useStaticTokenList flag is set to true', async () => {
+  it('should use static token list when useStaticTokenList flag is set to true', async () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,

--- a/src/assets/TokenListController.test.ts
+++ b/src/assets/TokenListController.test.ts
@@ -907,7 +907,7 @@ describe('TokenListController', () => {
     controller.destroy();
   });
 
-  it('should use static token list when useStaticTokenList flag is disabled', async () => {
+it('should use static token list when useStaticTokenList flag is set to true', async () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,

--- a/src/assets/TokenListController.test.ts
+++ b/src/assets/TokenListController.test.ts
@@ -6,7 +6,7 @@ import {
   NetworkController,
   NetworksChainId,
 } from '../network/NetworkController';
-import PreferencesController from '../user/PreferencesController';
+import { PreferencesController } from '../user/PreferencesController';
 import {
   TokenListController,
   TokenListStateChange,
@@ -1016,7 +1016,7 @@ describe('TokenListController', () => {
     preferences.update({
       useStaticTokenList: false,
     });
-    await new Promise<void>((resolve) => setTimeout(() => resolve(), 50));
+    await new Promise<void>((resolve) => setTimeout(() => resolve(), 10));
     expect(controller.state.tokenList).toStrictEqual(
       sampleTwoChainState.tokenList,
     );

--- a/src/assets/TokenListController.test.ts
+++ b/src/assets/TokenListController.test.ts
@@ -965,7 +965,7 @@ it('should use static token list when useStaticTokenList flag is set to true', a
     controller.destroy();
   });
 
-  it('should switch between static and dynamic list when the prefernce change after network change', async () => {
+  it('should switch between static and dynamic list when the preference change after network change', async () => {
     nock(TOKEN_END_POINT_API)
       .get(`/tokens/${NetworksChainId.mainnet}`)
       .reply(200, sampleMainnetTokenList)

--- a/src/assets/TokenListController.test.ts
+++ b/src/assets/TokenListController.test.ts
@@ -925,7 +925,7 @@ it('should use static token list when useStaticTokenList flag is set to true', a
     controller.destroy();
   });
 
-  it('should switch between static and dynamic list based on the prefernce change', async () => {
+  it('should switch between static and dynamic list based on the preference change', async () => {
     nock(TOKEN_END_POINT_API)
       .get(`/tokens/${NetworksChainId.mainnet}`)
       .reply(200, sampleMainnetTokenList)

--- a/src/assets/TokenListController.test.ts
+++ b/src/assets/TokenListController.test.ts
@@ -1,10 +1,12 @@
 import { stub } from 'sinon';
 import nock from 'nock';
+import contractmap from '@metamask/contract-metadata';
 import { ControllerMessenger } from '../ControllerMessenger';
 import {
   NetworkController,
   NetworksChainId,
 } from '../network/NetworkController';
+import PreferencesController from '../user/PreferencesController';
 import {
   TokenListController,
   TokenListStateChange,
@@ -15,6 +17,13 @@ const name = 'TokenListController';
 const TOKEN_END_POINT_API = 'https://token-api.airswap-prod.codefi.network';
 const timestamp = Date.now();
 
+const staticTokenList: any = {};
+for (const tokenAddress in contractmap) {
+  const { erc20, logo, ...token } = contractmap[tokenAddress];
+  if (erc20) {
+    staticTokenList[tokenAddress] = { ...token, iconUrl: logo };
+  }
+}
 const sampleMainnetTokenList = [
   {
     address: '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f',
@@ -464,8 +473,10 @@ function getRestrictedMessenger() {
 
 describe('TokenListController', () => {
   let network: NetworkController;
+  let preferences: PreferencesController;
   beforeEach(() => {
     network = new NetworkController();
+    preferences = new PreferencesController();
   });
   afterEach(() => {
     nock.cleanAll();
@@ -475,7 +486,9 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      useStaticTokenList: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       messenger,
     });
 
@@ -491,7 +504,9 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      useStaticTokenList: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       messenger,
       state: existingState,
     });
@@ -534,7 +549,9 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      useStaticTokenList: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       interval: 100,
       messenger,
     });
@@ -551,7 +568,9 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      useStaticTokenList: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       interval: 100,
       messenger,
     });
@@ -573,7 +592,9 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      useStaticTokenList: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       interval: 100,
       messenger,
     });
@@ -597,7 +618,9 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      useStaticTokenList: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       interval: 100,
       messenger,
     });
@@ -626,7 +649,9 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      useStaticTokenList: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       messenger,
     });
     await controller.start();
@@ -660,7 +685,9 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      useStaticTokenList: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       messenger,
       interval: 100,
     });
@@ -681,7 +708,9 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      useStaticTokenList: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       messenger,
       state: existingState,
     });
@@ -699,7 +728,9 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      useStaticTokenList: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       messenger,
     });
     await controller.start();
@@ -740,7 +771,9 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      useStaticTokenList: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       messenger,
     });
     await controller.start();
@@ -790,7 +823,9 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      useStaticTokenList: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       messenger,
       state: outdatedExistingState,
     });
@@ -808,7 +843,9 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      useStaticTokenList: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       messenger,
       state: expiredCacheExistingState,
     });
@@ -838,7 +875,9 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      useStaticTokenList: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       messenger,
       state: existingState,
       interval: 100,
@@ -863,6 +902,129 @@ describe('TokenListController', () => {
     );
     expect(controller.state.tokensChainsCache['56'].data).toStrictEqual(
       sampleTwoChainState.tokensChainsCache['56'].data,
+    );
+
+    controller.destroy();
+  });
+
+  it('should use static token list when useStaticTokenList flag is disabled', async () => {
+    const messenger = getRestrictedMessenger();
+    const controller = new TokenListController({
+      chainId: NetworksChainId.mainnet,
+      useStaticTokenList: true,
+      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
+      messenger,
+      state: existingState,
+      interval: 100,
+    });
+    await controller.start();
+    expect(controller.state.tokenList).toStrictEqual(staticTokenList);
+    expect(controller.state.tokensChainsCache).toStrictEqual({});
+
+    controller.destroy();
+  });
+
+  it('should switch between static and dynamic list based on the prefernce change', async () => {
+    nock(TOKEN_END_POINT_API)
+      .get(`/tokens/${NetworksChainId.mainnet}`)
+      .reply(200, sampleMainnetTokenList)
+      .persist();
+    const messenger = getRestrictedMessenger();
+    const controller = new TokenListController({
+      chainId: NetworksChainId.mainnet,
+      useStaticTokenList: false,
+      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
+      messenger,
+      interval: 100,
+    });
+    await controller.start();
+    expect(controller.state.tokenList).toStrictEqual(
+      sampleSingleChainState.tokenList,
+    );
+
+    preferences.update({
+      useStaticTokenList: true,
+    });
+    await new Promise<void>((resolve) => setTimeout(() => resolve(), 50));
+    expect(controller.state.tokenList).toStrictEqual(staticTokenList);
+    expect(controller.state.tokensChainsCache).toStrictEqual({});
+
+    preferences.update({
+      useStaticTokenList: false,
+    });
+    await new Promise<void>((resolve) => setTimeout(() => resolve(), 50));
+    expect(controller.state.tokenList).toStrictEqual(
+      sampleSingleChainState.tokenList,
+    );
+    expect(
+      controller.state.tokensChainsCache[NetworksChainId.mainnet].data,
+    ).toStrictEqual(sampleMainnetTokenList);
+
+    controller.destroy();
+  });
+
+  it('should switch between static and dynamic list when the prefernce change after network change', async () => {
+    nock(TOKEN_END_POINT_API)
+      .get(`/tokens/${NetworksChainId.mainnet}`)
+      .reply(200, sampleMainnetTokenList)
+      .get(`/tokens/56`)
+      .reply(200, sampleBinanceTokenList)
+      .persist();
+    const messenger = getRestrictedMessenger();
+    const controller = new TokenListController({
+      chainId: NetworksChainId.mainnet,
+      useStaticTokenList: false,
+      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
+      messenger,
+      interval: 100,
+    });
+    await controller.start();
+    expect(controller.state.tokenList).toStrictEqual(
+      sampleSingleChainState.tokenList,
+    );
+    expect(
+      controller.state.tokensChainsCache[NetworksChainId.mainnet].data,
+    ).toStrictEqual(sampleMainnetTokenList);
+
+    network.update({
+      provider: {
+        type: 'rpc',
+        chainId: '56',
+      },
+    });
+    await new Promise<void>((resolve) => setTimeout(() => resolve(), 10));
+    expect(controller.state.tokenList).toStrictEqual(
+      sampleTwoChainState.tokenList,
+    );
+    expect(
+      controller.state.tokensChainsCache[NetworksChainId.mainnet].data,
+    ).toStrictEqual(sampleMainnetTokenList);
+    expect(controller.state.tokensChainsCache['56'].data).toStrictEqual(
+      sampleBinanceTokenList,
+    );
+
+    preferences.update({
+      useStaticTokenList: true,
+    });
+    await new Promise<void>((resolve) => setTimeout(() => resolve(), 10));
+    expect(controller.state.tokenList).toStrictEqual(staticTokenList);
+    expect(controller.state.tokensChainsCache).toStrictEqual({});
+
+    preferences.update({
+      useStaticTokenList: false,
+    });
+    await new Promise<void>((resolve) => setTimeout(() => resolve(), 50));
+    expect(controller.state.tokenList).toStrictEqual(
+      sampleTwoChainState.tokenList,
+    );
+    expect(
+      controller.state.tokensChainsCache[NetworksChainId.mainnet],
+    ).toBeUndefined();
+    expect(controller.state.tokensChainsCache['56'].data).toStrictEqual(
+      sampleBinanceTokenList,
     );
 
     controller.destroy();
@@ -910,7 +1072,9 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      useStaticTokenList: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       messenger,
       interval: 200,
     });
@@ -959,7 +1123,9 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      useStaticTokenList: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       messenger,
     });
     const tokenMeta = await controller.fetchTokenMetadata(

--- a/src/user/PreferencesController.test.ts
+++ b/src/user/PreferencesController.test.ts
@@ -10,6 +10,7 @@ describe('PreferencesController', () => {
       ipfsGateway: 'https://ipfs.io/ipfs/',
       lostIdentities: {},
       selectedAddress: '',
+      useStaticTokenList: false,
     });
   });
 
@@ -207,5 +208,11 @@ describe('PreferencesController', () => {
     expect(controller.state.selectedAddress).toStrictEqual(
       '0x95D2bC047B0dDEc1E4A178EeB64d59F5E735cd0A',
     );
+  });
+
+  it('should set useStaticTokenList', () => {
+    const controller = new PreferencesController();
+    controller.setUseStaticTokenList(true);
+    expect(controller.state.useStaticTokenList).toStrictEqual(true);
   });
 });

--- a/src/user/PreferencesController.ts
+++ b/src/user/PreferencesController.ts
@@ -46,6 +46,7 @@ export interface PreferencesState extends BaseState {
   identities: { [address: string]: ContactEntry };
   lostIdentities: { [address: string]: ContactEntry };
   selectedAddress: string;
+  useStaticTokenList: boolean;
 }
 
 /**
@@ -75,6 +76,7 @@ export class PreferencesController extends BaseController<
       ipfsGateway: 'https://ipfs.io/ipfs/',
       lostIdentities: {},
       selectedAddress: '',
+      useStaticTokenList: false,
     };
     this.initialize();
   }
@@ -282,6 +284,15 @@ export class PreferencesController extends BaseController<
    */
   setIpfsGateway(ipfsGateway: string) {
     this.update({ ipfsGateway });
+  }
+
+  /**
+   * Toggle the token detection setting to use dynamic token list
+   *
+   * @param useStaticTokenList - IPFS gateway string
+   */
+  setUseStaticTokenList(useStaticTokenList: boolean) {
+    this.update({ useStaticTokenList });
   }
 }
 


### PR DESCRIPTION
If the user does not want to use the token service API to get the token details, this fallback to fetch from the `contract-metadata` will be called. The value of `useStaticTokenList` will determine which token list will be loaded to the TokenListcontroller state, the true value of which will call the Static token list from the `contract-metadata`, and a false value will fetch the token list from token service API. The cache will be stored only for when the token service API is used, when the user switch to the static token list the cache will be cleared.

