### PR TITLE
Removing syncToken functionality

### DIFF
--- a/src/apis/token-service.test.ts
+++ b/src/apis/token-service.test.ts
@@ -1,10 +1,6 @@
 import nock from 'nock';
 import { NetworksChainId } from '../network/NetworkController';
-import {
-  fetchTokenList,
-  syncTokens,
-  fetchTokenMetadata,
-} from './token-service';
+import { fetchTokenList, fetchTokenMetadata } from './token-service';
 
 const TOKEN_END_POINT_API = 'https://token-api.metaswap.codefi.network';
 
@@ -153,15 +149,6 @@ describe('FetchtokenList', () => {
     const tokens = await fetchTokenList(NetworksChainId.mainnet, signal);
 
     expect(tokens).toStrictEqual(sampleTokenList);
-  });
-  it('should call the api to sync tokens and returns nothing', async () => {
-    const { signal } = new AbortController();
-    nock(TOKEN_END_POINT_API)
-      .get(`/sync/${NetworksChainId.mainnet}`)
-      .reply(200)
-      .persist();
-
-    expect(await syncTokens(NetworksChainId.mainnet, signal)).toBeUndefined();
   });
   it('should call the api to return the token metadata for eth address provided', async () => {
     const { signal } = new AbortController();

--- a/src/apis/token-service.ts
+++ b/src/apis/token-service.ts
@@ -2,9 +2,6 @@ import { timeoutFetch } from '../util';
 
 const END_POINT = 'https://token-api.metaswap.codefi.network';
 
-function syncTokensURL(chainId: string) {
-  return `${END_POINT}/sync/${chainId}`;
-}
 function getTokensURL(chainId: string) {
   return `${END_POINT}/tokens/${chainId}`;
 }
@@ -49,19 +46,6 @@ export async function fetchTokenMetadata(
     return parseJsonResponse(response);
   }
   return undefined;
-}
-
-/**
- * Forces a sync of token metadata for a given network chainId.
- * Syncing happens every 1 hour in the background, this api can
- * be used to force a sync from our side
- */
-export async function syncTokens(
-  chainId: string,
-  abortSignal: AbortSignal,
-): Promise<void> {
-  const syncURL = syncTokensURL(chainId);
-  await queryApi(syncURL, abortSignal);
 }
 
 /**

--- a/src/assets/TokenListController.test.ts
+++ b/src/assets/TokenListController.test.ts
@@ -837,64 +837,6 @@ describe('TokenListController', () => {
     controller.destroy();
   });
 
-  it('should call syncTokens to update the token list in the backend and clears the cache for the next fetch', async () => {
-    const tokenListBeforeSync = [
-      {
-        address: '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f',
-        symbol: 'SNX',
-        decimals: 18,
-        occurrences: 11,
-        name: 'Synthetix',
-        iconUrl: 'https://airswap-token-images.s3.amazonaws.com/SNX.png',
-      },
-    ];
-    nock(TOKEN_END_POINT_API)
-      .get(`/sync/${NetworksChainId.mainnet}`)
-      .reply(200)
-      .persist();
-
-    nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${NetworksChainId.mainnet}`)
-      .once()
-      .reply(200, tokenListBeforeSync);
-
-    nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${NetworksChainId.mainnet}`)
-      .reply(200, sampleMainnetTokenList)
-      .persist();
-
-    const messenger = getRestrictedMessenger();
-    const controller = new TokenListController({
-      chainId: NetworksChainId.mainnet,
-      useStaticTokenList: false,
-      onNetworkStateChange: (listener) => network.subscribe(listener),
-      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
-      messenger,
-      interval: 200,
-    });
-    await controller.start();
-    expect(controller.state.tokenList).toStrictEqual({
-      '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f': {
-        address: '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f',
-        symbol: 'SNX',
-        decimals: 18,
-        occurrences: 11,
-        name: 'Synthetix',
-        iconUrl: 'https://airswap-token-images.s3.amazonaws.com/SNX.png',
-      },
-    });
-    expect(await controller.syncTokens()).toBeUndefined();
-    expect(controller.state.tokensChainsCache['1']).toStrictEqual({
-      timestamp: 0,
-      data: [],
-    });
-    await new Promise<void>((resolve) => setTimeout(() => resolve(), 300));
-    expect(controller.state.tokenList).toStrictEqual(
-      sampleSingleChainState.tokenList,
-    );
-    controller.destroy();
-  });
-
   it('should return the metadata for a tokenAddress provided', async () => {
     nock(TOKEN_END_POINT_API)
       .get(`/token/${NetworksChainId.mainnet}`)

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -6,11 +6,7 @@ import AbortController from 'abort-controller';
 import { BaseController } from '../BaseControllerV2';
 import type { RestrictedControllerMessenger } from '../ControllerMessenger';
 import { safelyExecute } from '../util';
-import {
-  fetchTokenList,
-  syncTokens,
-  fetchTokenMetadata,
-} from '../apis/token-service';
+import { fetchTokenList, fetchTokenMetadata } from '../apis/token-service';
 import { NetworkState } from '../network/NetworkController';
 import { PreferencesState } from '../user/PreferencesController';
 
@@ -337,34 +333,6 @@ export class TokenListController extends BaseController<
       return dataCache.data;
     }
     return null;
-  }
-
-  /**
-   * Calls the API to sync the tokens in the token service
-   */
-  async syncTokens(): Promise<void> {
-    const releaseLock = await this.mutex.acquire();
-    try {
-      await safelyExecute(() =>
-        syncTokens(this.chainId, this.abortController.signal),
-      );
-      const { tokenList, tokensChainsCache } = this.state;
-      const updatedTokensChainsCache = {
-        ...tokensChainsCache,
-        [this.chainId]: {
-          timestamp: 0,
-          data: [],
-        },
-      };
-      this.update(() => {
-        return {
-          tokenList,
-          tokensChainsCache: updatedTokensChainsCache,
-        };
-      });
-    } finally {
-      releaseLock();
-    }
   }
 
   /**


### PR DESCRIPTION
Fixes #589 
Removing SyncToken functionality from TokenListController and token-service as usage of this function from our application may result in the API being syncing constantly.