### PR TITLE
Verify failed transaction status

### DIFF
--- a/src/transaction/TransactionController.test.ts
+++ b/src/transaction/TransactionController.test.ts
@@ -680,6 +680,7 @@ describe('TransactionController', () => {
         chainId: '3',
         status: TransactionStatus.submitted,
         transactionHash: '1337',
+        pollingAttempts: 0,
       } as any);
       controller.state.transactions.push({} as any);
 
@@ -715,6 +716,7 @@ describe('TransactionController', () => {
         networkID: '3',
         status: TransactionStatus.submitted,
         transactionHash: '1337',
+        pollingAttempts: 0,
       } as any);
       controller.state.transactions.push({} as any);
 
@@ -748,6 +750,7 @@ describe('TransactionController', () => {
       networkID: '3',
       status: TransactionStatus.submitted,
       transactionHash: '1338',
+      pollingAttempts: 0,
     } as any);
     await controller.queryTransactionStatuses();
     expect(controller.state.transactions[0].status).toBe(
@@ -777,6 +780,7 @@ describe('TransactionController', () => {
       transaction: {
         gasUsed: undefined,
       },
+      pollingAttempts: 0,
     } as any);
     await controller.queryTransactionStatuses();
     expect(controller.state.transactions[0].verifiedOnBlockchain).toBe(true);
@@ -809,7 +813,7 @@ describe('TransactionController', () => {
     await controller.queryTransactionStatuses();
     expect(controller.state.transactions[0].pollingAttempts).toBe(1);
   });
-  it('should set the tranasction status to failed if the polling attempt limit is reached', async () => {
+  it('should set the transaction status to failed if the polling attempt limit is reached', async () => {
     await new Promise((resolve) => {
       const controller = new TransactionController(
         {

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -85,10 +85,25 @@ export interface Transaction {
   estimatedBaseFee?: string;
 }
 
+/**
+ * @type GasPriceValue
+ *
+ * GasPriceValue representation
+ *
+ * @property gasPrice - Value of the gas price
+ */
 export interface GasPriceValue {
   gasPrice: string;
 }
 
+/**
+ * @type FeeMarketEIP1559Values
+ *
+ * FeeMarketEIP1559Values representation
+ *
+ * @property maxFeePerGas - Value of the gas price
+ * @property maxPriorityFeePerGas - Part of the fee that goes to the miner
+ */
 export interface FeeMarketEIP1559Values {
   maxFeePerGas: string;
   maxPriorityFeePerGas: string;
@@ -119,6 +134,27 @@ export enum WalletDevice {
   OTHER = 'other_device',
 }
 
+/**
+ * @type TransactionMetaBase
+ *
+ * TransactionMetaBase representation
+ *
+ * @property isTransfer -
+ * @property transferInformation
+ * @property id - Transaction ID
+ * @property networkID - Current network ID
+ * @property chainId - Current chain ID
+ * @property origin - Transaction origin
+ * @property rawTransaction - Transaction encoded data
+ * @property time - Transaction timestamp
+ * @property toSmartContract - Value indicating if the transaction is directed to a smart contract
+ * @property transaction - Transaction data
+ * @property transactionHash - Transaction hash
+ * @property blockNumber - Transaction block number
+ * @property deviceConfirmedOn - Device in which the confirmed transaction was detected
+ * @property verifiedOnBlockchain - Value indicating if the transaction data was verified against th blockchain
+ * @property pollingAttempts - Value indicating the number of polling attempts to Infura
+ */
 type TransactionMetaBase = {
   isTransfer?: boolean;
   transferInformation?: {

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -1335,7 +1335,7 @@ export class TransactionController extends BaseController<
           transactionHash,
         ]);
 
-        if (!txObj && meta.pollingAttempts) {
+        if (!txObj && typeof meta.pollingAttempts === 'number') {
           meta.pollingAttempts += 1;
           return [meta, true];
         }

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -139,8 +139,8 @@ export enum WalletDevice {
  *
  * TransactionMetaBase representation
  *
- * @property isTransfer -
- * @property transferInformation
+ * @property isTransfer - Value indicating if the transaction is a transfer
+ * @property transferInformation - Transfer information
  * @property id - Transaction ID
  * @property networkID - Current network ID
  * @property chainId - Current chain ID
@@ -173,8 +173,8 @@ type TransactionMetaBase = {
   transactionHash?: string;
   blockNumber?: string;
   deviceConfirmedOn?: WalletDevice;
-  verifiedOnBlockchain: boolean;
-  pollingAttempts: number;
+  verifiedOnBlockchain?: boolean;
+  pollingAttempts?: number;
 };
 
 /**
@@ -1335,7 +1335,7 @@ export class TransactionController extends BaseController<
           transactionHash,
         ]);
 
-        if (!txObj) {
+        if (!txObj && meta.pollingAttempts) {
           meta.pollingAttempts += 1;
           return [meta, true];
         }


### PR DESCRIPTION
Update logic to verify if a transaction was replaced or dropped by querying the status three times before updating the status to `Failed` instead of using `getTransactionReceipt`.