### PR TITLE
Make TokenRatesController findChainSlug method accommodate hex formatted chainIds

### DIFF
--- a/src/assets/TokenRatesController.test.ts
+++ b/src/assets/TokenRatesController.test.ts
@@ -271,4 +271,59 @@ describe('TokenRatesController', () => {
     // FIXME: This is now being called twice
     expect(updateExchangeRatesStub.callCount).toStrictEqual(2);
   });
+
+  it('should find the chainslug when chainId is formatted as hex or decimal', async () => {
+    const chainData = [
+      {
+        id: 'fantom',
+        chain_identifier: 250,
+        name: 'Fantom',
+        shortname: '',
+      },
+      {
+        id: 'binance-smart-chain',
+        chain_identifier: 56,
+        name: 'Binance Smart Chain',
+        shortname: 'BSC',
+      },
+      {
+        id: 'xdai',
+        chain_identifier: 100,
+        name: 'xDAI',
+        shortname: '',
+      },
+      {
+        id: 'polygon-pos',
+        chain_identifier: 137,
+        name: 'Polygon POS',
+        shortname: 'MATIC',
+      },
+      {
+        id: 'ethereum',
+        chain_identifier: 1,
+        name: 'ethereum',
+        shortname: '',
+      },
+    ];
+
+    const controller = new TokenRatesController(
+      {
+        onTokensStateChange: stub(),
+        onCurrencyRateStateChange: stub(),
+        onNetworkStateChange: stub(),
+      },
+      { interval: 10 },
+    );
+    controller.update({
+      supportedChains: { data: chainData, timestamp: Date.now() },
+    });
+    controller.configure({ chainId: '1' });
+    const resultEth = await controller.getChainSlug();
+    expect(resultEth).toStrictEqual('ethereum');
+
+    controller.configure({ chainId: '0x38' });
+    const resultXDai = await controller.getChainSlug();
+
+    expect(resultXDai).toStrictEqual('binance-smart-chain');
+  });
 });

--- a/src/assets/TokenRatesController.ts
+++ b/src/assets/TokenRatesController.ts
@@ -113,13 +113,17 @@ function findChainSlug(
   if (!data) {
     return null;
   }
-  const chain =
+  let chain =
     data.find(
       ({ chain_identifier }) =>
-        chain_identifier !== null &&
-        (String(chain_identifier) === chainId ||
-          parseInt(chainId, 16) === chain_identifier),
+        chain_identifier !== null && String(chain_identifier) === chainId,
     ) ?? null;
+  if (chainId.startsWith('0x') || chain === null) {
+    chain =
+      data.find(({ chain_identifier }) => {
+        return parseInt(chainId, 16) === chain_identifier;
+      }) ?? null;
+  }
   return chain?.id || null;
 }
 

--- a/src/assets/TokenRatesController.ts
+++ b/src/assets/TokenRatesController.ts
@@ -116,7 +116,9 @@ function findChainSlug(
   const chain =
     data.find(
       ({ chain_identifier }) =>
-        chain_identifier !== null && String(chain_identifier) === chainId,
+        chain_identifier !== null &&
+        (String(chain_identifier) === chainId ||
+          parseInt(chainId, 16) === chain_identifier),
     ) ?? null;
   return chain?.id || null;
 }


### PR DESCRIPTION
The findChainSlug method on the TokensRateController should accept and correctly search for chain slugs when passed either a hex or decimal formatted chainId.


- CHANGED:
  - Makes a hex formatted chainID a valid argument to the findChainSlug method on TokensRateController. 
 

