### PR TITLE
TokenService improvements

### DIFF
--- a/src/apis/token-service.test.ts
+++ b/src/apis/token-service.test.ts
@@ -164,7 +164,7 @@ describe('FetchtokenList', () => {
   it('should call the api to return the token metadata for eth address provided', async () => {
     nock(TOKEN_END_POINT_API)
       .get(
-        `/tokens/${NetworksChainId.mainnet}?address=0x514910771af9ca656af840dff83e8264ecf986ca`,
+        `/token/${NetworksChainId.mainnet}?address=0x514910771af9ca656af840dff83e8264ecf986ca`,
       )
       .reply(200, sampleToken)
       .persist();

--- a/src/apis/token-service.ts
+++ b/src/apis/token-service.ts
@@ -17,7 +17,7 @@ function getTokenMetadataURL(chainId: string, tokenAddress: string) {
  *
  * @returns - Promise resolving token List
  */
-export async function fetchTokenList(chainId: string): Promise<Object> {
+export async function fetchTokenList(chainId: string): Promise<unknown> {
   const tokenURL = getTokensURL(chainId);
   return queryApi(tokenURL);
 }
@@ -40,7 +40,7 @@ export async function syncTokens(chainId: string): Promise<void> {
 export async function fetchTokenMetadata(
   chainId: string,
   tokenAddress: string,
-): Promise<Object> {
+): Promise<unknown> {
   const tokenMetadataURL = getTokenMetadataURL(chainId, tokenAddress);
   return queryApi(tokenMetadataURL);
 }
@@ -48,9 +48,9 @@ export async function fetchTokenMetadata(
 /**
  * Fetch metadata for the token address provided for a given network chainId
  *
- * @return Promise resolving request response json obj
+ * @return Promise resolving request response json value
  */
-async function queryApi (apiURL: string): Promise<Object> {
+async function queryApi(apiURL: string): Promise<unknown> {
   const fetchOptions: RequestInit = {
     referrer: apiURL,
     referrerPolicy: 'no-referrer-when-downgrade',
@@ -62,7 +62,7 @@ async function queryApi (apiURL: string): Promise<Object> {
   const tokenResponse = await timeoutFetch(apiURL, fetchOptions);
   const responseObj = await tokenResponse.json();
   // api may return errors as json without setting an error http status code
-  if (responseObj.error) {
+  if (responseObj?.error) {
     throw new Error(`TokenService Error: ${responseObj.error}`);
   }
   return responseObj;

--- a/src/apis/token-service.ts
+++ b/src/apis/token-service.ts
@@ -9,7 +9,7 @@ function getTokensURL(chainId: string) {
   return `${END_POINT}/tokens/${chainId}`;
 }
 function getTokenMetadataURL(chainId: string, tokenAddress: string) {
-  return `${END_POINT}/tokens/${chainId}?address=${tokenAddress}`;
+  return `${END_POINT}/token/${chainId}?address=${tokenAddress}`;
 }
 
 /**

--- a/src/apis/token-service.ts
+++ b/src/apis/token-service.ts
@@ -19,7 +19,22 @@ function getTokenMetadataURL(chainId: string, tokenAddress: string) {
  */
 export async function fetchTokenList(chainId: string): Promise<unknown> {
   const tokenURL = getTokensURL(chainId);
-  return queryApi(tokenURL);
+  const response = await queryApi(tokenURL);
+  return parseJsonResponse(response);
+}
+
+/**
+ * Fetch metadata for the token address provided for a given network chainId
+ *
+ * @return Promise resolving token metadata for the tokenAddress provided
+ */
+export async function fetchTokenMetadata(
+  chainId: string,
+  tokenAddress: string,
+): Promise<unknown> {
+  const tokenMetadataURL = getTokenMetadataURL(chainId, tokenAddress);
+  const response = await queryApi(tokenMetadataURL);
+  return parseJsonResponse(response);
 }
 
 /**
@@ -33,24 +48,11 @@ export async function syncTokens(chainId: string): Promise<void> {
 }
 
 /**
- * Fetch metadata for the token address provided for a given network chainId
+ * Perform fetch request against the api
  *
- * @return Promise resolving token metadata for the tokenAddress provided
+ * @return Promise resolving request response
  */
-export async function fetchTokenMetadata(
-  chainId: string,
-  tokenAddress: string,
-): Promise<unknown> {
-  const tokenMetadataURL = getTokenMetadataURL(chainId, tokenAddress);
-  return queryApi(tokenMetadataURL);
-}
-
-/**
- * Fetch metadata for the token address provided for a given network chainId
- *
- * @return Promise resolving request response json value
- */
-async function queryApi(apiURL: string): Promise<unknown> {
+async function queryApi(apiURL: string): Promise<Response> {
   const fetchOptions: RequestInit = {
     referrer: apiURL,
     referrerPolicy: 'no-referrer-when-downgrade',
@@ -59,8 +61,16 @@ async function queryApi(apiURL: string): Promise<unknown> {
   };
   fetchOptions.headers = new window.Headers();
   fetchOptions.headers.set('Content-Type', 'application/json');
-  const tokenResponse = await timeoutFetch(apiURL, fetchOptions);
-  const responseObj = await tokenResponse.json();
+  return await timeoutFetch(apiURL, fetchOptions);
+}
+
+/**
+ * Parse response
+ *
+ * @return Promise resolving request response json value
+ */
+async function parseJsonResponse(apiResponse: Response): Promise<unknown> {
+  const responseObj = await apiResponse.json();
   // api may return errors as json without setting an error http status code
   if (responseObj?.error) {
     throw new Error(`TokenService Error: ${responseObj.error}`);

--- a/src/apis/token-service.ts
+++ b/src/apis/token-service.ts
@@ -15,20 +15,11 @@ function getTokenMetadataURL(chainId: string, tokenAddress: string) {
 /**
  * Fetches the list of token metadata for a given network chainId
  *
- * @returns - Promise resolving token  List
+ * @returns - Promise resolving token List
  */
-export async function fetchTokenList(chainId: string): Promise<Response> {
+export async function fetchTokenList(chainId: string): Promise<Object> {
   const tokenURL = getTokensURL(chainId);
-  const fetchOptions: RequestInit = {
-    referrer: tokenURL,
-    referrerPolicy: 'no-referrer-when-downgrade',
-    method: 'GET',
-    mode: 'cors',
-  };
-  fetchOptions.headers = new window.Headers();
-  fetchOptions.headers.set('Content-Type', 'application/json');
-  const tokenResponse = await timeoutFetch(tokenURL, fetchOptions);
-  return await tokenResponse.json();
+  return queryApi(tokenURL);
 }
 
 /**
@@ -38,15 +29,7 @@ export async function fetchTokenList(chainId: string): Promise<Response> {
  */
 export async function syncTokens(chainId: string): Promise<void> {
   const syncURL = syncTokensURL(chainId);
-  const fetchOptions: RequestInit = {
-    referrer: syncURL,
-    referrerPolicy: 'no-referrer-when-downgrade',
-    method: 'GET',
-    mode: 'cors',
-  };
-  fetchOptions.headers = new window.Headers();
-  fetchOptions.headers.set('Content-Type', 'application/json');
-  await timeoutFetch(syncURL, fetchOptions);
+  queryApi(syncURL);
 }
 
 /**
@@ -57,17 +40,26 @@ export async function syncTokens(chainId: string): Promise<void> {
 export async function fetchTokenMetadata(
   chainId: string,
   tokenAddress: string,
-): Promise<Response> {
+): Promise<Object> {
   const tokenMetadataURL = getTokenMetadataURL(chainId, tokenAddress);
+  return queryApi(tokenMetadataURL);
+}
+
+/**
+ * Fetch metadata for the token address provided for a given network chainId
+ *
+ * @return Promise resolving request response json obj
+ */
+async function queryApi (apiURL: string): Promise<Object> {
   const fetchOptions: RequestInit = {
-    referrer: tokenMetadataURL,
+    referrer: apiURL,
     referrerPolicy: 'no-referrer-when-downgrade',
     method: 'GET',
     mode: 'cors',
   };
   fetchOptions.headers = new window.Headers();
   fetchOptions.headers.set('Content-Type', 'application/json');
-  const tokenResponse = await timeoutFetch(tokenMetadataURL, fetchOptions);
+  const tokenResponse = await timeoutFetch(apiURL, fetchOptions);
   const responseObj = await tokenResponse.json();
   // api may return errors as json without setting an error http status code
   if (responseObj.error) {

--- a/src/apis/token-service.ts
+++ b/src/apis/token-service.ts
@@ -69,6 +69,7 @@ export async function fetchTokenMetadata(
   fetchOptions.headers.set('Content-Type', 'application/json');
   const tokenResponse = await timeoutFetch(tokenMetadataURL, fetchOptions);
   const responseObj = await tokenResponse.json();
+  // api may return errors as json without setting an error http status code
   if (responseObj.error) {
     throw new Error(`TokenService Error: ${responseObj.error}`);
   }

--- a/src/apis/token-service.ts
+++ b/src/apis/token-service.ts
@@ -68,5 +68,9 @@ export async function fetchTokenMetadata(
   fetchOptions.headers = new window.Headers();
   fetchOptions.headers.set('Content-Type', 'application/json');
   const tokenResponse = await timeoutFetch(tokenMetadataURL, fetchOptions);
-  return await tokenResponse.json();
+  const responseObj = await tokenResponse.json();
+  if (responseObj.error) {
+    throw new Error(`TokenService Error: ${responseObj.error}`);
+  }
+  return responseObj;
 }

--- a/src/assets/TokenListController.test.ts
+++ b/src/assets/TokenListController.test.ts
@@ -1116,7 +1116,7 @@ describe('TokenListController', () => {
 
   it('should return the metadata for a tokenAddress provided', async () => {
     nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${NetworksChainId.mainnet}`)
+      .get(`/token/${NetworksChainId.mainnet}`)
       .query({ address: '0x514910771af9ca656af840dff83e8264ecf986ca' })
       .reply(200, sampleTokenMetaData)
       .persist();

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -315,14 +315,12 @@ export class TokenListController extends BaseController<
   /**
    * Fetch metadata for a token whose address is send to the API
    * @param tokenAddress
-   * @returns Promise that resolvesto Token Metadata
+   * @returns Promise that resolves to Token Metadata
    */
   async fetchTokenMetadata(tokenAddress: string): Promise<Token> {
     const releaseLock = await this.mutex.acquire();
     try {
-      const token = await safelyExecute(() =>
-        fetchTokenMetadata(this.chainId, tokenAddress),
-      );
+      const token = await fetchTokenMetadata(this.chainId, tokenAddress) as Token;
       return token;
     } finally {
       releaseLock();

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -320,7 +320,10 @@ export class TokenListController extends BaseController<
   async fetchTokenMetadata(tokenAddress: string): Promise<Token> {
     const releaseLock = await this.mutex.acquire();
     try {
-      const token = await fetchTokenMetadata(this.chainId, tokenAddress) as Token;
+      const token = (await fetchTokenMetadata(
+        this.chainId,
+        tokenAddress,
+      )) as Token;
       return token;
     } finally {
       releaseLock();

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -216,9 +216,8 @@ export class TokenListController extends BaseController<
   async fetchFromDynamicTokenList(): Promise<void> {
     const releaseLock = await this.mutex.acquire();
     try {
-      const tokensFromAPI: Token[] = await safelyExecute(() =>
-        this.fetchFromCache(),
-      );
+      const tokensFromAPI: Token[] =
+        (await safelyExecute(() => this.fetchFromCache())) || [];
       const { tokensChainsCache } = this.state;
       const tokenList: TokenMap = {};
 


### PR DESCRIPTION
1. should throw if api returns a json error. api returns a 200 ok but with json error obj
we should check for that an elevate to an error
2. token lookup uri is wrong. fixed. (nice catch @NiranjanaBinoy !)
3. return types were wrong, fixed.
4. added fallback value for `safelyExecute` usage
5. removed unsound `safelyExecute` usage

i guess this is a breaking change bc types?