### PR TITLE
adding ERC721 detection to TokensController

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eth-sig-util": "^3.0.0",
     "ethereumjs-util": "^7.0.10",
     "ethereumjs-wallet": "^1.0.1",
+    "ethers": "^5.4.1",
     "ethjs-unit": "^0.1.6",
     "ethjs-util": "^0.1.6",
     "human-standard-collectible-abi": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/controllers",
-  "version": "13.0.0-96b5e2d",
+  "version": "13.0.0",
   "description": "Collection of platform-agnostic modules for creating secure data models for cryptocurrency wallets",
   "keywords": [
     "MetaMask",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/controllers",
-  "version": "13.0.0",
+  "version": "13.0.0-96b5e2d",
   "description": "Collection of platform-agnostic modules for creating secure data models for cryptocurrency wallets",
   "keywords": [
     "MetaMask",

--- a/src/assets/AssetsDetectionController.test.ts
+++ b/src/assets/AssetsDetectionController.test.ts
@@ -580,6 +580,7 @@ describe('AssetsDetectionController', () => {
         symbol: 'GNO',
         decimals: 18,
         image: undefined,
+        isERC721: false,
       },
     ]);
   });
@@ -595,6 +596,7 @@ describe('AssetsDetectionController', () => {
         decimals: 18,
         image: undefined,
         symbol: 'GNO',
+        isERC721: false,
       },
     ]);
     getBalancesInSingleCall.resolves({
@@ -607,12 +609,14 @@ describe('AssetsDetectionController', () => {
         decimals: 18,
         image: undefined,
         symbol: 'GNO',
+        isERC721: false,
       },
       {
         address: '0x514910771AF9Ca656af840dff83E8264EcF986CA',
         symbol: 'LINK',
         decimals: 18,
         image: undefined,
+        isERC721: false,
       },
     ]);
   });

--- a/src/assets/AssetsDetectionController.test.ts
+++ b/src/assets/AssetsDetectionController.test.ts
@@ -255,6 +255,9 @@ describe('AssetsDetectionController', () => {
           },
         ],
       });
+    stub(tokensController, '_detectIsERC721').callsFake(() =>
+      Promise.resolve(false),
+    );
   });
 
   afterEach(() => {

--- a/src/assets/AssetsDetectionController.test.ts
+++ b/src/assets/AssetsDetectionController.test.ts
@@ -671,6 +671,8 @@ describe('AssetsDetectionController', () => {
   });
 
   it('should subscribe to new sibling detecting assets when account changes', async () => {
+      stub(tokensController, '_instantiateNewEthersProvider')
+      .callsFake(() => {});
     const firstNetworkType = 'rinkeby';
     const secondNetworkType = 'mainnet';
     const firstAddress = '0x123';

--- a/src/assets/AssetsDetectionController.test.ts
+++ b/src/assets/AssetsDetectionController.test.ts
@@ -671,8 +671,9 @@ describe('AssetsDetectionController', () => {
   });
 
   it('should subscribe to new sibling detecting assets when account changes', async () => {
-      stub(tokensController, '_instantiateNewEthersProvider')
-      .callsFake(() => {});
+    stub(tokensController, '_instantiateNewEthersProvider').callsFake(
+      () => null,
+    );
     const firstNetworkType = 'rinkeby';
     const secondNetworkType = 'mainnet';
     const firstAddress = '0x123';

--- a/src/assets/TokenRatesController.ts
+++ b/src/assets/TokenRatesController.ts
@@ -45,6 +45,7 @@ export interface Token {
   symbol: string;
   image?: string;
   balanceError?: Error | null;
+  isERC721?: boolean;
 }
 
 /**

--- a/src/assets/TokensController.test.ts
+++ b/src/assets/TokensController.test.ts
@@ -403,10 +403,6 @@ describe('TokensController', () => {
         );
     });
 
-    afterEach(function () {
-      sinon.restore();
-    });
-
     it('should error if passed no type', async function () {
       type = undefined;
       const result = tokensController.watchAsset(asset, type);
@@ -518,20 +514,6 @@ describe('TokensController', () => {
           ...asset,
         },
       ]);
-    });
-    it('should add a valid suggested asset via watchAsset', async () => {
-      await tokensController.watchAsset(
-        {
-          address: '0xe9f786dfdd9ae4d57e830acb52296837765f0e5b',
-          decimals: 18,
-          symbol: 'TKN',
-        },
-        'ERC20',
-      );
-      expect(tokensController.state.suggestedAssets[0].asset.address).toBe(
-        '0xe9f786dfdd9ae4d57e830acb52296837765f0e5b',
-      );
-      expect(tokensController.state.suggestedAssets[0].status).toBe('pending');
     });
 
     it('should fail an invalid type suggested asset via watchAsset', async () => {

--- a/src/assets/TokensController.test.ts
+++ b/src/assets/TokensController.test.ts
@@ -31,7 +31,7 @@ describe('TokensController', () => {
       );
     sinon
       .stub(tokensController, '_instantiateNewEthersProvider')
-      .callsFake(() => {});
+      .callsFake(() => null);
   });
 
   afterEach(() => {
@@ -426,16 +426,20 @@ describe('TokensController', () => {
     });
 
     it('should handle ERC20 type and add to suggestedAssets', async function () {
-      sinon.stub(tokensController, '_generateRandomId').callsFake(() => '12345')
+      sinon
+        .stub(tokensController, '_generateRandomId')
+        .callsFake(() => '12345');
       type = 'ERC20';
       tokensController.watchAsset(asset, type);
-      await expect(tokensController.state.suggestedAssets).toEqual([{
-        id: '12345',
-        status: 'pending',
-        time: 1,
-        type: 'ERC20',
-        asset: asset,
-      }]);
+      await expect(tokensController.state.suggestedAssets).toStrictEqual([
+        {
+          id: '12345',
+          status: 'pending',
+          time: 1,
+          type: 'ERC20',
+          asset,
+        },
+      ]);
     });
   });
 });

--- a/src/assets/TokensController.test.ts
+++ b/src/assets/TokensController.test.ts
@@ -39,7 +39,7 @@ describe('TokensController', () => {
 
   it('should add a token', async () => {
     const supportsInterfaceStub = sinon.stub().returns(Promise.resolve(false));
-    await sinon
+    sinon
       .stub(tokensController, '_createEthersContract')
       .callsFake(() =>
         Promise.resolve({ supportsInterface: supportsInterfaceStub }),
@@ -64,7 +64,7 @@ describe('TokensController', () => {
 
   it('should add tokens', async () => {
     const supportsInterfaceStub = sinon.stub().returns(Promise.resolve(false));
-    await sinon
+    sinon
       .stub(tokensController, '_createEthersContract')
       .callsFake(() =>
         Promise.resolve({ supportsInterface: supportsInterfaceStub }),
@@ -109,7 +109,7 @@ describe('TokensController', () => {
 
   it('should add token by selected address', async () => {
     const supportsInterfaceStub = sinon.stub().returns(Promise.resolve(false));
-    await sinon
+    sinon
       .stub(tokensController, '_createEthersContract')
       .callsFake(() =>
         Promise.resolve({ supportsInterface: supportsInterfaceStub }),
@@ -134,7 +134,7 @@ describe('TokensController', () => {
 
   it('should add token by network', async () => {
     const supportsInterfaceStub = sinon.stub().returns(Promise.resolve(false));
-    await sinon
+    sinon
       .stub(tokensController, '_createEthersContract')
       .callsFake(() =>
         Promise.resolve({ supportsInterface: supportsInterfaceStub }),
@@ -172,7 +172,7 @@ describe('TokensController', () => {
 
   it('should remove token', async () => {
     const supportsInterfaceStub = sinon.stub().returns(Promise.resolve(false));
-    await sinon
+    sinon
       .stub(tokensController, '_createEthersContract')
       .callsFake(() =>
         Promise.resolve({ supportsInterface: supportsInterfaceStub }),
@@ -184,7 +184,7 @@ describe('TokensController', () => {
 
   it('should remove token by selected address', async () => {
     const supportsInterfaceStub = sinon.stub().returns(Promise.resolve(false));
-    await sinon
+    sinon
       .stub(tokensController, '_createEthersContract')
       .callsFake(() =>
         Promise.resolve({ supportsInterface: supportsInterfaceStub }),
@@ -209,7 +209,7 @@ describe('TokensController', () => {
 
   it('should remove token by provider type', async () => {
     const supportsInterfaceStub = sinon.stub().returns(Promise.resolve(false));
-    await sinon
+    sinon
       .stub(tokensController, '_createEthersContract')
       .callsFake(() =>
         Promise.resolve({ supportsInterface: supportsInterfaceStub }),
@@ -260,7 +260,7 @@ describe('TokensController', () => {
 
   it('should not add duplicate tokens to the ignoredToken list', async () => {
     const supportsInterfaceStub = sinon.stub().returns(Promise.resolve(false));
-    await sinon
+    sinon
       .stub(tokensController, '_createEthersContract')
       .callsFake(() =>
         Promise.resolve({ supportsInterface: supportsInterfaceStub }),
@@ -280,7 +280,7 @@ describe('TokensController', () => {
 
   it('should be able to clear the ignoredToken list', async () => {
     const supportsInterfaceStub = sinon.stub().returns(Promise.resolve(false));
-    await sinon
+    sinon
       .stub(tokensController, '_createEthersContract')
       .callsFake(() =>
         Promise.resolve({ supportsInterface: supportsInterfaceStub }),

--- a/src/assets/TokensController.ts
+++ b/src/assets/TokensController.ts
@@ -279,7 +279,6 @@ export class TokensController extends BaseController<
           tokens.push(newEntry);
         }
       });
-
       const addressTokens = allTokens[selectedAddress];
       const newAddressTokens = { ...addressTokens, ...{ [chainId]: tokens } };
       const newAllTokens = {
@@ -319,7 +318,7 @@ export class TokensController extends BaseController<
    *
    * @param {string} tokensAddress - the token contract address.
    * @returns boolean indicating whether the token address passed in supports the EIP-721 interface.
-   * 
+   *
    */
   async _detectIsERC721(tokenAddress: string) {
     const checksumAddress = toChecksumHexAddress(tokenAddress);
@@ -333,15 +332,14 @@ export class TokensController extends BaseController<
       abiERC721,
       this.ethersProvider,
     );
-      
+
     return await tokenContract
       .supportsInterface(ERC721_INTERFACE_ID)
-      .catch((error: { code: string, method: string }) => {
-        if(error.code === "UNPREDICTABLE_GAS_LIMIT"){
+      .catch((error: { code: string; method: string }) => {
+        if (error.code === 'UNPREDICTABLE_GAS_LIMIT') {
           return false;
-        } else {
-          throw error;
         }
+        throw error;
       });
   }
 

--- a/src/assets/TokensController.ts
+++ b/src/assets/TokensController.ts
@@ -501,8 +501,8 @@ export class TokensController extends BaseController<
       return true;
     });
 
-    if(!newIgnoredTokens.find((token: Token) => token.address === address)){
-      newIgnoredTokens.push({address: address, decimals: 0, symbol: ''})
+    if (!newIgnoredTokens.find((token: Token) => token.address === address)) {
+      newIgnoredTokens.push({ address, decimals: 0, symbol: '' });
     }
 
     const addressTokens = allTokens[selectedAddress];

--- a/src/assets/TokensController.ts
+++ b/src/assets/TokensController.ts
@@ -326,7 +326,10 @@ export class TokensController extends BaseController<
     // to check against the contract
     if (contractsMap[checksumAddress]?.erc721 === true) {
       return Promise.resolve(true);
+    } else if (contractsMap[checksumAddress]?.erc20 === true) {
+      return Promise.resolve(false);
     }
+
     const tokenContract = await this._createEthersContract(
       tokenAddress,
       abiERC721,

--- a/src/assets/TokensController.ts
+++ b/src/assets/TokensController.ts
@@ -187,11 +187,15 @@ export class TokensController extends BaseController<
       const { selectedAddress } = this.config;
       const { chainId } = provider;
       this.configure({ chainId });
-      this.ethersProvider = new ethers.providers.Web3Provider(this.config?.provider);
+      this.ethersProvider = this._instantiateNewEthersProvider()
       this.update({
         tokens: allTokens[selectedAddress]?.[chainId] || [],
       });
     });
+  }
+
+  _instantiateNewEthersProvider(): any {
+    return new ethers.providers.Web3Provider(this.config?.provider);
   }
 
   /**
@@ -350,6 +354,9 @@ export class TokensController extends BaseController<
     return tokenContract;
   }
 
+  _generateRandomId(): string{
+    return random()
+  }
   /**
    * Adds a new suggestedAsset to state. Parameters will be validated according to
    * asset type being watched. A `<suggestedAssetMeta.id>:pending` hub event will be emitted once added.
@@ -361,7 +368,7 @@ export class TokensController extends BaseController<
   async watchAsset(asset: Token, type: string): Promise<AssetSuggestionResult> {
     const suggestedAssetMeta = {
       asset,
-      id: random(),
+      id: this._generateRandomId(),
       status: SuggestedAssetStatus.pending as SuggestedAssetStatus.pending,
       time: Date.now(),
       type,
@@ -397,6 +404,7 @@ export class TokensController extends BaseController<
         },
       );
     });
+
     const { suggestedAssets } = this.state;
     suggestedAssets.push(suggestedAssetMeta);
     this.update({ suggestedAssets: [...suggestedAssets] });

--- a/src/assets/TokensController.ts
+++ b/src/assets/TokensController.ts
@@ -332,15 +332,18 @@ export class TokensController extends BaseController<
       abiERC721,
       this.ethersProvider,
     );
-
-    return await tokenContract
-      .supportsInterface(ERC721_INTERFACE_ID)
-      .catch((error: { code: string; method: string }) => {
-        if (error.code === 'UNPREDICTABLE_GAS_LIMIT') {
-          return false;
-        }
-        throw error;
-      });
+    try {
+      return await tokenContract.supportsInterface(ERC721_INTERFACE_ID);
+    } catch (error: any) {
+      // currently error.code === UNPREDICTABLE_GAS_LIMIT is our best way of
+      // determining when a token is ERC20 (or not ERC721 compatible)
+      // its possible this has to do with the fact that ERC20's don't need to
+      // implement the supportsInterface method. But more research should be done here.
+      if (error?.code === 'UNPREDICTABLE_GAS_LIMIT') {
+        return false;
+      }
+      throw error;
+    }
   }
 
   async _createEthersContract(

--- a/src/assets/TokensController.ts
+++ b/src/assets/TokensController.ts
@@ -101,7 +101,6 @@ export class TokensController extends BaseController<
   TokensState
 > {
   private mutex = new Mutex();
-
   private ethersProvider: any;
 
   private failSuggestedAsset(
@@ -142,6 +141,8 @@ export class TokensController extends BaseController<
     {
       onPreferencesStateChange,
       onNetworkStateChange,
+      config,
+      state,
     }: {
       onPreferencesStateChange: (
         listener: (preferencesState: PreferencesState) => void,
@@ -149,25 +150,30 @@ export class TokensController extends BaseController<
       onNetworkStateChange: (
         listener: (networkState: NetworkState) => void,
       ) => void;
+      config?: Partial<TokensConfig>,
+      state?: Partial<TokensState>,
     },
-    config?: Partial<TokensConfig>,
-    state?: Partial<TokensState>,
   ) {
     super(config, state);
+
     this.defaultConfig = {
       networkType: MAINNET,
       selectedAddress: '',
       chainId: '',
       provider: undefined,
+      ...config,
     };
+
     this.defaultState = {
       allTokens: {},
       ignoredTokens: [],
       suggestedAssets: [],
       tokens: [],
+      ...state,
     };
 
     this.initialize();
+
     onPreferencesStateChange(({ selectedAddress }) => {
       const { allTokens } = this.state;
       const { chainId } = this.config;
@@ -181,14 +187,11 @@ export class TokensController extends BaseController<
       const { selectedAddress } = this.config;
       const { chainId } = provider;
       this.configure({ chainId });
+      this.ethersProvider = new ethers.providers.Web3Provider(this.config?.provider);
       this.update({
         tokens: allTokens[selectedAddress]?.[chainId] || [],
       });
     });
-  }
-
-  configureProvider(provider: any) {
-    this.ethersProvider = new ethers.providers.Web3Provider(provider);
   }
 
   /**

--- a/src/assets/TokensController.ts
+++ b/src/assets/TokensController.ts
@@ -101,6 +101,7 @@ export class TokensController extends BaseController<
   TokensState
 > {
   private mutex = new Mutex();
+
   private ethersProvider: any;
 
   private failSuggestedAsset(
@@ -137,23 +138,21 @@ export class TokensController extends BaseController<
    * @param config - Initial options used to configure this controller
    * @param state - Initial state to set on this controller
    */
-  constructor(
-    {
-      onPreferencesStateChange,
-      onNetworkStateChange,
-      config,
-      state,
-    }: {
-      onPreferencesStateChange: (
-        listener: (preferencesState: PreferencesState) => void,
-      ) => void;
-      onNetworkStateChange: (
-        listener: (networkState: NetworkState) => void,
-      ) => void;
-      config?: Partial<TokensConfig>,
-      state?: Partial<TokensState>,
-    },
-  ) {
+  constructor({
+    onPreferencesStateChange,
+    onNetworkStateChange,
+    config,
+    state,
+  }: {
+    onPreferencesStateChange: (
+      listener: (preferencesState: PreferencesState) => void,
+    ) => void;
+    onNetworkStateChange: (
+      listener: (networkState: NetworkState) => void,
+    ) => void;
+    config?: Partial<TokensConfig>;
+    state?: Partial<TokensState>;
+  }) {
     super(config, state);
 
     this.defaultConfig = {
@@ -187,7 +186,7 @@ export class TokensController extends BaseController<
       const { selectedAddress } = this.config;
       const { chainId } = provider;
       this.configure({ chainId });
-      this.ethersProvider = this._instantiateNewEthersProvider()
+      this.ethersProvider = this._instantiateNewEthersProvider();
       this.update({
         tokens: allTokens[selectedAddress]?.[chainId] || [],
       });
@@ -354,9 +353,10 @@ export class TokensController extends BaseController<
     return tokenContract;
   }
 
-  _generateRandomId(): string{
-    return random()
+  _generateRandomId(): string {
+    return random();
   }
+
   /**
    * Adds a new suggestedAsset to state. Parameters will be validated according to
    * asset type being watched. A `<suggestedAssetMeta.id>:pending` hub event will be emitted once added.

--- a/src/assets/TokensController.ts
+++ b/src/assets/TokensController.ts
@@ -500,6 +500,11 @@ export class TokensController extends BaseController<
       }
       return true;
     });
+
+    if(!newIgnoredTokens.find((token: Token) => token.address === address)){
+      newIgnoredTokens.push({address: address, decimals: 0, symbol: ''})
+    }
+
     const addressTokens = allTokens[selectedAddress];
     const newAddressTokens = { ...addressTokens, ...{ [chainId]: newTokens } };
     const newAllTokens = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -447,6 +447,345 @@
     "@ethereumjs/common" "^2.3.1"
     ethereumjs-util "^7.0.10"
 
+"@ethersproject/abi@5.4.0", "@ethersproject/abi@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.4.0.tgz#a6d63bdb3672f738398846d4279fa6b6c9818242"
+  integrity sha512-9gU2H+/yK1j2eVMdzm6xvHSnMxk8waIHQGYCZg5uvAyH0rsAzxkModzBSpbAkAuhKFEovC2S9hM4nPuLym8IZw==
+  dependencies:
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/hash" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+
+"@ethersproject/abstract-provider@5.4.0", "@ethersproject/abstract-provider@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.4.0.tgz#415331031b0f678388971e1987305244edc04e1d"
+  integrity sha512-vPBR7HKUBY0lpdllIn7tLIzNN7DrVnhCLKSzY0l8WAwxz686m/aL7ASDzrVxV93GJtIub6N2t4dfZ29CkPOxgA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/networks" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
+    "@ethersproject/web" "^5.4.0"
+
+"@ethersproject/abstract-signer@5.4.0", "@ethersproject/abstract-signer@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.4.0.tgz#cd5f50b93141ee9f9f49feb4075a0b3eafb57d65"
+  integrity sha512-AieQAzt05HJZS2bMofpuxMEp81AHufA5D6M4ScKwtolj041nrfIbIi8ciNW7+F59VYxXq+V4c3d568Q6l2m8ew==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+
+"@ethersproject/address@5.4.0", "@ethersproject/address@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.4.0.tgz#ba2d00a0f8c4c0854933b963b9a3a9f6eb4a37a3"
+  integrity sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==
+  dependencies:
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/rlp" "^5.4.0"
+
+"@ethersproject/base64@5.4.0", "@ethersproject/base64@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.4.0.tgz#7252bf65295954c9048c7ca5f43e5c86441b2a9a"
+  integrity sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+
+"@ethersproject/basex@5.4.0", "@ethersproject/basex@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.4.0.tgz#0a2da0f4e76c504a94f2b21d3161ed9438c7f8a6"
+  integrity sha512-J07+QCVJ7np2bcpxydFVf/CuYo9mZ7T73Pe7KQY4c1lRlrixMeblauMxHXD0MPwFmUHZIILDNViVkykFBZylbg==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+
+"@ethersproject/bignumber@5.4.0", "@ethersproject/bignumber@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.4.0.tgz#be8dea298c0ec71208ee60f0b245be0761217ad9"
+  integrity sha512-OXUu9f9hO3vGRIPxU40cignXZVaYyfx6j9NNMjebKdnaCL3anCLSSy8/b8d03vY6dh7duCC0kW72GEC4tZer2w==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    bn.js "^4.11.9"
+
+"@ethersproject/bytes@5.4.0", "@ethersproject/bytes@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.4.0.tgz#56fa32ce3bf67153756dbaefda921d1d4774404e"
+  integrity sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==
+  dependencies:
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/constants@5.4.0", "@ethersproject/constants@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.4.0.tgz#ee0bdcb30bf1b532d2353c977bf2ef1ee117958a"
+  integrity sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==
+  dependencies:
+    "@ethersproject/bignumber" "^5.4.0"
+
+"@ethersproject/contracts@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.4.0.tgz#e05fe6bd33acc98741e27d553889ec5920078abb"
+  integrity sha512-hkO3L3IhS1Z3ZtHtaAG/T87nQ7KiPV+/qnvutag35I0IkiQ8G3ZpCQ9NNOpSCzn4pWSW4CfzmtE02FcqnLI+hw==
+  dependencies:
+    "@ethersproject/abi" "^5.4.0"
+    "@ethersproject/abstract-provider" "^5.4.0"
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
+
+"@ethersproject/hash@5.4.0", "@ethersproject/hash@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.4.0.tgz#d18a8e927e828e22860a011f39e429d388344ae0"
+  integrity sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+
+"@ethersproject/hdnode@5.4.0", "@ethersproject/hdnode@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.4.0.tgz#4bc9999b9a12eb5ce80c5faa83114a57e4107cac"
+  integrity sha512-pKxdS0KAaeVGfZPp1KOiDLB0jba11tG6OP1u11QnYfb7pXn6IZx0xceqWRr6ygke8+Kw74IpOoSi7/DwANhy8Q==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/basex" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/pbkdf2" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/sha2" "^5.4.0"
+    "@ethersproject/signing-key" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
+    "@ethersproject/wordlists" "^5.4.0"
+
+"@ethersproject/json-wallets@5.4.0", "@ethersproject/json-wallets@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.4.0.tgz#2583341cfe313fc9856642e8ace3080154145e95"
+  integrity sha512-igWcu3fx4aiczrzEHwG1xJZo9l1cFfQOWzTqwRw/xcvxTk58q4f9M7cjh51EKphMHvrJtcezJ1gf1q1AUOfEQQ==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/hdnode" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/pbkdf2" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/random" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
+    aes-js "3.0.0"
+    scrypt-js "3.0.1"
+
+"@ethersproject/keccak256@5.4.0", "@ethersproject/keccak256@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.4.0.tgz#7143b8eea4976080241d2bd92e3b1f1bf7025318"
+  integrity sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    js-sha3 "0.5.7"
+
+"@ethersproject/logger@5.4.0", "@ethersproject/logger@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.4.0.tgz#f39adadf62ad610c420bcd156fd41270e91b3ca9"
+  integrity sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ==
+
+"@ethersproject/networks@5.4.1", "@ethersproject/networks@^5.4.0":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.4.1.tgz#2ce83b8e42aa85216e5d277a7952d97b6ce8d852"
+  integrity sha512-8SvowCKz9Uf4xC5DTKI8+il8lWqOr78kmiqAVLYT9lzB8aSmJHQMD1GSuJI0CW4hMAnzocpGpZLgiMdzsNSPig==
+  dependencies:
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/pbkdf2@5.4.0", "@ethersproject/pbkdf2@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.4.0.tgz#ed88782a67fda1594c22d60d0ca911a9d669641c"
+  integrity sha512-x94aIv6tiA04g6BnazZSLoRXqyusawRyZWlUhKip2jvoLpzJuLb//KtMM6PEovE47pMbW+Qe1uw+68ameJjB7g==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/sha2" "^5.4.0"
+
+"@ethersproject/properties@5.4.0", "@ethersproject/properties@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.4.0.tgz#38ba20539b44dcc5d5f80c45ad902017dcdbefe7"
+  integrity sha512-7jczalGVRAJ+XSRvNA6D5sAwT4gavLq3OXPuV/74o3Rd2wuzSL035IMpIMgei4CYyBdialJMrTqkOnzccLHn4A==
+  dependencies:
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/providers@5.4.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.4.1.tgz#654267b563b833046b9c9647647cfc8267cb93b4"
+  integrity sha512-p06eiFKz8nu/5Ju0kIX024gzEQIgE5pvvGrBCngpyVjpuLtUIWT3097Agw4mTn9/dEA0FMcfByzFqacBMSgCVg==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.4.0"
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/basex" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/hash" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/networks" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/random" "^5.4.0"
+    "@ethersproject/rlp" "^5.4.0"
+    "@ethersproject/sha2" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
+    "@ethersproject/web" "^5.4.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
+
+"@ethersproject/random@5.4.0", "@ethersproject/random@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.4.0.tgz#9cdde60e160d024be39cc16f8de3b9ce39191e16"
+  integrity sha512-pnpWNQlf0VAZDEOVp1rsYQosmv2o0ITS/PecNw+mS2/btF8eYdspkN0vIXrCMtkX09EAh9bdk8GoXmFXM1eAKw==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/rlp@5.4.0", "@ethersproject/rlp@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.4.0.tgz#de61afda5ff979454e76d3b3310a6c32ad060931"
+  integrity sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/sha2@5.4.0", "@ethersproject/sha2@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.4.0.tgz#c9a8db1037014cbc4e9482bd662f86c090440371"
+  integrity sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    hash.js "1.1.7"
+
+"@ethersproject/signing-key@5.4.0", "@ethersproject/signing-key@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.4.0.tgz#2f05120984e81cf89a3d5f6dec5c68ee0894fbec"
+  integrity sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    bn.js "^4.11.9"
+    elliptic "6.5.4"
+    hash.js "1.1.7"
+
+"@ethersproject/solidity@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.4.0.tgz#1305e058ea02dc4891df18b33232b11a14ece9ec"
+  integrity sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==
+  dependencies:
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/sha2" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+
+"@ethersproject/strings@5.4.0", "@ethersproject/strings@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.4.0.tgz#fb12270132dd84b02906a8d895ae7e7fa3d07d9a"
+  integrity sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/transactions@5.4.0", "@ethersproject/transactions@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.4.0.tgz#a159d035179334bd92f340ce0f77e83e9e1522e0"
+  integrity sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==
+  dependencies:
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/rlp" "^5.4.0"
+    "@ethersproject/signing-key" "^5.4.0"
+
+"@ethersproject/units@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.4.0.tgz#d57477a4498b14b88b10396062c8cbbaf20c79fe"
+  integrity sha512-Z88krX40KCp+JqPCP5oPv5p750g+uU6gopDYRTBGcDvOASh6qhiEYCRatuM/suC4S2XW9Zz90QI35MfSrTIaFg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/wallet@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.4.0.tgz#fa5b59830b42e9be56eadd45a16a2e0933ad9353"
+  integrity sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.4.0"
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/hash" "^5.4.0"
+    "@ethersproject/hdnode" "^5.4.0"
+    "@ethersproject/json-wallets" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/random" "^5.4.0"
+    "@ethersproject/signing-key" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
+    "@ethersproject/wordlists" "^5.4.0"
+
+"@ethersproject/web@5.4.0", "@ethersproject/web@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.4.0.tgz#49fac173b96992334ed36a175538ba07a7413d1f"
+  integrity sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==
+  dependencies:
+    "@ethersproject/base64" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+
+"@ethersproject/wordlists@5.4.0", "@ethersproject/wordlists@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.4.0.tgz#f34205ec3bbc9e2c49cadaee774cf0b07e7573d7"
+  integrity sha512-FemEkf6a+EBKEPxlzeVgUaVSodU7G0Na89jqKjmWMlDB0tomoU8RlEMgUvXyqtrg8N4cwpLh8nyRnm1Nay1isA==
+  dependencies:
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/hash" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz#10602de5570baea82f8afbfa2630b24e7a8cfe5b"
@@ -1225,6 +1564,11 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.0.tgz#e1ad486e6c54501634c6c397c5c121daa383607c"
   integrity sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==
 
+aes-js@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
+  integrity sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=
+
 aes-js@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.1.2.tgz#db9aabde85d5caabbfc0d4f2a4446960f627146a"
@@ -1584,6 +1928,11 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
+
+bech32@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
+  integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
 "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git":
   version "2.0.7"
@@ -2297,7 +2646,7 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-elliptic@^6.4.0, elliptic@^6.4.1, elliptic@^6.5.2:
+elliptic@6.5.4, elliptic@^6.4.0, elliptic@^6.4.1, elliptic@^6.5.2:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
@@ -2980,6 +3329,42 @@ ethereumjs-wallet@^1.0.1:
     scrypt-js "^3.0.1"
     utf8 "^3.0.0"
     uuid "^3.3.2"
+
+ethers@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.4.1.tgz#bcff1e9f45bf1a061bf313ec04e8d9881d2d53f9"
+  integrity sha512-SrcddMdCgP1hukDvCPd87Aipbf4NWjQvdfAbZ65XSZGbfyuYPtIrUJPDH5B1SBRsdlfiEgX3eoz28DdBDzMNFg==
+  dependencies:
+    "@ethersproject/abi" "5.4.0"
+    "@ethersproject/abstract-provider" "5.4.0"
+    "@ethersproject/abstract-signer" "5.4.0"
+    "@ethersproject/address" "5.4.0"
+    "@ethersproject/base64" "5.4.0"
+    "@ethersproject/basex" "5.4.0"
+    "@ethersproject/bignumber" "5.4.0"
+    "@ethersproject/bytes" "5.4.0"
+    "@ethersproject/constants" "5.4.0"
+    "@ethersproject/contracts" "5.4.0"
+    "@ethersproject/hash" "5.4.0"
+    "@ethersproject/hdnode" "5.4.0"
+    "@ethersproject/json-wallets" "5.4.0"
+    "@ethersproject/keccak256" "5.4.0"
+    "@ethersproject/logger" "5.4.0"
+    "@ethersproject/networks" "5.4.1"
+    "@ethersproject/pbkdf2" "5.4.0"
+    "@ethersproject/properties" "5.4.0"
+    "@ethersproject/providers" "5.4.1"
+    "@ethersproject/random" "5.4.0"
+    "@ethersproject/rlp" "5.4.0"
+    "@ethersproject/sha2" "5.4.0"
+    "@ethersproject/signing-key" "5.4.0"
+    "@ethersproject/solidity" "5.4.0"
+    "@ethersproject/strings" "5.4.0"
+    "@ethersproject/transactions" "5.4.0"
+    "@ethersproject/units" "5.4.0"
+    "@ethersproject/wallet" "5.4.0"
+    "@ethersproject/web" "5.4.0"
+    "@ethersproject/wordlists" "5.4.0"
 
 ethjs-abi@0.2.0:
   version "0.2.0"
@@ -3695,7 +4080,7 @@ hash-base@^3.0.0:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
+hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
   integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
@@ -4651,7 +5036,7 @@ js-sha3@0.5.5:
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.5.tgz#baf0c0e8c54ad5903447df96ade7a4a1bca79a4a"
   integrity sha1-uvDA6MVK1ZA0R9+Wreekobynmko=
 
-js-sha3@^0.5.7:
+js-sha3@0.5.7, js-sha3@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.7.tgz#0d4ffd8002d5333aabaf4a23eed2f6374c9f28e7"
   integrity sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=
@@ -6376,7 +6761,7 @@ saxes@^5.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scrypt-js@^3.0.0, scrypt-js@^3.0.1:
+scrypt-js@3.0.1, scrypt-js@^3.0.0, scrypt-js@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
   integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
@@ -7471,6 +7856,11 @@ write-file-atomic@^3.0.0:
     is-typedarray "^1.0.0"
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
+
+ws@7.4.6:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
 ws@^5.1.1:
   version "5.2.3"


### PR DESCRIPTION
Until we support collectibles in the extension, we need the controller that tracks token state to be aware of whether tokens are ERC721, in order to support behavior in the extension that prevents users from attempting to send ERC721 tokens and losing gas in a transaction we cannot execute. 

This PR adds the isERC721 flag to tokens in the TokensController with all of the required methods and wiring to land it in the extension (an upcoming PR in the extension repo).