### PR TITLE
Fix `resetPolling` functionality

### DIFF
--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -290,10 +290,11 @@ export class GasFeeController extends BaseController<typeof name, GasFeeState> {
     this.ethQuery = new EthQuery(provider);
     onNetworkStateChange(async () => {
       const newProvider = getProvider();
+      const newChainId = newProvider.getChainId();
       this.ethQuery = new EthQuery(newProvider);
-      if (this.currentChainId !== newProvider.chainId) {
+      if (this.currentChainId !== newChainId) {
+        this.currentChainId = newChainId;
         await this.resetPolling();
-        this.currentChainId = newProvider.chainId;
       }
     });
   }

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -295,11 +295,9 @@ export class GasFeeController extends BaseController<typeof name, GasFeeState> {
 
   async resetPolling() {
     if (this.pollTokens.size !== 0) {
-      // restart polling
-      const { getGasFeeEstimatesAndStartPolling } = this;
       const tokens = Array.from(this.pollTokens);
       this.stopPolling();
-      await getGasFeeEstimatesAndStartPolling(tokens[0]);
+      await this.getGasFeeEstimatesAndStartPolling(tokens[0]);
       tokens.slice(1).forEach((token) => {
         this.pollTokens.add(token);
       });

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -293,6 +293,7 @@ export class GasFeeController extends BaseController<typeof name, GasFeeState> {
       this.ethQuery = new EthQuery(newProvider);
       if (this.currentChainId !== newProvider.chainId) {
         await this.resetPolling();
+        this.currentChainId = newProvider.chainId;
       }
     });
   }

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -290,7 +290,7 @@ export class GasFeeController extends BaseController<typeof name, GasFeeState> {
     this.ethQuery = new EthQuery(provider);
     onNetworkStateChange(async () => {
       const newProvider = getProvider();
-      const newChainId = newProvider.getChainId();
+      const newChainId = this.getChainId();
       this.ethQuery = new EthQuery(newProvider);
       if (this.currentChainId !== newChainId) {
         this.currentChainId = newChainId;

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -223,6 +223,8 @@ export class GasFeeController extends BaseController<typeof name, GasFeeState> {
 
   private getChainId;
 
+  private currentChainId;
+
   private ethQuery: any;
 
   /**
@@ -283,13 +285,15 @@ export class GasFeeController extends BaseController<typeof name, GasFeeState> {
     this.EIP1559APIEndpoint = EIP1559APIEndpoint;
     this.legacyAPIEndpoint = legacyAPIEndpoint;
     this.getChainId = getChainId;
-
+    this.currentChainId = this.getChainId();
     const provider = getProvider();
     this.ethQuery = new EthQuery(provider);
     onNetworkStateChange(async () => {
       const newProvider = getProvider();
       this.ethQuery = new EthQuery(newProvider);
-      await this.resetPolling();
+      if (this.currentChainId !== newProvider.chainId) {
+        await this.resetPolling();
+      }
     });
   }
 

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -337,11 +337,13 @@ export class NetworkController extends BaseController<
             } else {
               const isEIP1559Compatible =
                 typeof block.baseFeePerGas !== 'undefined';
-              this.update({
-                properties: {
-                  isEIP1559Compatible,
-                },
-              });
+              if (properties.isEIP1559Compatible !== isEIP1559Compatible) {
+                this.update({
+                  properties: {
+                    isEIP1559Compatible,
+                  },
+                });
+              }
               resolve(isEIP1559Compatible);
             }
           },


### PR DESCRIPTION
This PR addresses the problem of the resetPolling being called on every network controller state change, so more frequent than necessary. We now check by chainId if the network changed and we don't update the network controller properties if they are the same.