### PR TITLE
Fix bug that allowed for multiple fetch requests instantiate from getGasFeeEstimatesAndStartPolling

### DIFF
--- a/src/gas/GasFeeController.test.ts
+++ b/src/gas/GasFeeController.test.ts
@@ -143,7 +143,7 @@ describe('GasFeeController', () => {
       expect(result2).toStrictEqual(pollToken);
     });
 
-    it('should fetch new estimates if the poll tokens are cleared, and then should not make additional new fetches', async () => {
+    it('should cause the fetching new estimates if called after the poll tokens are cleared, and then should not cause additional new fetches when subsequently called', async () => {
       const pollToken = 'token';
 
       const firstCallPromise = gasFeeController.getGasFeeEstimatesAndStartPolling(

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -323,13 +323,14 @@ export class GasFeeController extends BaseController<
   async getGasFeeEstimatesAndStartPolling(
     pollToken: string | undefined,
   ): Promise<string> {
-    if (this.pollTokens.size === 0) {
-      await this._fetchGasFeeEstimateData();
-    }
-
     const _pollToken = pollToken || random();
 
-    this._startPolling(_pollToken);
+    this.pollTokens.add(_pollToken);
+
+    if (this.pollTokens.size === 1) {
+      await this._fetchGasFeeEstimateData();
+      this._poll();
+    }
 
     return _pollToken;
   }
@@ -444,15 +445,7 @@ export class GasFeeController extends BaseController<
     this.stopPolling();
   }
 
-  // should take a token, so we know that we are only counting once for each open transaction
-  private async _startPolling(pollToken: string) {
-    if (this.pollTokens.size === 0) {
-      this._poll();
-    }
-    this.pollTokens.add(pollToken);
-  }
-
-  private async _poll() {
+  private _poll() {
     if (this.intervalId) {
       clearInterval(this.intervalId);
     }


### PR DESCRIPTION
There was a bug in `getGasFeeEstimatesAndStartPolling` that could result in multiple fetch requests to the gas api being made, despite the `pollTokens` related logic meant to prevent this.

> If pollTokens is empty, it immediately fetches the gas estimates, but doesn't add the poll token until after the fetch has finished.
> So every single call will result in a new network request until the first one finishes. Then it will behave correctly and ensure only a single poll is active.

This PR fixes this by ensuring that the `pollTokens` are set before the asyncronous call. Tests are added that fail without this change and succeed with it.