### PR TITLE
Add abort-controller polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@ethereumjs/tx": "^3.2.1",
     "@metamask/contract-metadata": "^1.29.0",
     "@types/uuid": "^8.3.0",
+    "abort-controller": "^3.0.0",
     "async-mutex": "^0.2.6",
     "babel-runtime": "^6.26.0",
     "eth-ens-namehash": "^2.0.8",

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -1,6 +1,7 @@
 import contractMap from '@metamask/contract-metadata';
 import type { Patch } from 'immer';
 import { Mutex } from 'async-mutex';
+import { AbortController } from 'abort-controller';
 import { BaseController } from '../BaseControllerV2';
 import type { RestrictedControllerMessenger } from '../ControllerMessenger';
 import { safelyExecute } from '../util';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1520,6 +1520,13 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
 abstract-leveldown@~2.6.0:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz#1c5e8c6a5ef965ae8c35dfb3a8770c476b82c4b8"
@@ -3506,6 +3513,11 @@ ethjs@^0.3.0:
     ethjs-util "0.1.3"
     js-sha3 "0.5.5"
     number-to-bn "1.7.0"
+
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 events@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
**Add abort-controller polyfill**

**Description**

- FIXED:

  - Add abort-controller polyfill, which fixes the broken contract in release v15.0.0 where we introduced a use of AbortController without updating the node engine requirement in package.json to atleast node v15.0.0 where support for AbortController was added.

