### PR TITLE
Remove redundant default export from util.ts

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -745,23 +745,3 @@ export function validateMinimumIncrease(proposed: string, min: string) {
   const errorMsg = `The proposed value: ${proposedDecimal} should meet or exceed the minimum value: ${minDecimal}`;
   throw new Error(errorMsg);
 }
-
-export default {
-  BNToHex,
-  fractionBN,
-  query,
-  getBuyURL,
-  handleFetch,
-  hexToBN,
-  hexToText,
-  isSmartContractCode,
-  normalizeTransaction,
-  safelyExecute,
-  safelyExecuteWithTimeout,
-  successfulFetch,
-  timeoutFetch,
-  validateTokenToWatch,
-  validateTransaction,
-  validateTypedSignMessageDataV1,
-  validateTypedSignMessageDataV3,
-};


### PR DESCRIPTION
That which serves no purpose is to be eradicated.

Everything in the `export default` block was already a named export, so this quite literally serves no purpose. This is probably a breaking change anyway, but ¯\\\_(ツ)\_/¯