### PR TITLE
Remove uneccessary calls to Collection.set in contoller messenger

### DIFF
--- a/src/ControllerMessenger.ts
+++ b/src/ControllerMessenger.ts
@@ -413,9 +413,9 @@ export class ControllerMessenger<
     let subscribers = this.events.get(eventType);
     if (!subscribers) {
       subscribers = new Set();
+      this.events.set(eventType, subscribers);
     }
     subscribers.add(handler);
-    this.events.set(eventType, subscribers);
   }
 
   /**
@@ -439,7 +439,6 @@ export class ControllerMessenger<
     }
 
     subscribers.delete(handler);
-    this.events.set(eventType, subscribers);
   }
 
   /**


### PR DESCRIPTION
The unrestricted controller messenger implementation contained a couple of unnecessary calls to `Collection.set`. This PR removes them.

Every removed / changed instance consisted of mutating the object value (actually also collections) of some key in a collection, and then setting the key to the same object value. Mutating the object value of a collection does not affect the collection's reference to said object, so those calls were unnecessary.