### PR TITLE
Tweaks in GasFeeController for type-0 transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/controllers",
-  "version": "17.0.0",
+  "version": "17.1.0",
   "description": "Collection of platform-agnostic modules for creating secure data models for cryptocurrency wallets",
   "keywords": [
     "MetaMask",

--- a/src/gas/GasFeeController.test.ts
+++ b/src/gas/GasFeeController.test.ts
@@ -6,6 +6,7 @@ import {
   GetGasFeeState,
   GasFeeStateChange,
   LegacyGasPriceEstimate,
+  GAS_ESTIMATE_TYPES,
 } from './GasFeeController';
 
 const TEST_GAS_FEE_API = 'https://mock-gas-server.herokuapp.com/<chain_id>';
@@ -255,6 +256,10 @@ describe('GasFeeController', () => {
       expect(
         (gasFeeController.state.gasFeeEstimates as LegacyGasPriceEstimate).high,
       ).toBe('30');
+
+      expect(gasFeeController.state.gasEstimateType).toStrictEqual(
+        GAS_ESTIMATE_TYPES.LEGACY,
+      );
 
       expect(gasFeeController.state.gasFeeEstimates).not.toHaveProperty(
         'estimatedBaseFee',

--- a/src/gas/GasFeeController.test.ts
+++ b/src/gas/GasFeeController.test.ts
@@ -243,4 +243,22 @@ describe('GasFeeController', () => {
       );
     });
   });
+
+  describe('when checking for type-0 transaction on any network supporting EIP-1559', () => {
+    it('should _fetchGasFeeEstimateData', async () => {
+      getCurrentNetworkLegacyGasAPICompatibility.mockImplementation(() => true);
+      expect(gasFeeController.state.gasFeeEstimates).toStrictEqual({});
+      const estimates = await gasFeeController._fetchGasFeeEstimateData({
+        transactionType: '0x0',
+      });
+      expect(estimates).toHaveProperty('gasFeeEstimates');
+      expect(
+        (gasFeeController.state.gasFeeEstimates as LegacyGasPriceEstimate).high,
+      ).toBe('30');
+
+      expect(gasFeeController.state.gasFeeEstimates).not.toHaveProperty(
+        'estimatedBaseFee',
+      );
+    });
+  });
 });

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -374,6 +374,7 @@ export class GasFeeController extends BaseController<
    * @param options - The gas fee estimate options.
    * @param options.shouldUpdateState - Determines whether the state should be updated with the
    * updated gas estimates.
+   * @param options.transactionType - Determines type of the transaction for which estimate data is required.
    * @returns The gas fee estimates.
    */
   async _fetchGasFeeEstimateData(


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Tweaks in GasFeeController for type-0 transactions**

- Tweaking GasFeeController to get legacy estimates of Gas for type-0 transactions.

- CHANGED:

  - `_fetchGasFeeEstimateData` has been changed to accept optional addition parameter transactionType and get legacy estimates of Gas for type-0 transactions 

**Checklist**

- [X] Tests are included if applicable
- [X] Any added code is fully documented

**Issue**
https://github.com/MetaMask/metamask-extension/issues/12189

