### PR TITLE
Fix return type of `fetchGasFeeEstimates`

### DIFF
--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -347,7 +347,7 @@ export class GasFeeController extends BaseController<
    */
   async _fetchGasFeeEstimateData(
     options: FetchGasFeeEstimateOptions = {},
-  ): Promise<GasFeeState | undefined> {
+  ): Promise<GasFeeState> {
     const { shouldUpdateState = true } = options;
     let isEIP1559Compatible;
     const isLegacyGasAPICompatible = this.getCurrentNetworkLegacyGasAPICompatibility();


### PR DESCRIPTION
The return type of the `_fetchGasFeeEstimates` method (and the `fetchGasFeeEstimates` method, transitively) of the GasFeeController has been updated to remove the `| undefined`. It never returns `undefined`.