### PR TITLE
Feature/reduce tx persist

### DIFF
--- a/src/transaction/TransactionController.test.ts
+++ b/src/transaction/TransactionController.test.ts
@@ -211,7 +211,7 @@ const ETH_TRANSACTIONS = [
     hash: '0x342e9d73e10004af41d04973139fc7219dbadcbb5629730cfe65e9f9cb15ff91',
     input: '0x11',
     isError: '0',
-    nonce: '1',
+    nonce: '3',
     timeStamp: '1543596356',
     to: '0xb2d191b6fe03c5b8a1ab249cfe88c37553357a23',
     transactionIndex: '13',
@@ -1270,8 +1270,9 @@ describe('TransactionController', () => {
       resolve('');
     });
   });
-  it('should limit tx state to a length of 1', async () => {
+  it('should limit tx state to a length of 2', async () => {
     await new Promise(async (resolve) => {
+      globalAny.fetch = mockFetchs(MOCK_FETCH_TX_HISTORY_DATA_OK);
       const controller = new TransactionController(
         {
           getNetworkState: () => MOCK_NETWORK.state,
@@ -1281,21 +1282,24 @@ describe('TransactionController', () => {
         {
           interval: 5000,
           sign: async (transaction: any) => transaction,
-          txHistoryLimit: 1,
+          txHistoryLimit: 2,
         },
       );
-      const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+      const from = '0x6bf137f335ea1b8f193b8f6ea92561a60d23a207';
+      await controller.fetchAll(from);
       await controller.addTransaction({
         from,
+        nonce: '55555',
         gas: '0x0',
         gasPrice: '0x50fd51da',
         to: from,
         value: '0x0',
       });
-      expect(controller.state.transactions).toHaveLength(1);
+      expect(controller.state.transactions).toHaveLength(2);
       expect(controller.state.transactions[0].transaction.gasPrice).toBe(
-        '0x50fd51da',
+        '0x4a817c800',
       );
+      console.log(controller.state.transactions);
       resolve('');
     });
   });
@@ -1317,7 +1321,7 @@ describe('TransactionController', () => {
       const from = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
       await controller.addTransaction({
         from,
-        nonce: '1',
+        nonce: '1111111',
         gas: '0x0',
         gasPrice: '0x50fd51da',
         to: from,

--- a/src/transaction/TransactionController.test.ts
+++ b/src/transaction/TransactionController.test.ts
@@ -1167,7 +1167,6 @@ describe('TransactionController', () => {
   });
 
   it('should handle new method data', async () => {
-    console.log('should handle new method data');
     const controller = new TransactionController(
       {
         getNetworkState: () => MOCK_MAINNET_NETWORK.state,

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -961,7 +961,9 @@ export class TransactionController extends BaseController<
     );
     /* istanbul ignore else */
     if (gotUpdates) {
-      this.trimTransactionsForState(transactions);
+      this.update({
+        transactions: this.trimTransactionsForState(transactions),
+      });
     }
   }
 
@@ -978,7 +980,7 @@ export class TransactionController extends BaseController<
     validateTransaction(transactionMeta.transaction);
     const index = transactions.findIndex(({ id }) => transactionMeta.id === id);
     transactions[index] = transactionMeta;
-    this.trimTransactionsForState(transactions);
+    this.update({ transactions: this.trimTransactionsForState(transactions) });
   }
 
   /**
@@ -989,7 +991,7 @@ export class TransactionController extends BaseController<
   wipeTransactions(ignoreNetwork?: boolean) {
     /* istanbul ignore next */
     if (ignoreNetwork) {
-      this.trimTransactionsForState([]);
+      this.update({ transactions: [] });
       return;
     }
     const { provider, network: currentNetworkID } = this.getNetworkState();
@@ -1004,7 +1006,9 @@ export class TransactionController extends BaseController<
       },
     );
 
-    this.trimTransactionsForState(newTransactions);
+    this.update({
+      transactions: this.trimTransactionsForState(newTransactions),
+    });
   }
 
   /**
@@ -1089,7 +1093,7 @@ export class TransactionController extends BaseController<
     });
     // Update state only if new transactions were fetched
     if (allTxs.length > this.state.transactions.length) {
-      this.trimTransactionsForState(allTxs);
+      this.update({ transactions: this.trimTransactionsForState(allTxs) });
     }
     return latestIncomingTxBlockNumber;
   }

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -1108,7 +1108,7 @@ export class TransactionController extends BaseController<
    */
   private trimTransactionsForState(transactions: TransactionMeta[]) {
     const nonceNetworkSet = new Set();
-    const txsToKeep = transactions.filter((tx) => {
+    const txsToKeep = transactions.reverse().filter((tx) => {
       const { chainId, networkID, status, transaction, time } = tx;
       if (transaction) {
         const key = `${transaction.nonce}-${chainId ?? networkID}-${new Date(
@@ -1126,6 +1126,7 @@ export class TransactionController extends BaseController<
       }
       return false;
     });
+    txsToKeep.reverse();
     this.update({ transactions: [...txsToKeep] });
   }
 

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -543,7 +543,7 @@ export class TransactionController extends BaseController<
     });
 
     transactions.push(transactionMeta);
-    this.trimTransactionsForState(transactions);
+    this.update({ transactions: this.trimTransactionsForState(transactions) });
     this.hub.emit(`unapprovedTransaction`, transactionMeta);
     return { result, transactionMeta };
   }
@@ -694,7 +694,7 @@ export class TransactionController extends BaseController<
     const transactions = this.state.transactions.filter(
       ({ id }) => id !== transactionID,
     );
-    this.trimTransactionsForState(transactions);
+    this.update({ transactions: this.trimTransactionsForState(transactions) });
   }
 
   /**
@@ -852,7 +852,7 @@ export class TransactionController extends BaseController<
             },
           };
     transactions.push(newTransactionMeta);
-    this.trimTransactionsForState(transactions);
+    this.update({ transactions: this.trimTransactionsForState(transactions) });
     this.hub.emit(`${transactionMeta.id}:speedup`, newTransactionMeta);
   }
 
@@ -1127,7 +1127,7 @@ export class TransactionController extends BaseController<
       return false;
     });
     txsToKeep.reverse();
-    this.update({ transactions: [...txsToKeep] });
+    return txsToKeep;
   }
 
   /**

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -1111,17 +1111,18 @@ export class TransactionController extends BaseController<
     const txsToDelete = transactions
       .reverse()
       .filter((tx) => {
-        const { nonce } = tx.transaction;
-        const { chainId, networkID, status } = tx;
-        const key = `${nonce}-${chainId ?? networkID}`;
-        if (nonceNetworkSet.has(key)) {
-          return false;
-        } else if (
-          nonceNetworkSet.size < this.config.txHistoryLimit ||
-          !this.isFinalState(status)
-        ) {
-          nonceNetworkSet.add(key);
-          return false;
+        const { chainId, networkID, status, transaction } = tx;
+        if (transaction) {
+          const key = `${transaction.nonce}-${chainId ?? networkID}`;
+          if (nonceNetworkSet.has(key)) {
+            return false;
+          } else if (
+            nonceNetworkSet.size < this.config.txHistoryLimit - 1 ||
+            !this.isFinalState(status)
+          ) {
+            nonceNetworkSet.add(key);
+            return false;
+          }
         }
         return true;
       })
@@ -1130,6 +1131,8 @@ export class TransactionController extends BaseController<
     txsToDelete.forEach((txId) => {
       delete transactions[Number(txId)];
     });
+
+    transactions.reverse();
 
     this.update({ transactions: [...transactions] });
   }


### PR DESCRIPTION
Description

- Added `txHistoryLimit` option (default value 40 txs) in the `TransactionConfig`
- Added `trimTransactionForState` function to reduced the number of txs persisted in the state. 
- Added unit tests to confirm the limiting of txs
- Updated unit tests evaluating the default value of `txHistoryLimit`