### PR TITLE
Make gweiDecToWEIBN util resilient against params with too many decimals

### DIFF
--- a/src/gas/gas-util.test.ts
+++ b/src/gas/gas-util.test.ts
@@ -1,7 +1,102 @@
 import nock from 'nock';
-import { fetchLegacyGasPriceEstimates } from './gas-util';
+import {
+  fetchLegacyGasPriceEstimates,
+  normalizeGWEIDecimalNumbers,
+  fetchGasEstimates,
+} from './gas-util';
+
+const mockEIP1559ApiResponses = [
+  {
+    low: {
+      minWaitTimeEstimate: 120000,
+      maxWaitTimeEstimate: 300000,
+      suggestedMaxPriorityFeePerGas: '1',
+      suggestedMaxFeePerGas: '35',
+    },
+    medium: {
+      minWaitTimeEstimate: 0,
+      maxWaitTimeEstimate: 30000,
+      suggestedMaxPriorityFeePerGas: '2',
+      suggestedMaxFeePerGas: '40',
+    },
+    high: {
+      minWaitTimeEstimate: 0,
+      maxWaitTimeEstimate: 15000,
+      suggestedMaxPriorityFeePerGas: '3',
+      suggestedMaxFeePerGas: '60',
+    },
+    estimatedBaseFee: '30',
+  },
+  {
+    low: {
+      minWaitTimeEstimate: 180000,
+      maxWaitTimeEstimate: 360000,
+      suggestedMaxPriorityFeePerGas: '1.0000000162',
+      suggestedMaxFeePerGas: '40',
+    },
+    medium: {
+      minWaitTimeEstimate: 15000,
+      maxWaitTimeEstimate: 60000,
+      suggestedMaxPriorityFeePerGas: '1.0000000160000028',
+      suggestedMaxFeePerGas: '45',
+    },
+    high: {
+      minWaitTimeEstimate: 0,
+      maxWaitTimeEstimate: 15000,
+      suggestedMaxPriorityFeePerGas: '3',
+      suggestedMaxFeePerGas: '1.000000016522',
+    },
+    estimatedBaseFee: '32.000000016522',
+  },
+];
 
 describe('gas utils', () => {
+  describe('fetchGasEstimates', () => {
+    it('should fetch external gasFeeEstimates when data is valid', async () => {
+      const scope = nock('https://not-a-real-url/')
+        .get(/.+/u)
+        .reply(200, mockEIP1559ApiResponses[0])
+        .persist();
+      const result = await fetchGasEstimates('https://not-a-real-url/');
+      expect(result).toMatchObject(mockEIP1559ApiResponses[0]);
+      scope.done();
+      nock.cleanAll();
+    });
+
+    it('should fetch and normalize external gasFeeEstimates when data is has an invalid number of decimals', async () => {
+      const expectedResult = {
+        low: {
+          minWaitTimeEstimate: 180000,
+          maxWaitTimeEstimate: 360000,
+          suggestedMaxPriorityFeePerGas: '1.000000016',
+          suggestedMaxFeePerGas: '40',
+        },
+        medium: {
+          minWaitTimeEstimate: 15000,
+          maxWaitTimeEstimate: 60000,
+          suggestedMaxPriorityFeePerGas: '1.000000016',
+          suggestedMaxFeePerGas: '45',
+        },
+        high: {
+          minWaitTimeEstimate: 0,
+          maxWaitTimeEstimate: 15000,
+          suggestedMaxPriorityFeePerGas: '3',
+          suggestedMaxFeePerGas: '1.000000017',
+        },
+        estimatedBaseFee: '32.000000017',
+      };
+
+      const scope = nock('https://not-a-real-url/')
+        .get(/.+/u)
+        .reply(200, mockEIP1559ApiResponses[1])
+        .persist();
+      const result = await fetchGasEstimates('https://not-a-real-url/');
+      expect(result).toMatchObject(expectedResult);
+      scope.done();
+      nock.cleanAll();
+    });
+  });
+
   describe('fetchLegacyGasPriceEstimates', () => {
     it('should fetch external gasPrices and return high/medium/low', async () => {
       const scope = nock('https://not-a-real-url/')
@@ -22,6 +117,75 @@ describe('gas utils', () => {
       });
       scope.done();
       nock.cleanAll();
+    });
+  });
+
+  describe('normalizeGWEIDecimalNumbers', () => {
+    it('should convert a whole number to WEI', () => {
+      expect(normalizeGWEIDecimalNumbers(1)).toBe('1');
+      expect(normalizeGWEIDecimalNumbers(123)).toBe('123');
+      expect(normalizeGWEIDecimalNumbers(101)).toBe('101');
+      expect(normalizeGWEIDecimalNumbers(1234)).toBe('1234');
+      expect(normalizeGWEIDecimalNumbers(1000)).toBe('1000');
+    });
+
+    it('should convert a number with a decimal part to WEI', () => {
+      expect(normalizeGWEIDecimalNumbers(1.1)).toBe('1.1');
+      expect(normalizeGWEIDecimalNumbers(123.01)).toBe('123.01');
+      expect(normalizeGWEIDecimalNumbers(101.001)).toBe('101.001');
+      expect(normalizeGWEIDecimalNumbers(100.001)).toBe('100.001');
+      expect(normalizeGWEIDecimalNumbers(1234.567)).toBe('1234.567');
+    });
+
+    it('should convert a number < 1 to WEI', () => {
+      expect(normalizeGWEIDecimalNumbers(0.1)).toBe('0.1');
+      expect(normalizeGWEIDecimalNumbers(0.01)).toBe('0.01');
+      expect(normalizeGWEIDecimalNumbers(0.001)).toBe('0.001');
+      expect(normalizeGWEIDecimalNumbers(0.567)).toBe('0.567');
+    });
+
+    it('should round to whole WEI numbers', () => {
+      expect(normalizeGWEIDecimalNumbers(0.1001)).toBe('0.1001');
+      expect(normalizeGWEIDecimalNumbers(0.0109)).toBe('0.0109');
+      expect(normalizeGWEIDecimalNumbers(0.0014)).toBe('0.0014');
+      expect(normalizeGWEIDecimalNumbers(0.5676)).toBe('0.5676');
+    });
+
+    it('should handle inputs with more than 9 decimal places', () => {
+      expect(normalizeGWEIDecimalNumbers(1.0000000162)).toBe('1.000000016');
+      expect(normalizeGWEIDecimalNumbers(1.0000000165)).toBe('1.000000017');
+      expect(normalizeGWEIDecimalNumbers(1.0000000199)).toBe('1.00000002');
+      expect(normalizeGWEIDecimalNumbers(1.9999999999)).toBe('2');
+      expect(normalizeGWEIDecimalNumbers(1.0000005998)).toBe('1.0000006');
+      expect(normalizeGWEIDecimalNumbers(123456.0000005998)).toBe(
+        '123456.0000006',
+      );
+      expect(normalizeGWEIDecimalNumbers(1.000000016025)).toBe('1.000000016');
+      expect(normalizeGWEIDecimalNumbers(1.0000000160000028)).toBe(
+        '1.000000016',
+      );
+      expect(normalizeGWEIDecimalNumbers(1.000000016522)).toBe('1.000000017');
+      expect(normalizeGWEIDecimalNumbers(1.000000016800022)).toBe(
+        '1.000000017',
+      );
+    });
+
+    it('should work if there are extraneous trailing decimal zeroes', () => {
+      expect(normalizeGWEIDecimalNumbers('0.5000')).toBe('0.5');
+      expect(normalizeGWEIDecimalNumbers('123.002300')).toBe('123.0023');
+      expect(normalizeGWEIDecimalNumbers('123.002300000000')).toBe('123.0023');
+      expect(normalizeGWEIDecimalNumbers('0.00000200000')).toBe('0.000002');
+    });
+
+    it('should work if there is no whole number specified', () => {
+      expect(normalizeGWEIDecimalNumbers('.1')).toBe('0.1');
+      expect(normalizeGWEIDecimalNumbers('.01')).toBe('0.01');
+      expect(normalizeGWEIDecimalNumbers('.001')).toBe('0.001');
+      expect(normalizeGWEIDecimalNumbers('.567')).toBe('0.567');
+    });
+
+    it('should handle NaN', () => {
+      expect(normalizeGWEIDecimalNumbers(NaN)).toBe('0');
     });
   });
 });

--- a/src/gas/gas-util.ts
+++ b/src/gas/gas-util.ts
@@ -8,8 +8,45 @@ import {
   LegacyGasPriceEstimate,
 } from './GasFeeController';
 
+export function normalizeGWEIDecimalNumbers(n: string | number) {
+  const numberAsWEIHex = gweiDecToWEIBN(n).toString(16);
+  const numberAsGWEI = weiHexToGweiDec(numberAsWEIHex).toString(10);
+  return numberAsGWEI;
+}
+
 export async function fetchGasEstimates(url: string): Promise<GasFeeEstimates> {
-  return await handleFetch(url);
+  const estimates: GasFeeEstimates = await handleFetch(url);
+  const normalizedEstimates: GasFeeEstimates = {
+    estimatedBaseFee: normalizeGWEIDecimalNumbers(estimates.estimatedBaseFee),
+    low: {
+      ...estimates.low,
+      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(
+        estimates.low.suggestedMaxPriorityFeePerGas,
+      ),
+      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(
+        estimates.low.suggestedMaxFeePerGas,
+      ),
+    },
+    medium: {
+      ...estimates.medium,
+      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(
+        estimates.medium.suggestedMaxPriorityFeePerGas,
+      ),
+      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(
+        estimates.medium.suggestedMaxFeePerGas,
+      ),
+    },
+    high: {
+      ...estimates.high,
+      suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(
+        estimates.high.suggestedMaxPriorityFeePerGas,
+      ),
+      suggestedMaxFeePerGas: normalizeGWEIDecimalNumbers(
+        estimates.high.suggestedMaxFeePerGas,
+      ),
+    },
+  };
+  return normalizedEstimates;
 }
 
 /**

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -120,12 +120,14 @@ describe('util', () => {
       expect(util.gweiDecToWEIBN(123).toNumber()).toBe(123000000000);
       expect(util.gweiDecToWEIBN(101).toNumber()).toBe(101000000000);
       expect(util.gweiDecToWEIBN(1234).toNumber()).toBe(1234000000000);
+      expect(util.gweiDecToWEIBN(1000).toNumber()).toBe(1000000000000);
     });
 
     it('should convert a number with a decimal part to WEI', () => {
       expect(util.gweiDecToWEIBN(1.1).toNumber()).toBe(1100000000);
       expect(util.gweiDecToWEIBN(123.01).toNumber()).toBe(123010000000);
       expect(util.gweiDecToWEIBN(101.001).toNumber()).toBe(101001000000);
+      expect(util.gweiDecToWEIBN(100.001).toNumber()).toBe(100001000000);
       expect(util.gweiDecToWEIBN(1234.567).toNumber()).toBe(1234567000000);
     });
 
@@ -141,6 +143,33 @@ describe('util', () => {
       expect(util.gweiDecToWEIBN(0.0109).toNumber()).toBe(10900000);
       expect(util.gweiDecToWEIBN(0.0014).toNumber()).toBe(1400000);
       expect(util.gweiDecToWEIBN(0.5676).toNumber()).toBe(567600000);
+    });
+
+    it('should handle inputs with more than 9 decimal places', () => {
+      expect(util.gweiDecToWEIBN(1.0000000162).toNumber()).toBe(1000000016);
+      expect(util.gweiDecToWEIBN(1.0000000165).toNumber()).toBe(1000000017);
+      expect(util.gweiDecToWEIBN(1.0000000199).toNumber()).toBe(1000000020);
+      expect(util.gweiDecToWEIBN(1.9999999999).toNumber()).toBe(2000000000);
+      expect(util.gweiDecToWEIBN(1.0000005998).toNumber()).toBe(1000000600);
+      expect(util.gweiDecToWEIBN(123456.0000005998).toNumber()).toBe(
+        123456000000600,
+      );
+    });
+
+    it('should work if there are extraneous trailing decimal zeroes', () => {
+      expect(util.gweiDecToWEIBN('0.5000').toNumber()).toBe(500000000);
+      expect(util.gweiDecToWEIBN('123.002300').toNumber()).toBe(123002300000);
+      expect(util.gweiDecToWEIBN('123.002300000000').toNumber()).toBe(
+        123002300000,
+      );
+      expect(util.gweiDecToWEIBN('0.00000200000').toNumber()).toBe(2000);
+    });
+
+    it('should work if there is no whole number specified', () => {
+      expect(util.gweiDecToWEIBN('.1').toNumber()).toBe(100000000);
+      expect(util.gweiDecToWEIBN('.01').toNumber()).toBe(10000000);
+      expect(util.gweiDecToWEIBN('.001').toNumber()).toBe(1000000);
+      expect(util.gweiDecToWEIBN('.567').toNumber()).toBe(567000000);
     });
 
     it('should handle NaN', () => {

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -154,6 +154,14 @@ describe('util', () => {
       expect(util.gweiDecToWEIBN(123456.0000005998).toNumber()).toBe(
         123456000000600,
       );
+      expect(util.gweiDecToWEIBN(1.000000016025).toNumber()).toBe(1000000016);
+      expect(util.gweiDecToWEIBN(1.0000000160000028).toNumber()).toBe(
+        1000000016,
+      );
+      expect(util.gweiDecToWEIBN(1.000000016522).toNumber()).toBe(1000000017);
+      expect(util.gweiDecToWEIBN(1.000000016800022).toNumber()).toBe(
+        1000000017,
+      );
     });
 
     it('should work if there are extraneous trailing decimal zeroes', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -78,7 +78,27 @@ export function gweiDecToWEIBN(n: number | string) {
   if (Number.isNaN(n)) {
     return new BN(0);
   }
-  return toWei(n.toString(), 'gwei');
+
+  const parts = n.toString().split('.');
+  const wholePart = parts[0] || '0';
+  let decimalPart = parts[1] || '';
+
+  if (!decimalPart) {
+    return toWei(wholePart, 'gwei');
+  }
+  if (decimalPart.length <= 9) {
+    return toWei(`${wholePart}.${decimalPart}`, 'gwei');
+  }
+  const lastDecimalDigit = decimalPart[decimalPart.length - 1];
+
+  decimalPart = decimalPart.slice(0, 9);
+  let wei = toWei(`${wholePart}.${decimalPart}`, 'gwei');
+
+  if (Number(lastDecimalDigit) >= 5) {
+    wei = wei.add(new BN(1));
+  }
+
+  return wei;
 }
 
 /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -89,12 +89,14 @@ export function gweiDecToWEIBN(n: number | string) {
   if (decimalPart.length <= 9) {
     return toWei(`${wholePart}.${decimalPart}`, 'gwei');
   }
-  const lastDecimalDigit = decimalPart[decimalPart.length - 1];
+
+  const decimalPartToRemove = decimalPart.slice(9);
+  const decimalRoundingDigit = decimalPartToRemove[0];
 
   decimalPart = decimalPart.slice(0, 9);
   let wei = toWei(`${wholePart}.${decimalPart}`, 'gwei');
 
-  if (Number(lastDecimalDigit) >= 5) {
+  if (Number(decimalRoundingDigit) >= 5) {
     wei = wei.add(new BN(1));
   }
 


### PR DESCRIPTION
`gweiDecToWEIBN` uses `toWei` from `ethjs-unit`

`toWei` will throw an error if it receives more than 9 decimal places when converting from gwei (because WEI cannot have decimal parts)

given that `gweiDecToWEIBN` can receive data from an external api, errors can happen if that data is flawed in having too many decimal places.

This PR ensures that such faulty data is correctly handled.