### PR TITLE
Add options to GasFeeController fetchGasFeeEstimates

### DIFF
--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -159,6 +159,10 @@ export type GasFeeStateNoEstimates = {
   gasEstimateType: NoEstimateType;
 };
 
+export interface FetchGasFeeEstimateOptions {
+  shouldUpdateState?: boolean;
+}
+
 /**
  * @type GasFeeState
  *
@@ -288,8 +292,8 @@ export class GasFeeController extends BaseController<typeof name, GasFeeState> {
     });
   }
 
-  async fetchGasFeeEstimates() {
-    return await this._fetchGasFeeEstimateData();
+  async fetchGasFeeEstimates(options?: FetchGasFeeEstimateOptions) {
+    return await this._fetchGasFeeEstimateData(options);
   }
 
   async getGasFeeEstimatesAndStartPolling(
@@ -311,7 +315,10 @@ export class GasFeeController extends BaseController<typeof name, GasFeeState> {
    *
    * @returns GasFeeEstimates
    */
-  async _fetchGasFeeEstimateData(): Promise<GasFeeState | undefined> {
+  async _fetchGasFeeEstimateData(
+    options: FetchGasFeeEstimateOptions = {},
+  ): Promise<GasFeeState | undefined> {
+    const { shouldUpdateState = true } = options;
     let isEIP1559Compatible;
     const isLegacyGasAPICompatible = this.getCurrentNetworkLegacyGasAPICompatibility();
 
@@ -376,10 +383,11 @@ export class GasFeeController extends BaseController<typeof name, GasFeeState> {
         );
       }
     }
-
-    this.update(() => {
-      return newState;
-    });
+    if (shouldUpdateState) {
+      this.update(() => {
+        return newState;
+      });
+    }
 
     return newState;
   }


### PR DESCRIPTION
This PR adds an `options` object to `fetchGasFeeEstimates` and `_fetchGasFeeEstimateData`. Options include `shouldUpdateState: boolean` property to decide wether to update state or not, `true` by default. 