### PR TITLE
[FIX] Turn off token detection by default

### DIFF
--- a/src/user/PreferencesController.ts
+++ b/src/user/PreferencesController.ts
@@ -75,7 +75,7 @@ export class PreferencesController extends BaseController<
       ipfsGateway: 'https://ipfs.io/ipfs/',
       lostIdentities: {},
       selectedAddress: '',
-      useStaticTokenList: false,
+      useStaticTokenList: true,
     };
     this.initialize();
   }


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**PR Title**

- [FIX] Turn off token detection by default

**Description**

Token detection is on by default for mobile users who update to v3.4.0. We need to set `useStaticTokenList` on `PreferencesController` to `false` by default.

- CHANGED:
  - Set `useStaticTokenList` on `PreferencesController` to `false` by default.

**Checklist**

- [ ] Tests are included if applicable
- [ ] Any added code is fully documented

**Issue**

Resolves #???
