### PR TITLE
Enabling http caching for token service

### DIFF
--- a/src/apis/token-service.ts
+++ b/src/apis/token-service.ts
@@ -63,6 +63,7 @@ async function queryApi(
     method: 'GET',
     mode: 'cors',
     signal: abortSignal,
+    cache: 'default',
   };
   fetchOptions.headers = new window.Headers();
   fetchOptions.headers.set('Content-Type', 'application/json');


### PR DESCRIPTION
Fixes: #593 
We need to enable http caching for token API from our side

