### PR TITLE
Make TokenRatesController support fiat conversion for more networks

### DIFF
--- a/src/assets/TokenRatesController.test.ts
+++ b/src/assets/TokenRatesController.test.ts
@@ -63,6 +63,8 @@ describe('TokenRatesController', () => {
     nock('https://min-api.cryptocompare.com')
       .get('/data/price?fsym=ETH&tsyms=USD')
       .reply(200, { USD: 179.63 })
+      .get('/data/price?fsym=ETH&tsyms=ETH')
+      .reply(200, { ETH: 1 })
       .persist();
   });
 

--- a/src/assets/TokenRatesController.test.ts
+++ b/src/assets/TokenRatesController.test.ts
@@ -65,6 +65,8 @@ describe('TokenRatesController', () => {
       .reply(200, {})
       .get(`${COINGECKO_BSC_PATH}?contract_addresses=0xfoO&vs_currencies=gno`)
       .reply(200, {})
+      .get(COINGECKO_SUPPORTED_CURRENCIES)
+      .reply(200, ['eth', 'usd'])
       .persist();
 
     nock('https://min-api.cryptocompare.com')
@@ -194,9 +196,6 @@ describe('TokenRatesController', () => {
       },
       { interval: 10, chainId: '1' },
     );
-    stub(controller, 'checkIsSupportedVsCurrency').returns(
-      Promise.resolve(true),
-    );
     const address = '0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359';
     expect(controller.state.contractExchangeRates).toStrictEqual({});
     controller.tokens = [
@@ -282,8 +281,6 @@ describe('TokenRatesController', () => {
 
   it('should update exchange rates when native currency is not supported by coingecko', async () => {
     nock(COINGECKO_HOST)
-      .get(COINGECKO_SUPPORTED_CURRENCIES)
-      .reply(200, ['eth', 'usd'])
       .get(COINGECKO_ASSETS_PATH)
       .reply(200, [
         {
@@ -318,8 +315,8 @@ describe('TokenRatesController', () => {
       .persist();
 
     nock('https://min-api.cryptocompare.com')
-      .get('/data/price?fsym=MATIC&tsyms=ETH')
-      .reply(200, { ETH: 2 }) // 2 eth to 1 matic
+      .get('/data/price?fsym=ETH&tsyms=MATIC')
+      .reply(200, { MATIC: 0.5 }) // .5 eth to 1 matic
       .persist();
 
     const expectedExchangeRates = {

--- a/src/assets/TokenRatesController.test.ts
+++ b/src/assets/TokenRatesController.test.ts
@@ -5,11 +5,11 @@ import { NetworkController } from '../network/NetworkController';
 import { TokenRatesController } from './TokenRatesController';
 import { TokensController } from './TokensController';
 
-const COINGECKO_HOST = 'https://api.coingecko.com';
-const COINGECKO_ETH_PATH = '/api/v3/simple/token_price/ethereum';
-const COINGECKO_BSC_PATH = '/api/v3/simple/token_price/binance-smart-chain';
-const COINGECKO_MATIC_PATH = '/api/v3/simple/token_price/polygon-pos-network';
-const COINGECKO_ASSETS_PATH = '/api/v3/asset_platforms';
+const COINGECKO_HOST = 'https://api.coingecko.com/api/v3';
+const COINGECKO_ETH_PATH = '/simple/token_price/ethereum';
+const COINGECKO_BSC_PATH = '/simple/token_price/binance-smart-chain';
+const COINGECKO_MATIC_PATH = '/simple/token_price/polygon-pos-network';
+const COINGECKO_ASSETS_PATH = '/asset_platforms';
 const COINGECKO_SUPPORTED_CURRENCIES = '/simple/supported_vs_currencies';
 const ADDRESS = '0x01';
 
@@ -87,14 +87,6 @@ describe('TokenRatesController', () => {
     });
     expect(controller.state).toStrictEqual({
       contractExchangeRates: {},
-      supportedChains: {
-        data: null,
-        timestamp: 0,
-      },
-      supportedVsCurrencies: {
-        data: [],
-        timestamp: 0,
-      },
     });
   });
 
@@ -188,7 +180,6 @@ describe('TokenRatesController', () => {
   });
 
   it('should update all rates', async () => {
-    nock(COINGECKO_HOST);
     const network = new NetworkController();
     const preferences = new PreferencesController();
     const tokensController = new TokensController({

--- a/src/assets/TokenRatesController.test.ts
+++ b/src/assets/TokenRatesController.test.ts
@@ -91,6 +91,10 @@ describe('TokenRatesController', () => {
         data: null,
         timestamp: 0,
       },
+      supportedVsCurrencies: {
+        data: [],
+        timestamp: 0,
+      },
     });
   });
 
@@ -184,6 +188,7 @@ describe('TokenRatesController', () => {
   });
 
   it('should update all rates', async () => {
+    nock(COINGECKO_HOST);
     const network = new NetworkController();
     const preferences = new PreferencesController();
     const tokensController = new TokensController({
@@ -197,6 +202,9 @@ describe('TokenRatesController', () => {
         onNetworkStateChange: (listener) => network.subscribe(listener),
       },
       { interval: 10, chainId: '1' },
+    );
+    stub(controller, 'checkIsSupportedVsCurrency').returns(
+      Promise.resolve(true),
     );
     const address = '0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359';
     expect(controller.state.contractExchangeRates).toStrictEqual({});

--- a/src/assets/TokenRatesController.ts
+++ b/src/assets/TokenRatesController.ts
@@ -277,10 +277,10 @@ export class TokenRatesController extends BaseController<
    * Checks if the current native currency is a supported vs currency to use
    * to query for token exchange rates
    *
-   * @param currency - the native currency of the currently active network
+   * @param nativeCurrency - the native currency of the currently active network
    * @returns - Promise resolving to a boolean indicating whether it's a supported vsCurrency
    */
-  async checkIsSupportedVsCurrency(currency: string) {
+  async checkIsSupportedVsCurrency(nativeCurrency: string) {
     const { threshold } = this.config;
     const {
       data: cachedSupportedVsCurrencies,
@@ -297,10 +297,10 @@ export class TokenRatesController extends BaseController<
         data: currencies,
         timestamp: Date.now(),
       };
-      return currencies.includes(currency.toLowerCase());
+      return currencies.includes(nativeCurrency.toLowerCase());
     }
 
-    return cachedSupportedVsCurrencies.includes(currency.toLowerCase());
+    return cachedSupportedVsCurrencies.includes(nativeCurrency.toLowerCase());
   }
 
   /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,3 @@
 export const MAINNET = 'mainnet';
 export const RPC = 'rpc';
+export const FALL_BACK_VS_CURRENCY = 'ETH';


### PR DESCRIPTION
**Token Rates Controller Enhancement**

Currently we cannot provide fiat conversion rates for some custom networks (Polygon for one) [even though it is a supported coingecko platform](https://www.coingecko.com/api/documentations/v3#/asset_platforms/get_asset_platforms), because the native currency of the network [is not a supported vs_currency](https://www.coingecko.com/api/documentations/v3#/simple/get_simple_supported_vs_currencies) for querying exchange rates via their [exchange rate endpoint](https://www.coingecko.com/api/documentations/v3#/simple/get_simple_token_price__id_). This PR makes it possible to provide these fiat conversions by using `ETH` as a fallback vs_currency when the native currency is not supported and then simply updating the returned conversion rates so that they conform to the expected token/nativeCurrency format using the nativeCurrency/eth conversion rate.


