### PR TITLE
Improve BaseControllerV2 messenger type

### DIFF
--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -60,7 +60,8 @@ function getCountMessenger(
 
 class CountController extends BaseController<
   typeof countControllerName,
-  CountControllerState
+  CountControllerState,
+  CountMessenger
 > {
   update(
     callback: (
@@ -653,7 +654,8 @@ describe('getPersistentState', () => {
     >;
     class VisitorController extends BaseController<
       typeof visitorName,
-      VisitorControllerState
+      VisitorControllerState,
+      VisitorMessenger
     > {
       constructor(messagingSystem: VisitorMessenger) {
         super({
@@ -716,7 +718,8 @@ describe('getPersistentState', () => {
 
     class VisitorOverflowController extends BaseController<
       typeof visitorOverflowName,
-      VisitorOverflowControllerState
+      VisitorOverflowControllerState,
+      VisitorOverflowMessenger
     > {
       constructor(messagingSystem: VisitorOverflowMessenger) {
         super({

--- a/src/BaseControllerV2.ts
+++ b/src/BaseControllerV2.ts
@@ -110,17 +110,12 @@ export type Json =
  */
 export class BaseController<
   N extends string,
-  S extends Record<string, unknown>
+  S extends Record<string, unknown>,
+  messenger extends RestrictedControllerMessenger<N, any, any, string, string>
 > {
   private internalState: IsJsonable<S>;
 
-  protected messagingSystem: RestrictedControllerMessenger<
-    N,
-    any,
-    any,
-    string,
-    string
-  >;
+  protected messagingSystem: messenger;
 
   /**
    * The name of the controller.
@@ -155,7 +150,7 @@ export class BaseController<
     name,
     state,
   }: {
-    messenger: RestrictedControllerMessenger<N, any, any, string, string>;
+    messenger: messenger;
     metadata: StateMetadata<S>;
     name: N;
     state: IsJsonable<S>;

--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -28,6 +28,14 @@ type FooControllerEvent = {
   payload: [FooControllerState, Patch[]];
 };
 
+type FooMessenger = RestrictedControllerMessenger<
+  'FooController',
+  never,
+  FooControllerEvent,
+  string,
+  never
+>;
+
 const fooControllerStateMetadata = {
   foo: {
     persist: true,
@@ -37,17 +45,10 @@ const fooControllerStateMetadata = {
 
 class FooController extends BaseControllerV2<
   'FooController',
-  FooControllerState
+  FooControllerState,
+  FooMessenger
 > {
-  constructor(
-    messagingSystem: RestrictedControllerMessenger<
-      'FooController',
-      never,
-      FooControllerEvent,
-      string,
-      never
-    >,
-  ) {
+  constructor(messagingSystem: FooMessenger) {
     super({
       messenger: messagingSystem,
       metadata: fooControllerStateMetadata,

--- a/src/ControllerMessenger.ts
+++ b/src/ControllerMessenger.ts
@@ -33,11 +33,11 @@ type SelectorEventHandler<SelectorReturnValue> = (
   previousValue: SelectorReturnValue | undefined,
 ) => void;
 
-type ActionConstraint = {
+export type ActionConstraint = {
   type: string;
   handler: (...args: any) => unknown;
 };
-type EventConstraint = { type: string; payload: unknown[] };
+export type EventConstraint = { type: string; payload: unknown[] };
 
 type EventSubscriptionMap = Map<
   GenericEventHandler | SelectorEventHandler<unknown>,

--- a/src/assets/CurrencyRateController.ts
+++ b/src/assets/CurrencyRateController.ts
@@ -40,6 +40,14 @@ export type GetCurrencyRateState = {
   handler: () => CurrencyRateState;
 };
 
+type CurrencyRateMessenger = RestrictedControllerMessenger<
+  typeof name,
+  GetCurrencyRateState,
+  CurrencyRateStateChange,
+  never,
+  never
+>;
+
 const metadata = {
   conversionDate: { persist: true, anonymous: true },
   conversionRate: { persist: true, anonymous: true },
@@ -66,7 +74,8 @@ const defaultState = {
  */
 export class CurrencyRateController extends BaseController<
   typeof name,
-  CurrencyRateState
+  CurrencyRateState,
+  CurrencyRateMessenger
 > {
   private mutex = new Mutex();
 
@@ -97,13 +106,7 @@ export class CurrencyRateController extends BaseController<
   }: {
     includeUsdRate?: boolean;
     interval?: number;
-    messenger: RestrictedControllerMessenger<
-      typeof name,
-      GetCurrencyRateState,
-      CurrencyRateStateChange,
-      never,
-      never
-    >;
+    messenger: CurrencyRateMessenger;
     state?: Partial<CurrencyRateState>;
     fetchExchangeRate?: typeof defaultFetchExchangeRate;
   }) {

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -72,6 +72,14 @@ interface TokensChainsCache {
   [chainSlug: string]: DataCache;
 }
 
+type TokenListMessenger = RestrictedControllerMessenger<
+  typeof name,
+  GetTokenListState,
+  TokenListStateChange,
+  never,
+  never
+>;
+
 const metadata = {
   tokenList: { persist: true, anonymous: true },
   tokensChainsCache: { persist: true, anonymous: true },
@@ -87,7 +95,8 @@ const defaultState: TokenListState = {
  */
 export class TokenListController extends BaseController<
   typeof name,
-  TokenListState
+  TokenListState,
+  TokenListMessenger
 > {
   private mutex = new Mutex();
 
@@ -129,13 +138,7 @@ export class TokenListController extends BaseController<
     ) => void;
     interval?: number;
     cacheRefreshThreshold?: number;
-    messenger: RestrictedControllerMessenger<
-      typeof name,
-      GetTokenListState,
-      TokenListStateChange,
-      never,
-      never
-    >;
+    messenger: TokenListMessenger;
     state?: Partial<TokenListState>;
   }) {
     super({

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -189,6 +189,14 @@ export type GetGasFeeState = {
   handler: () => GasFeeState;
 };
 
+type GasFeeMessenger = RestrictedControllerMessenger<
+  typeof name,
+  GetGasFeeState,
+  GasFeeStateChange,
+  never,
+  never
+>;
+
 const defaultState: GasFeeState = {
   gasFeeEstimates: {},
   estimatedGasFeeTimeBounds: {},
@@ -198,7 +206,11 @@ const defaultState: GasFeeState = {
 /**
  * Controller that retrieves gas fee estimate data and polls for updated data on a set interval
  */
-export class GasFeeController extends BaseController<typeof name, GasFeeState> {
+export class GasFeeController extends BaseController<
+  typeof name,
+  GasFeeState,
+  GasFeeMessenger
+> {
   private intervalId?: NodeJS.Timeout;
 
   private intervalDelay;
@@ -248,13 +260,7 @@ export class GasFeeController extends BaseController<typeof name, GasFeeState> {
     EIP1559APIEndpoint = GAS_FEE_API,
   }: {
     interval?: number;
-    messenger: RestrictedControllerMessenger<
-      typeof name,
-      GetGasFeeState,
-      GasFeeStateChange,
-      never,
-      never
-    >;
+    messenger: GasFeeMessenger;
     state?: GasFeeState;
     fetchGasEstimates?: typeof defaultFetchGasEstimates;
     fetchEthGasPriceEstimate?: typeof defaultFetchEthGasPriceEstimate;


### PR DESCRIPTION
The new base controller now accepts the messenger type as a generic parameter, rather than hard-coding it to be `RestrictedControllerMessenger<N, any, any, string, string>`. This allows controllers to use the messenger directly without sacrificing any type safety.

Note: this is a **breaking change**, because anyone extending `BaseControllerV2` will now be required to supply an additional generic parameter.