### PR TITLE
Change AbortController to default import

### DIFF
--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -1,7 +1,8 @@
 import contractMap from '@metamask/contract-metadata';
 import type { Patch } from 'immer';
 import { Mutex } from 'async-mutex';
-import { AbortController } from 'abort-controller';
+// eslint-disable-next-line
+import AbortController from 'abort-controller';
 import { BaseController } from '../BaseControllerV2';
 import type { RestrictedControllerMessenger } from '../ControllerMessenger';
 import { safelyExecute } from '../util';

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -1,7 +1,7 @@
 import contractMap from '@metamask/contract-metadata';
 import type { Patch } from 'immer';
 import { Mutex } from 'async-mutex';
-// eslint-disable-next-line
+// eslint-disable-next-line import/no-named-as-default
 import AbortController from 'abort-controller';
 import { BaseController } from '../BaseControllerV2';
 import type { RestrictedControllerMessenger } from '../ControllerMessenger';


### PR DESCRIPTION
🤦 

- FIXED:

  - Fixes error thrown when attempting to instantiate `AbortController` (polyfill) constructor as a named import. Despite the package seeming to support named imports, this change seems to be required for the TokenListController to not blow up. 


