### PR TITLE
16.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [16.0.0]
+### Changed
+- **BREAKING**: Remove Synctokens method from the tokens-service ([#590](https://github.com/MetaMask/controllers/pull/590))
+  - This is breaking for any consumers of this method.
+- Enable default caching for token-service ([#594](https://github.com/MetaMask/controllers/pull/594))
+- Set tokenList to empty object in test networks ([#588](https://github.com/MetaMask/controllers/pull/588))
+
+### Fixed
+- Fix bug that allowed for multiple fetch requests instantiate from getGasFeeEstimatesAndStartPolling ([#586](https://github.com/MetaMask/controllers/pull/586))
+
+
 ## [15.1.0]
 ### Changed
 - Improve transaction state management ([#582](https://github.com/MetaMask/controllers/pull/582))
@@ -369,7 +380,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Remove shapeshift controller (#209)
 
-[Unreleased]: https://github.com/MetaMask/controllers/compare/v15.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/controllers/compare/v16.0.0...HEAD
+[16.0.0]: https://github.com/MetaMask/controllers/compare/v15.1.0...v16.0.0
 [15.1.0]: https://github.com/MetaMask/controllers/compare/v15.0.2...v15.1.0
 [15.0.2]: https://github.com/MetaMask/controllers/compare/v15.0.1...v15.0.2
 [15.0.1]: https://github.com/MetaMask/controllers/compare/v15.0.0...v15.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [16.0.0]
 ### Changed
-- **BREAKING**: Remove Synctokens method from the tokens-service ([#590](https://github.com/MetaMask/controllers/pull/590))
+- **BREAKING**: Remove `syncTokens` method from the TokenListController ([#590](https://github.com/MetaMask/controllers/pull/590))
   - This is breaking for any consumers of this method.
 - Enable default caching for token-service ([#594](https://github.com/MetaMask/controllers/pull/594))
 - Set tokenList to empty object in test networks ([#588](https://github.com/MetaMask/controllers/pull/588))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set tokenList to empty object in test networks ([#588](https://github.com/MetaMask/controllers/pull/588))
 
 ### Fixed
-- Fix bug that allowed for multiple fetch requests instantiate from getGasFeeEstimatesAndStartPolling ([#586](https://github.com/MetaMask/controllers/pull/586))
+- Fix bug that allowed `getGasFeeEstimatesAndStartPolling` to initiate multiple simultaneous fetch requests ([#586](https://github.com/MetaMask/controllers/pull/586))
 
 
 ## [15.1.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [16.0.0]
 ### Changed
-- **BREAKING**: Remove `syncTokens` method from the TokenListController ([#590](https://github.com/MetaMask/controllers/pull/590))
-  - This is breaking for any consumers of this method.
 - Enable HTTP caching for the dynamic token list managed by the TokenListController ([#594](https://github.com/MetaMask/controllers/pull/594))
-- Set tokenList to empty object in test networks ([#588](https://github.com/MetaMask/controllers/pull/588))
+
+### Removed
+- **BREAKING**: Remove `syncTokens` method from the TokenListController ([#590](https://github.com/MetaMask/controllers/pull/590))
 
 ### Fixed
 - Fix bug that allowed `getGasFeeEstimatesAndStartPolling` to initiate multiple simultaneous fetch requests ([#586](https://github.com/MetaMask/controllers/pull/586))
-
+- Fix bug that cause an invalid tokenList to be in controller state when active network is not supported by our tokenList API ([#588](https://github.com/MetaMask/controllers/pull/588))
 
 ## [15.1.0]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **BREAKING**: Remove `syncTokens` method from the TokenListController ([#590](https://github.com/MetaMask/controllers/pull/590))
   - This is breaking for any consumers of this method.
-- Enable default caching for token-service ([#594](https://github.com/MetaMask/controllers/pull/594))
+- Enable HTTP caching for the dynamic token list managed by the TokenListController ([#594](https://github.com/MetaMask/controllers/pull/594))
 - Set tokenList to empty object in test networks ([#588](https://github.com/MetaMask/controllers/pull/588))
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/controllers",
-  "version": "15.1.0",
+  "version": "16.0.0",
   "description": "Collection of platform-agnostic modules for creating secure data models for cryptocurrency wallets",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
This a release candidate for v.16.0.0
## [16.0.0]

### Changed
- **BREAKING**: Remove Synctokens method from the tokens-service ([#590](https://github.com/MetaMask/controllers/pull/590))
  - This is breaking for any consumers of this method.
- Enable default caching for token-service ([#594](https://github.com/MetaMask/controllers/pull/594))

### Fixed
- Fix bug that allowed for multiple fetch requests instantiate from getGasFeeEstimatesAndStartPolling ([#586](https://github.com/MetaMask/controllers/pull/586))