### PR TITLE
Setting tokenList to empty object in test networks

### DIFF
--- a/src/assets/TokenListController.test.ts
+++ b/src/assets/TokenListController.test.ts
@@ -629,6 +629,8 @@ describe('TokenListController', () => {
     nock(TOKEN_END_POINT_API)
       .get(`/tokens/${NetworksChainId.mainnet}`)
       .reply(200, sampleMainnetTokenList)
+      .get(`/tokens/${NetworksChainId.ropsten}`)
+      .reply(200, { error: 'ChainId 3 is not supported' })
       .get(`/tokens/56`)
       .reply(200, sampleBinanceTokenList)
       .persist();
@@ -647,6 +649,19 @@ describe('TokenListController', () => {
     expect(controller.state.tokenList).toStrictEqual(
       sampleSingleChainState.tokenList,
     );
+    expect(
+      controller.state.tokensChainsCache[NetworksChainId.mainnet].data,
+    ).toStrictEqual(
+      sampleTwoChainState.tokensChainsCache[NetworksChainId.mainnet].data,
+    );
+    network.update({
+      provider: {
+        type: 'ropsten',
+        chainId: NetworksChainId.ropsten,
+      },
+    });
+    await new Promise<void>((resolve) => setTimeout(() => resolve(), 10));
+    expect(controller.state.tokenList).toStrictEqual({});
     expect(
       controller.state.tokensChainsCache[NetworksChainId.mainnet].data,
     ).toStrictEqual(

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -274,11 +274,15 @@ export class TokenListController extends BaseController<
         const tokensFromAPI: DynamicToken[] = await safelyExecute(() =>
           fetchTokenList(this.chainId, this.abortController.signal),
         );
-        if (!tokensFromAPI) {
+        if (!tokensFromAPI) {     
+          const backupTokenList = tokensChainsCache[this.chainId]? tokensChainsCache[this.chainId].data:[];
+          for (const token of backupTokenList) {
+            tokenList[token.address] = token;
+          }
           this.update(() => {
             return {
               ...tokensData,
-              tokenList: {},
+              tokenList,
               tokensChainsCache,
             };
           });

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -274,8 +274,10 @@ export class TokenListController extends BaseController<
         const tokensFromAPI: DynamicToken[] = await safelyExecute(() =>
           fetchTokenList(this.chainId, this.abortController.signal),
         );
-        if (!tokensFromAPI) {     
-          const backupTokenList = tokensChainsCache[this.chainId]? tokensChainsCache[this.chainId].data:[];
+        if (!tokensFromAPI) {
+          const backupTokenList = tokensChainsCache[this.chainId]
+            ? tokensChainsCache[this.chainId].data
+            : [];
           for (const token of backupTokenList) {
             tokenList[token.address] = token;
           }

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -275,6 +275,13 @@ export class TokenListController extends BaseController<
           fetchTokenList(this.chainId, this.abortController.signal),
         );
         if (!tokensFromAPI) {
+          this.update(() => {
+            return {
+              ...tokensData,
+              tokenList: {},
+              tokensChainsCache,
+            };
+          });
           return;
         }
         // filtering out tokens with less than 2 occurrences


### PR DESCRIPTION
Fixes #587 

For test networks, the tokenList object should be cleared as the API does not support the test networks and auto-detection should be disabled.