### PR TITLE
Make controller messenger subscriptions "safe"

### DIFF
--- a/src/ControllerMessenger.ts
+++ b/src/ControllerMessenger.ts
@@ -1,6 +1,4 @@
-import utils from './util';
-
-const { safeApply } = utils;
+import { safeApply } from './util';
 
 type ActionHandler<Action, ActionType> = (
   ...args: ExtractActionParameters<Action, ActionType>

--- a/src/util.ts
+++ b/src/util.ts
@@ -774,24 +774,3 @@ export function validateMinimumIncrease(proposed: string, min: string) {
   const errorMsg = `The proposed value: ${proposedDecimal} should meet or exceed the minimum value: ${minDecimal}`;
   throw new Error(errorMsg);
 }
-
-export default {
-  BNToHex,
-  fractionBN,
-  query,
-  getBuyURL,
-  handleFetch,
-  hexToBN,
-  hexToText,
-  isSmartContractCode,
-  normalizeTransaction,
-  safeApply,
-  safelyExecute,
-  safelyExecuteWithTimeout,
-  successfulFetch,
-  timeoutFetch,
-  validateTokenToWatch,
-  validateTransaction,
-  validateTypedSignMessageDataV1,
-  validateTypedSignMessageDataV3,
-};


### PR DESCRIPTION
Fixes #566

Per the referenced issue, this PR ensures that any remaining controller messenger event handlers (and selectors) will be called even if one of them throws. This is accomplished by adding a `safeApply` utility function in the vein of the one used in `safe-event-emitter`. The difference is that this version can also return values, which we need in order to use it with selector functions in selector subscriptions.

This PR also:
- stops ignoring coverage for error logging in `safelyExecute` and `safelyExecuteWithTimeout` and adds test cases instead.
- removes the redundant default export of everything that was already exported by name in `util.ts`.

At the time of writing, the remaining outstanding question is what we should do with the currently swallowed error. We minimally want them to be caught by Sentry, and we should consider adding logging.