### PR TITLE
Reset polling onNetworkStateChange

### DIFF
--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -286,10 +286,24 @@ export class GasFeeController extends BaseController<typeof name, GasFeeState> {
 
     const provider = getProvider();
     this.ethQuery = new EthQuery(provider);
-    onNetworkStateChange(() => {
+    onNetworkStateChange(async () => {
       const newProvider = getProvider();
       this.ethQuery = new EthQuery(newProvider);
+      await this.resetPolling();
     });
+  }
+
+  async resetPolling() {
+    if (this.pollTokens.size !== 0) {
+      // restart polling
+      const { getGasFeeEstimatesAndStartPolling } = this;
+      const tokens = Array.from(this.pollTokens);
+      this.stopPolling();
+      await getGasFeeEstimatesAndStartPolling(tokens[0]);
+      tokens.slice(1).forEach((token) => {
+        this.pollTokens.add(token);
+      });
+    }
   }
 
   async fetchGasFeeEstimates(options?: FetchGasFeeEstimateOptions) {


### PR DESCRIPTION
This is to deal with an edge case @danjm discovered where in the extension you can have a transaction in progress (which starts polling) and then if you switch network you're potentially getting the wrong quotes. This resets polling on network change if there's any polling already in progress.