### PR TITLE
Return nextState and patches from BaseControllerV2.update

### DIFF
--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -67,7 +67,7 @@ class CountController extends BaseController<
       state: Draft<CountControllerState>,
     ) => void | CountControllerState,
   ) {
-    super.update(callback);
+    return super.update(callback);
   }
 
   destroy() {
@@ -158,6 +158,24 @@ describe('BaseController', () => {
     });
 
     expect(controller.state).toStrictEqual({ count: 1 });
+  });
+
+  it('should return next state and patches', () => {
+    const controller = new CountController({
+      messenger: getCountMessenger(),
+      name: 'CountController',
+      state: { count: 0 },
+      metadata: countControllerStateMetadata,
+    });
+
+    const [nextState, patches] = controller.update((draft) => {
+      draft.count += 1;
+    });
+
+    expect(nextState).toStrictEqual(controller.state);
+    expect(patches).toStrictEqual([
+      { op: 'replace', path: ['count'], value: 1 },
+    ]);
   });
 
   it('should throw an error if update callback modifies draft and returns value', () => {

--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -138,11 +138,14 @@ describe('BaseController', () => {
       metadata: countControllerStateMetadata,
     });
 
-    controller.update((draft) => {
+    const patches = controller.update((draft) => {
       draft.count += 1;
     });
 
     expect(controller.state).toStrictEqual({ count: 1 });
+    expect(patches).toStrictEqual([
+      { op: 'replace', path: ['count'], value: 1 },
+    ]);
   });
 
   it('should allow updating state by return a value', () => {
@@ -153,28 +156,13 @@ describe('BaseController', () => {
       metadata: countControllerStateMetadata,
     });
 
-    controller.update(() => {
+    const patches = controller.update(() => {
       return { count: 1 };
     });
 
     expect(controller.state).toStrictEqual({ count: 1 });
-  });
-
-  it('should return next state and patches', () => {
-    const controller = new CountController({
-      messenger: getCountMessenger(),
-      name: 'CountController',
-      state: { count: 0 },
-      metadata: countControllerStateMetadata,
-    });
-
-    const [nextState, patches] = controller.update((draft) => {
-      draft.count += 1;
-    });
-
-    expect(nextState).toStrictEqual(controller.state);
     expect(patches).toStrictEqual([
-      { op: 'replace', path: ['count'], value: 1 },
+      { op: 'replace', path: [], value: { count: 1 } },
     ]);
   });
 

--- a/src/BaseControllerV2.ts
+++ b/src/BaseControllerV2.ts
@@ -208,7 +208,7 @@ export class BaseController<
       nextState as S,
       patches,
     );
-    return [nextState, patches];
+    return patches;
   }
 
   /**

--- a/src/BaseControllerV2.ts
+++ b/src/BaseControllerV2.ts
@@ -208,6 +208,7 @@ export class BaseController<
       nextState as S,
       patches,
     );
+    return [nextState, patches];
   }
 
   /**


### PR DESCRIPTION
Controller implementations may sometimes wish to implement side effects based on state changes. Depending on the implementation, they may have to diff their own state in order to understand what changed. `BaseControllerV2.update` is a protected method that handles patches' value of `immer`'s `produceWithPatches` internally. This PR adds the patches as a return value of `update` to give controller implementations state diffing "for free".