### PR TITLE
Move controller messenger type demonstration to its own test suite

### DIFF
--- a/src/ControllerMessenger.test.ts
+++ b/src/ControllerMessenger.test.ts
@@ -1,3 +1,4 @@
+import type { Patch } from 'immer';
 import sinon from 'sinon';
 
 import { ControllerMessenger } from './ControllerMessenger';
@@ -21,10 +22,26 @@ describe('ControllerMessenger', () => {
   });
 
   it('should allow registering and calling multiple different action handlers', () => {
+    // These 'Other' types are included to demonstrate that controller messenger
+    // generics can indeed be unions of actions and events from different
+    // controllers.
+    type GetOtherState = {
+      type: `OtherController:getState`;
+      handler: () => { stuff: string };
+    };
+
+    type OtherStateChange = {
+      type: `OtherController:stateChange`;
+      payload: [{ stuff: string }, Patch[]];
+    };
+
     type MessageAction =
       | { type: 'concat'; handler: (message: string) => void }
       | { type: 'reset'; handler: (initialMessage: string) => void };
-    const controllerMessenger = new ControllerMessenger<MessageAction, never>();
+    const controllerMessenger = new ControllerMessenger<
+      MessageAction | GetOtherState,
+      OtherStateChange
+    >();
 
     let message = '';
     controllerMessenger.registerActionHandler(

--- a/src/assets/CurrencyRateController.test.ts
+++ b/src/assets/CurrencyRateController.test.ts
@@ -1,5 +1,4 @@
 import { stub } from 'sinon';
-import type { Patch } from 'immer';
 import nock from 'nock';
 import { ControllerMessenger } from '../ControllerMessenger';
 import {
@@ -10,22 +9,10 @@ import {
 
 const name = 'CurrencyRateController';
 
-type OtherStateChange = {
-  type: `OtherController:stateChange`;
-  payload: [{ stuff: string }, Patch[]];
-};
-
-type GetOtherState = {
-  type: `OtherController:getState`;
-  handler: () => { stuff: string };
-};
-
 function getRestrictedMessenger() {
-  // The 'Other' types are included to demonstrate that this all works with a
-  // controller messenger that includes types from other controllers.
   const controllerMessenger = new ControllerMessenger<
-    GetCurrencyRateState | GetOtherState,
-    CurrencyRateStateChange | OtherStateChange
+    GetCurrencyRateState,
+    CurrencyRateStateChange
   >();
   const messenger = controllerMessenger.getRestricted<
     'CurrencyRateController',


### PR DESCRIPTION
Previously, we demonstrated how controller messenger generics could be a union of actions and events from different controllers in the currency rate controller tests. Although we have use cases in production that demonstrate this, I think it's worthwhile to keep an example in the tests. This PR moves this type demonstration into the controller messenger test suite.