### PR TITLE
Add client id header to GasFeeController

### DIFF
--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -239,6 +239,8 @@ export class GasFeeController extends BaseController<
 
   private ethQuery: any;
 
+  private clientId?: string;
+
   /**
    * Creates a GasFeeController instance
    *
@@ -258,6 +260,7 @@ export class GasFeeController extends BaseController<
     onNetworkStateChange,
     legacyAPIEndpoint = LEGACY_GAS_PRICES_API_URL,
     EIP1559APIEndpoint = GAS_FEE_API,
+    clientId,
   }: {
     interval?: number;
     messenger: GasFeeMessenger;
@@ -273,6 +276,7 @@ export class GasFeeController extends BaseController<
     onNetworkStateChange: (listener: (state: NetworkState) => void) => void;
     legacyAPIEndpoint?: string;
     EIP1559APIEndpoint?: string;
+    clientId?: string;
   }) {
     super({
       name,
@@ -294,6 +298,7 @@ export class GasFeeController extends BaseController<
     this.currentChainId = this.getChainId();
     const provider = getProvider();
     this.ethQuery = new EthQuery(provider);
+    this.clientId = clientId;
     onNetworkStateChange(async () => {
       const newProvider = getProvider();
       const newChainId = this.getChainId();
@@ -368,6 +373,7 @@ export class GasFeeController extends BaseController<
       if (isEIP1559Compatible) {
         const estimates = await this.fetchGasEstimates(
           this.EIP1559APIEndpoint.replace('<chain_id>', `${chainId}`),
+          this.clientId,
         );
         const {
           suggestedMaxPriorityFeePerGas,
@@ -385,6 +391,7 @@ export class GasFeeController extends BaseController<
       } else if (isLegacyGasAPICompatible) {
         const estimates = await this.fetchLegacyGasPriceEstimates(
           this.legacyAPIEndpoint.replace('<chain_id>', `${chainId}`),
+          this.clientId,
         );
         newState = {
           gasFeeEstimates: estimates,

--- a/src/gas/gas-util.test.ts
+++ b/src/gas/gas-util.test.ts
@@ -63,6 +63,18 @@ describe('gas utils', () => {
       nock.cleanAll();
     });
 
+    it('should fetch external gasFeeEstimates with client id header when clientId arg is added', async () => {
+      const scope = nock('https://not-a-real-url/')
+        .matchHeader('x-client-id', 'test')
+        .get(/.+/u)
+        .reply(200, mockEIP1559ApiResponses[0])
+        .persist();
+      const result = await fetchGasEstimates('https://not-a-real-url/', 'test');
+      expect(result).toMatchObject(mockEIP1559ApiResponses[0]);
+      scope.done();
+      nock.cleanAll();
+    });
+
     it('should fetch and normalize external gasFeeEstimates when data is has an invalid number of decimals', async () => {
       const expectedResult = {
         low: {
@@ -109,6 +121,29 @@ describe('gas utils', () => {
         .persist();
       const result = await fetchLegacyGasPriceEstimates(
         'https://not-a-real-url/',
+      );
+      expect(result).toMatchObject({
+        high: '30',
+        medium: '25',
+        low: '22',
+      });
+      scope.done();
+      nock.cleanAll();
+    });
+
+    it('should fetch external gasPrices with client id header when clientId arg is passed', async () => {
+      const scope = nock('https://not-a-real-url/')
+        .matchHeader('x-client-id', 'test')
+        .get(/.+/u)
+        .reply(200, {
+          SafeGasPrice: '22',
+          ProposeGasPrice: '25',
+          FastGasPrice: '30',
+        })
+        .persist();
+      const result = await fetchLegacyGasPriceEstimates(
+        'https://not-a-real-url/',
+        'test',
       );
       expect(result).toMatchObject({
         high: '30',

--- a/src/gas/gas-util.ts
+++ b/src/gas/gas-util.ts
@@ -16,8 +16,14 @@ export function normalizeGWEIDecimalNumbers(n: string | number) {
   return numberAsGWEI;
 }
 
-export async function fetchGasEstimates(url: string, clientId?: string): Promise<GasFeeEstimates> {
-  const estimates: GasFeeEstimates = await handleFetch(url, clientId ? { headers: makeClientIdHeader(clientId) } : undefined);
+export async function fetchGasEstimates(
+  url: string,
+  clientId?: string,
+): Promise<GasFeeEstimates> {
+  const estimates: GasFeeEstimates = await handleFetch(
+    url,
+    clientId ? { headers: makeClientIdHeader(clientId) } : undefined,
+  );
   const normalizedEstimates: GasFeeEstimates = {
     estimatedBaseFee: normalizeGWEIDecimalNumbers(estimates.estimatedBaseFee),
     low: {
@@ -66,7 +72,7 @@ export async function fetchLegacyGasPriceEstimates(
     mode: 'cors',
     headers: {
       'Content-Type': 'application/json',
-      ...clientId && makeClientIdHeader(clientId),
+      ...(clientId && makeClientIdHeader(clientId)),
     },
   });
   return {

--- a/src/gas/gas-util.ts
+++ b/src/gas/gas-util.ts
@@ -8,14 +8,16 @@ import {
   LegacyGasPriceEstimate,
 } from './GasFeeController';
 
+const makeClientIdHeader = (clientId: string) => ({ 'X-Client-Id': clientId });
+
 export function normalizeGWEIDecimalNumbers(n: string | number) {
   const numberAsWEIHex = gweiDecToWEIBN(n).toString(16);
   const numberAsGWEI = weiHexToGweiDec(numberAsWEIHex).toString(10);
   return numberAsGWEI;
 }
 
-export async function fetchGasEstimates(url: string): Promise<GasFeeEstimates> {
-  const estimates: GasFeeEstimates = await handleFetch(url);
+export async function fetchGasEstimates(url: string, clientId?: string): Promise<GasFeeEstimates> {
+  const estimates: GasFeeEstimates = await handleFetch(url, clientId ? { headers: makeClientIdHeader(clientId) } : undefined);
   const normalizedEstimates: GasFeeEstimates = {
     estimatedBaseFee: normalizeGWEIDecimalNumbers(estimates.estimatedBaseFee),
     low: {
@@ -55,6 +57,7 @@ export async function fetchGasEstimates(url: string): Promise<GasFeeEstimates> {
  */
 export async function fetchLegacyGasPriceEstimates(
   url: string,
+  clientId?: string,
 ): Promise<LegacyGasPriceEstimate> {
   const result = await handleFetch(url, {
     referrer: url,
@@ -63,6 +66,7 @@ export async function fetchLegacyGasPriceEstimates(
     mode: 'cors',
     headers: {
       'Content-Type': 'application/json',
+      ...clientId && makeClientIdHeader(clientId),
     },
   });
   return {


### PR DESCRIPTION
**PR Title**

- Add optional clientId param to GasFeeController

**Description**

We accept the clientId param in the GasFeeController and pass it into the gas api via the request header. This allows the gas api to determine the origin of each request and collect better metrics and thus perform better analysis to better understand bugs and user behavior across the clients.

I manually tested this change out on the extension. I passed `clientId: extension` into the GasFeeController instance and watched the client id header (e.g. `x-client-id: extension`) populate on every request to the gas api.

- ADDED:

  - Add optional clientId param to the GasFeeController
  - Assign param to object's `this` variable
  - Pass `this.clientId` into fetchGasEstimates and fetchLegacyPriceGasEstimates calls
  - From there, pass clientId into the underlying requests as a header

**Checklist**

- [ ] Tests are included if applicable
- [ ] Any added code is fully documented

**Issue**

Resolves #???
