### PR TITLE
Add case insensitive checks for token addresses in collectibles and tokens controllers

### DIFF
--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -383,7 +383,8 @@ export class CollectiblesController extends BaseController<
       const { chainId, selectedAddress } = this.config;
       const existingEntry: Collectible | undefined = collectibles.find(
         (collectible) =>
-          collectible.address === address && collectible.tokenId === tokenId,
+          collectible.address.toLowerCase() === address.toLowerCase() &&
+          collectible.tokenId === tokenId,
       );
       /* istanbul ignore next */
       collectibleMetadata =
@@ -398,7 +399,7 @@ export class CollectiblesController extends BaseController<
         if (differentMetadata) {
           const indexToRemove = collectibles.findIndex(
             (collectible) =>
-              collectible.address === address &&
+              collectible.address.toLowerCase() === address.toLowerCase() &&
               collectible.tokenId === tokenId,
           );
           /* istanbul ignore next */
@@ -452,7 +453,8 @@ export class CollectiblesController extends BaseController<
       const { allCollectibleContracts, collectibleContracts } = this.state;
       const { chainId, selectedAddress } = this.config;
       const existingEntry = collectibleContracts.find(
-        (collectibleContract) => collectibleContract.address === address,
+        (collectibleContract) =>
+          collectibleContract.address.toLowerCase() === address.toLowerCase(),
       );
       if (existingEntry) {
         return collectibleContracts;
@@ -530,7 +532,10 @@ export class CollectiblesController extends BaseController<
     const { chainId, selectedAddress } = this.config;
     const newIgnoredCollectibles = [...ignoredCollectibles];
     const newCollectibles = collectibles.filter((collectible) => {
-      if (collectible.address === address && collectible.tokenId === tokenId) {
+      if (
+        collectible.address.toLowerCase() === address.toLowerCase() &&
+        collectible.tokenId === tokenId
+      ) {
         const alreadyIgnored = newIgnoredCollectibles.find(
           (c) => c.address === address && c.tokenId === tokenId,
         );
@@ -567,7 +572,10 @@ export class CollectiblesController extends BaseController<
     const { chainId, selectedAddress } = this.config;
     const newCollectibles = collectibles.filter(
       (collectible) =>
-        !(collectible.address === address && collectible.tokenId === tokenId),
+        !(
+          collectible.address.toLowerCase() === address.toLowerCase() &&
+          collectible.tokenId === tokenId
+        ),
     );
     const addressCollectibles = allCollectibles[selectedAddress];
     const newAddressCollectibles = {
@@ -595,7 +603,8 @@ export class CollectiblesController extends BaseController<
     const { allCollectibleContracts, collectibleContracts } = this.state;
     const { chainId, selectedAddress } = this.config;
     const newCollectibleContracts = collectibleContracts.filter(
-      (collectibleContract) => !(collectibleContract.address === address),
+      (collectibleContract) =>
+        !(collectibleContract.address.toLowerCase() === address.toLowerCase()),
     );
     const addressCollectibleContracts =
       allCollectibleContracts[selectedAddress];
@@ -744,7 +753,7 @@ export class CollectiblesController extends BaseController<
 
     // If collectible contract was not added, do not add individual collectible
     const collectibleContract = newCollectibleContracts.find(
-      (contract) => contract.address === address,
+      (contract) => contract.address.toLowerCase() === address.toLowerCase(),
     );
     // If collectible contract information, add individual collectible
     if (collectibleContract) {
@@ -767,7 +776,8 @@ export class CollectiblesController extends BaseController<
     this.removeIndividualCollectible(address, tokenId);
     const { collectibles } = this.state;
     const remainingCollectible = collectibles.find(
-      (collectible) => collectible.address === address,
+      (collectible) =>
+        collectible.address.toLowerCase() === address.toLowerCase(),
     );
     if (!remainingCollectible) {
       this.removeCollectibleContract(address);
@@ -785,7 +795,8 @@ export class CollectiblesController extends BaseController<
     this.removeAndIgnoreIndividualCollectible(address, tokenId);
     const { collectibles } = this.state;
     const remainingCollectible = collectibles.find(
-      (collectible) => collectible.address === address,
+      (collectible) =>
+        collectible.address.toLowerCase() === address.toLowerCase(),
     );
     if (!remainingCollectible) {
       this.removeCollectibleContract(address);

--- a/src/assets/TokensController.ts
+++ b/src/assets/TokensController.ts
@@ -219,7 +219,9 @@ export class TokensController extends BaseController<
       const { chainId, selectedAddress } = this.config;
       const isERC721 = await this._detectIsERC721(address);
       const newEntry: Token = { address, symbol, decimals, image, isERC721 };
-      const previousEntry = tokens.find((token) => token.address === address);
+      const previousEntry = tokens.find(
+        (token) => token.address.toLowerCase() === address.toLowerCase(),
+      );
       if (previousEntry) {
         const previousIndex = tokens.indexOf(previousEntry);
         tokens[previousIndex] = newEntry;
@@ -270,7 +272,8 @@ export class TokensController extends BaseController<
           isERC721,
         };
         const previousEntry = tokens.find(
-          (token) => token.address === checksumAddress,
+          (token) =>
+            token.address.toLowerCase() === checksumAddress.toLowerCase(),
         );
         if (previousEntry) {
           const previousIndex = tokens.indexOf(previousEntry);
@@ -306,7 +309,7 @@ export class TokensController extends BaseController<
     const isERC721 = await this._detectIsERC721(tokenAddress);
     const { tokens } = this.state;
     const tokenIndex = tokens.findIndex((token) => {
-      return token.address === tokenAddress;
+      return token.address.toLowerCase() === tokenAddress.toLowerCase();
     });
     tokens[tokenIndex].isERC721 = isERC721;
     this.update({ tokens });
@@ -491,9 +494,9 @@ export class TokensController extends BaseController<
     const { chainId, selectedAddress } = this.config;
     const newIgnoredTokens = [...ignoredTokens];
     const newTokens = tokens.filter((token) => {
-      if (token.address === address) {
+      if (token.address.toLowerCase() === address.toLowerCase()) {
         const alreadyIgnored = newIgnoredTokens.find(
-          (t) => t.address === address,
+          (t) => t.address.toLowerCase() === address.toLowerCase(),
         );
         !alreadyIgnored && newIgnoredTokens.push(token);
         return false;
@@ -501,7 +504,11 @@ export class TokensController extends BaseController<
       return true;
     });
 
-    if (!newIgnoredTokens.find((token: Token) => token.address === address)) {
+    if (
+      !newIgnoredTokens.find(
+        (token: Token) => token.address.toLowerCase() === address.toLowerCase(),
+      )
+    ) {
       newIgnoredTokens.push({ address, decimals: 0, symbol: '' });
     }
 


### PR DESCRIPTION
This seeks to resolve a host of issues that can arise when token addresses with different casing slip through.