### PR TITLE
Extract determineGasFeeCalculations

### DIFF
--- a/src/gas/GasFeeController.test.ts
+++ b/src/gas/GasFeeController.test.ts
@@ -2,18 +2,23 @@ import { useFakeTimers, SinonFakeTimers } from 'sinon';
 import { mocked } from 'ts-jest/utils';
 import { ControllerMessenger } from '../ControllerMessenger';
 import {
-  EstimatedGasFeeTimeBounds,
+  GAS_ESTIMATE_TYPES,
   GasFeeController,
-  GasFeeEstimates,
+  GasFeeState,
   GasFeeStateChange,
+  GasFeeStateEthGasPrice,
+  GasFeeStateFeeMarket,
+  GasFeeStateLegacy,
   GetGasFeeState,
-  LegacyGasPriceEstimate,
 } from './GasFeeController';
-import { calculateTimeEstimate } from './gas-util';
+import determineGasFeeCalculations from './determineGasFeeCalculations';
 
-const mockedCalculateTimeEstimate = mocked(calculateTimeEstimate);
+jest.mock('./determineGasFeeCalculations');
 
-jest.mock('./gas-util');
+const mockedDetermineGasFeeCalculations = mocked(
+  determineGasFeeCalculations,
+  true,
+);
 
 const name = 'GasFeeController';
 
@@ -38,104 +43,95 @@ function getRestrictedMessenger() {
 }
 
 /**
- * Builds a mock return value for the `fetchGasEstimates` function that GasFeeController takes. All
- * of the values here are filled in to satisfy the GasFeeEstimates type as well as the gas fee
- * estimate logic within GasFeeController and are not intended to represent any particular scenario.
+ * Builds mock gas fee state that would typically be generated for an EIP-1559-compatible network.
+ * This data is merely intended to fit the GasFeeStateFeeMarket type and does not represent any
+ * real-world scenario.
  *
  * @param args - The arguments.
- * @param args.modifier - A number you can use to build a unique return value in the event that
- * `fetchGasEstimates` is called multiple times. All data points will be multiplied by this number.
+ * @param args.modifier - A number you can use to build a unique return value in the event that you
+ * need to build multiple return values. All data points will be multiplied by this number.
  * @returns The mock data.
  */
-function buildMockReturnValueForFetchGasEstimates({
+function buildMockGasFeeStateFeeMarket({
   modifier = 1,
-} = {}): GasFeeEstimates {
+} = {}): GasFeeStateFeeMarket {
   return {
-    low: {
-      minWaitTimeEstimate: 10000 * modifier,
-      maxWaitTimeEstimate: 20000 * modifier,
-      suggestedMaxPriorityFeePerGas: modifier.toString(),
-      suggestedMaxFeePerGas: (10 * modifier).toString(),
+    gasFeeEstimates: {
+      low: {
+        minWaitTimeEstimate: 10000 * modifier,
+        maxWaitTimeEstimate: 20000 * modifier,
+        suggestedMaxPriorityFeePerGas: modifier.toString(),
+        suggestedMaxFeePerGas: (10 * modifier).toString(),
+      },
+      medium: {
+        minWaitTimeEstimate: 30000 * modifier,
+        maxWaitTimeEstimate: 40000 * modifier,
+        suggestedMaxPriorityFeePerGas: (1.5 * modifier).toString(),
+        suggestedMaxFeePerGas: (20 * modifier).toString(),
+      },
+      high: {
+        minWaitTimeEstimate: 50000 * modifier,
+        maxWaitTimeEstimate: 60000 * modifier,
+        suggestedMaxPriorityFeePerGas: (2 * modifier).toString(),
+        suggestedMaxFeePerGas: (30 * modifier).toString(),
+      },
+      estimatedBaseFee: (100 * modifier).toString(),
     },
-    medium: {
-      minWaitTimeEstimate: 30000 * modifier,
-      maxWaitTimeEstimate: 40000 * modifier,
-      suggestedMaxPriorityFeePerGas: (1.5 * modifier).toString(),
-      suggestedMaxFeePerGas: (20 * modifier).toString(),
+    estimatedGasFeeTimeBounds: {
+      lowerTimeBound: 1000 * modifier,
+      upperTimeBound: 2000 * modifier,
     },
-    high: {
-      minWaitTimeEstimate: 50000 * modifier,
-      maxWaitTimeEstimate: 60000 * modifier,
-      suggestedMaxPriorityFeePerGas: (2 * modifier).toString(),
-      suggestedMaxFeePerGas: (30 * modifier).toString(),
-    },
-    estimatedBaseFee: (100 * modifier).toString(),
+    gasEstimateType: GAS_ESTIMATE_TYPES.FEE_MARKET,
   };
 }
 
 /**
- * Builds a mock return value for the `legacyFetchGasPriceEstimates` function that GasFeeController
- * takes. All of the values here are filled in to satisfy the LegacyGasPriceEstimate type as well as
- * the gas fee estimate logic in GasFeeController and are not intended to represent any particular
- * scenario.
+ * Builds mock gas fee state that would typically be generated for an non-EIP-1559-compatible
+ * network. This data is merely intended to fit the GasFeeStateLegacy type and does not represent
+ * any real-world scenario.
  *
  * @param args - The arguments.
- * @param args.modifier - A number you can use to build a unique return value in the event that
- * `legacyFetchGasPriceEstimates` is called multiple times. All data points will be multiplied by
- * this number.
+ * @param args.modifier - A number you can use to build a unique return value in the event that you
+ * need to build multiple return values. All data points will be multiplied by this number.
  * @returns The mock data.
  */
-function buildMockReturnValueForLegacyFetchGasPriceEstimates({
+function buildMockGasFeeStateLegacy({ modifier = 1 } = {}): GasFeeStateLegacy {
+  return {
+    gasFeeEstimates: {
+      low: (10 * modifier).toString(),
+      medium: (20 * modifier).toString(),
+      high: (30 * modifier).toString(),
+    },
+    estimatedGasFeeTimeBounds: {},
+    gasEstimateType: GAS_ESTIMATE_TYPES.LEGACY,
+  };
+}
+
+/**
+ * Builds mock gas fee state that would typically be generated for the case in which eth_gasPrice is
+ * used to fetch estimates. This data is merely intended to fit the GasFeeStateEthGasPrice type and
+ * does not represent any real-world scenario.
+ *
+ * @param args - The arguments.
+ * @param args.modifier - A number you can use to build a unique return value in the event that you
+ * need to build multiple return values. All data points will be multiplied by this number.
+ * @returns The mock data.
+ */
+function buildMockGasFeeStateEthGasPrice({
   modifier = 1,
-} = {}): LegacyGasPriceEstimate {
+} = {}): GasFeeStateEthGasPrice {
   return {
-    low: (10 * modifier).toString(),
-    medium: (20 * modifier).toString(),
-    high: (30 * modifier).toString(),
+    gasFeeEstimates: {
+      gasPrice: (100 * modifier).toString(),
+    },
+    estimatedGasFeeTimeBounds: {},
+    gasEstimateType: GAS_ESTIMATE_TYPES.ETH_GASPRICE,
   };
-}
-
-/**
- * Builds a mock returnv alue for the `calculateTimeEstimate` function that GasFeeController takes.
- * All of the values here are filled in to satisfy the EstimatedGasFeeTimeBounds type and are not
- * intended to represent any particular scenario.
- *
- * @returns The mock data.
- */
-function buildMockReturnValueForCalculateTimeEstimate(): EstimatedGasFeeTimeBounds {
-  return {
-    lowerTimeBound: 0,
-    upperTimeBound: 0,
-  };
-}
-
-/**
- * Returns a Jest mock function for a fetch* function that GasFeeController takes which is
- * configured to return the given mock data.
- *
- * @param mockReturnValues - A set of values that the mock function should return, for all of the
- * expected invocations of that function.
- * @returns The Jest mock function.
- */
-function createMockForFetchMethod(mockReturnValues: any[]) {
-  const mock = jest.fn();
-
-  if (mockReturnValues.length === 1) {
-    mock.mockReturnValue(mockReturnValues[0]);
-  } else {
-    mockReturnValues.forEach((response: any) => {
-      mock.mockImplementationOnce(() => Promise.resolve(response));
-    });
-  }
-
-  return mock;
 }
 
 describe('GasFeeController', () => {
   let clock: SinonFakeTimers;
   let gasFeeController: GasFeeController;
-  let fetchGasEstimates: jest.Mock<any>;
-  let fetchLegacyGasPriceEstimates: jest.Mock<any>;
 
   /**
    * Builds an instance of GasFeeController for use in testing, and then makes it available in
@@ -147,10 +143,6 @@ describe('GasFeeController', () => {
    * GasFeeController.
    * @param options.getCurrentNetworkLegacyGasAPICompatibility - Sets
    * getCurrentNetworkLegacyGasAPICompatibility on the GasFeeController.
-   * @param options.mockReturnValuesForFetchGasEstimates - Specifies mock data for one or more
-   * invocations of `fetchGasEstimates`.
-   * @param options.mockReturnValuesForFetchLegacyGasPriceEstimates - Specifies mock data for one or
-   * more invocations of `fetchLegacyGasPriceEstimates`.
    * @param options.legacyAPIEndpoint - Sets legacyAPIEndpoint on the GasFeeController.
    * @param options.EIP1559APIEndpoint - Sets EIP1559APIEndpoint on the GasFeeController.
    * @param options.clientId - Sets clientId on the GasFeeController.
@@ -161,12 +153,6 @@ describe('GasFeeController', () => {
     getCurrentNetworkLegacyGasAPICompatibility = jest
       .fn()
       .mockReturnValue(false),
-    mockReturnValuesForFetchGasEstimates = [
-      buildMockReturnValueForFetchGasEstimates(),
-    ],
-    mockReturnValuesForFetchLegacyGasPriceEstimates = [
-      buildMockReturnValueForLegacyFetchGasPriceEstimates(),
-    ],
     legacyAPIEndpoint = 'http://legacy.endpoint/<chain_id>',
     EIP1559APIEndpoint = 'http://eip-1559.endpoint/<chain_id>',
     clientId,
@@ -174,27 +160,14 @@ describe('GasFeeController', () => {
     getChainId?: jest.Mock<`0x${string}` | `${number}` | number>;
     getIsEIP1559Compatible?: jest.Mock<Promise<boolean>>;
     getCurrentNetworkLegacyGasAPICompatibility?: jest.Mock<boolean>;
-    mockReturnValuesForFetchGasEstimates?: any[];
-    mockReturnValuesForFetchLegacyGasPriceEstimates?: any[];
     legacyAPIEndpoint?: string;
     EIP1559APIEndpoint?: string;
     clientId?: string;
   } = {}) {
-    fetchGasEstimates = createMockForFetchMethod(
-      mockReturnValuesForFetchGasEstimates,
-    );
-
-    fetchLegacyGasPriceEstimates = createMockForFetchMethod(
-      mockReturnValuesForFetchLegacyGasPriceEstimates,
-    );
-
     gasFeeController = new GasFeeController({
       messenger: getRestrictedMessenger(),
       getProvider: jest.fn(),
       getChainId,
-      fetchGasEstimates,
-      fetchLegacyGasPriceEstimates,
-      fetchEthGasPriceEstimate: jest.fn().mockResolvedValue({ gasPrice: '1' }),
       onNetworkStateChange: jest.fn(),
       getCurrentNetworkLegacyGasAPICompatibility,
       getCurrentNetworkEIP1559Compatibility: getIsEIP1559Compatible, // change this for networkController.state.properties.isEIP1559Compatible ???
@@ -206,6 +179,9 @@ describe('GasFeeController', () => {
 
   beforeEach(() => {
     clock = useFakeTimers();
+    mockedDetermineGasFeeCalculations.mockResolvedValue(
+      buildMockGasFeeStateFeeMarket(),
+    );
   });
 
   afterEach(() => {
@@ -227,71 +203,51 @@ describe('GasFeeController', () => {
   describe('getGasFeeEstimatesAndStartPolling', () => {
     describe('if never called before', () => {
       describe('and called with undefined', () => {
-        it('should update the state with a fetched set of estimates', async () => {
-          const mockReturnValuesForFetchGasEstimates = [
-            buildMockReturnValueForFetchGasEstimates(),
-          ];
-          setupGasFeeController({
-            mockReturnValuesForFetchGasEstimates,
-          });
+        const mockDetermineGasFeeCalculationsReturnValues: GasFeeState[] = [
+          buildMockGasFeeStateFeeMarket(),
+          buildMockGasFeeStateEthGasPrice(),
+        ];
 
+        beforeEach(() => {
+          mockedDetermineGasFeeCalculations.mockReset();
+
+          mockDetermineGasFeeCalculationsReturnValues.forEach((returnValue) => {
+            mockedDetermineGasFeeCalculations.mockImplementationOnce(() => {
+              return Promise.resolve(returnValue);
+            });
+          });
+        });
+
+        it('should update the state with a fetched set of estimates', async () => {
           await gasFeeController.getGasFeeEstimatesAndStartPolling(undefined);
 
-          expect(gasFeeController.state.gasFeeEstimates).toStrictEqual(
-            mockReturnValuesForFetchGasEstimates[0],
-          );
-
-          expect(
-            gasFeeController.state.estimatedGasFeeTimeBounds,
-          ).toStrictEqual({});
-
-          expect(gasFeeController.state.gasEstimateType).toStrictEqual(
-            'fee-market',
+          expect(gasFeeController.state).toMatchObject(
+            mockDetermineGasFeeCalculationsReturnValues[0],
           );
         });
 
-        it('should continue updating the state with all estimate data (including new time estimates because of a subsequent request) on a set interval', async () => {
-          const mockReturnValuesForFetchGasEstimates = [
-            buildMockReturnValueForFetchGasEstimates({ modifier: 1 }),
-            buildMockReturnValueForFetchGasEstimates({ modifier: 1.5 }),
-          ];
-          setupGasFeeController({
-            mockReturnValuesForFetchGasEstimates,
-          });
-          const estimatedGasFeeTimeBounds = buildMockReturnValueForCalculateTimeEstimate();
-          mockedCalculateTimeEstimate.mockReturnValue(
-            estimatedGasFeeTimeBounds,
-          );
-
+        it('should continue updating the state with all estimate data (including new time estimates because of a subsequent call to determineGasFeeCalculations) on a set interval', async () => {
           await gasFeeController.getGasFeeEstimatesAndStartPolling(undefined);
           await clock.nextAsync();
 
-          expect(gasFeeController.state.gasFeeEstimates).toStrictEqual(
-            mockReturnValuesForFetchGasEstimates[1],
-          );
-
-          expect(
-            gasFeeController.state.estimatedGasFeeTimeBounds,
-          ).toStrictEqual(estimatedGasFeeTimeBounds);
-
-          expect(gasFeeController.state.gasEstimateType).toStrictEqual(
-            'fee-market',
+          expect(gasFeeController.state).toMatchObject(
+            mockDetermineGasFeeCalculationsReturnValues[1],
           );
         });
       });
 
       describe('and called with a previously unseen token', () => {
-        it('should make a request to fetch estimates', async () => {
+        it('should call determineGasFeeCalculations', async () => {
           setupGasFeeController();
 
           await gasFeeController.getGasFeeEstimatesAndStartPolling(
             'some-previously-unseen-token',
           );
 
-          expect(fetchGasEstimates.mock.calls).toHaveLength(1);
+          expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(1);
         });
 
-        it('should make further requests on a set interval', async () => {
+        it('should make further calls to determineGasFeeCalculations on a set interval', async () => {
           setupGasFeeController();
 
           await gasFeeController.getGasFeeEstimatesAndStartPolling(
@@ -299,22 +255,22 @@ describe('GasFeeController', () => {
           );
           await clock.nextAsync();
 
-          expect(fetchGasEstimates.mock.calls).toHaveLength(2);
+          expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(2);
         });
       });
     });
 
     describe('if called twice with undefined', () => {
-      it('should not make another request to fetch estimates', async () => {
+      it('should not call determineGasFeeCalculations again', async () => {
         setupGasFeeController();
 
         await gasFeeController.getGasFeeEstimatesAndStartPolling(undefined);
         await gasFeeController.getGasFeeEstimatesAndStartPolling(undefined);
 
-        expect(fetchGasEstimates.mock.calls).toHaveLength(1);
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(1);
       });
 
-      it('should not make more than one request per set interval', async () => {
+      it('should not make more than one call to determineGasFeeCalculations per set interval', async () => {
         setupGasFeeController();
 
         await gasFeeController.getGasFeeEstimatesAndStartPolling(undefined);
@@ -322,12 +278,12 @@ describe('GasFeeController', () => {
         await clock.nextAsync();
         await clock.nextAsync();
 
-        expect(fetchGasEstimates.mock.calls).toHaveLength(3);
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(3);
       });
     });
 
     describe('if called once with undefined and again with the same token', () => {
-      it('should make another request to fetch estimates', async () => {
+      it('should call determineGasFeeCalculations again', async () => {
         setupGasFeeController();
 
         const pollToken = await gasFeeController.getGasFeeEstimatesAndStartPolling(
@@ -335,10 +291,10 @@ describe('GasFeeController', () => {
         );
         await gasFeeController.getGasFeeEstimatesAndStartPolling(pollToken);
 
-        expect(fetchGasEstimates.mock.calls).toHaveLength(2);
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(2);
       });
 
-      it('should not make more than one request per set interval', async () => {
+      it('should not make more than one call to determineGasFeeCalculations per set interval', async () => {
         setupGasFeeController();
 
         const pollToken = await gasFeeController.getGasFeeEstimatesAndStartPolling(
@@ -348,12 +304,12 @@ describe('GasFeeController', () => {
         await clock.nextAsync();
         await clock.nextAsync();
 
-        expect(fetchGasEstimates.mock.calls).toHaveLength(4);
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(4);
       });
     });
 
     describe('if called twice, both with previously unseen tokens', () => {
-      it('should not make another request to fetch estimates', async () => {
+      it('should not call determineGasFeeCalculations again', async () => {
         setupGasFeeController();
 
         await gasFeeController.getGasFeeEstimatesAndStartPolling(
@@ -364,10 +320,10 @@ describe('GasFeeController', () => {
           'some-previously-unseen-token-2',
         );
 
-        expect(fetchGasEstimates.mock.calls).toHaveLength(1);
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(1);
       });
 
-      it('should not make more than one request per set interval', async () => {
+      it('should not make more than one call to determineGasFeeCalculations per set interval', async () => {
         setupGasFeeController();
 
         await gasFeeController.getGasFeeEstimatesAndStartPolling(
@@ -380,7 +336,7 @@ describe('GasFeeController', () => {
         await clock.nextAsync();
         await clock.nextAsync();
 
-        expect(fetchGasEstimates.mock.calls).toHaveLength(3);
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(3);
       });
     });
   });
@@ -388,18 +344,18 @@ describe('GasFeeController', () => {
   describe('disconnectPoller', () => {
     describe('assuming that getGasFeeEstimatesAndStartPolling was already called exactly once', () => {
       describe('given the same token as the result of the first call', () => {
-        it('should prevent requests from being made periodically', async () => {
+        it('should prevent calls to determineGasFeeCalculations from being made periodically', async () => {
           setupGasFeeController();
           const pollToken = await gasFeeController.getGasFeeEstimatesAndStartPolling(
             undefined,
           );
           await clock.nextAsync();
-          expect(fetchGasEstimates.mock.calls).toHaveLength(2);
+          expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(2);
 
           gasFeeController.disconnectPoller(pollToken);
 
           await clock.nextAsync();
-          expect(fetchGasEstimates.mock.calls).toHaveLength(2);
+          expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(2);
         });
 
         it('should make it so that a second call to getGasFeeEstimatesAndStartPolling with the same token has the same effect as the inaugural call', async () => {
@@ -408,45 +364,45 @@ describe('GasFeeController', () => {
             undefined,
           );
           await clock.nextAsync();
-          expect(fetchGasEstimates.mock.calls).toHaveLength(2);
+          expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(2);
 
           gasFeeController.disconnectPoller(pollToken);
 
           await gasFeeController.getGasFeeEstimatesAndStartPolling(pollToken);
           await clock.nextAsync();
-          expect(fetchGasEstimates.mock.calls).toHaveLength(4);
+          expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(4);
         });
       });
 
       describe('given a previously unseen token', () => {
-        it('should not prevent requests from being made periodically', async () => {
+        it('should not prevent calls to determineGasFeeCalculations from being made periodically', async () => {
           setupGasFeeController();
           await gasFeeController.getGasFeeEstimatesAndStartPolling(undefined);
           await clock.nextAsync();
-          expect(fetchGasEstimates.mock.calls).toHaveLength(2);
+          expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(2);
 
           gasFeeController.disconnectPoller('some-previously-unseen-token');
 
           await clock.nextAsync();
-          expect(fetchGasEstimates.mock.calls).toHaveLength(3);
+          expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(3);
         });
       });
     });
 
     describe('if getGasFeeEstimatesAndStartPolling was called twice with different tokens', () => {
-      it('should not prevent requests from being made periodically', async () => {
+      it('should not prevent calls to determineGasFeeCalculations from being made periodically', async () => {
         setupGasFeeController();
         const pollToken1 = await gasFeeController.getGasFeeEstimatesAndStartPolling(
           undefined,
         );
         await gasFeeController.getGasFeeEstimatesAndStartPolling(undefined);
         await clock.nextAsync();
-        expect(fetchGasEstimates.mock.calls).toHaveLength(2);
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(2);
 
         gasFeeController.disconnectPoller(pollToken1);
 
         await clock.nextAsync();
-        expect(fetchGasEstimates.mock.calls).toHaveLength(3);
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(3);
       });
     });
 
@@ -461,17 +417,17 @@ describe('GasFeeController', () => {
   });
 
   describe('stopPolling', () => {
-    describe('assuming that getGasFeeEstimatesAndStartPolling was already called once', () => {
-      it('should prevent requests from being made periodically', async () => {
+    describe('assuming that getGasFeeEstimatesAndStartPolling was already called exactly once', () => {
+      it('should prevent calls to determineGasFeeCalculations from being made periodically', async () => {
         setupGasFeeController();
         await gasFeeController.getGasFeeEstimatesAndStartPolling(undefined);
         await clock.nextAsync();
-        expect(fetchGasEstimates.mock.calls).toHaveLength(2);
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(2);
 
         gasFeeController.stopPolling();
 
         await clock.nextAsync();
-        expect(fetchGasEstimates.mock.calls).toHaveLength(2);
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(2);
       });
 
       it('should make it so that a second call to getGasFeeEstimatesAndStartPolling with the same token has the same effect as the inaugural call', async () => {
@@ -480,13 +436,13 @@ describe('GasFeeController', () => {
           undefined,
         );
         await clock.nextAsync();
-        expect(fetchGasEstimates.mock.calls).toHaveLength(2);
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(2);
 
         gasFeeController.stopPolling();
 
         await gasFeeController.getGasFeeEstimatesAndStartPolling(pollToken);
         await clock.nextAsync();
-        expect(fetchGasEstimates.mock.calls).toHaveLength(4);
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(4);
       });
 
       it('should revert the state back to its original form', async () => {
@@ -505,19 +461,19 @@ describe('GasFeeController', () => {
     });
 
     describe('if getGasFeeEstimatesAndStartPolling was called multiple times with the same token (thereby restarting the polling once)', () => {
-      it('should prevent requests from being made periodically', async () => {
+      it('should prevent calls to determineGasFeeCalculations from being made periodically', async () => {
         setupGasFeeController();
         const pollToken = await gasFeeController.getGasFeeEstimatesAndStartPolling(
           undefined,
         );
         await gasFeeController.getGasFeeEstimatesAndStartPolling(pollToken);
         await clock.nextAsync();
-        expect(fetchGasEstimates.mock.calls).toHaveLength(3);
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(3);
 
         gasFeeController.stopPolling();
 
         await clock.nextAsync();
-        expect(fetchGasEstimates.mock.calls).toHaveLength(3);
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(3);
       });
 
       it('should make it so that another call to getGasFeeEstimatesAndStartPolling with a previously generated token has the same effect as the inaugural call', async () => {
@@ -527,13 +483,13 @@ describe('GasFeeController', () => {
         );
         await gasFeeController.getGasFeeEstimatesAndStartPolling(pollToken);
         await clock.nextAsync();
-        expect(fetchGasEstimates.mock.calls).toHaveLength(3);
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(3);
 
         gasFeeController.stopPolling();
 
         await gasFeeController.getGasFeeEstimatesAndStartPolling(pollToken);
         await clock.nextAsync();
-        expect(fetchGasEstimates.mock.calls).toHaveLength(5);
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledTimes(5);
       });
     });
 
@@ -547,31 +503,28 @@ describe('GasFeeController', () => {
 
   describe('_fetchGasFeeEstimateData', () => {
     describe('when on any network supporting legacy gas estimation api', () => {
-      const mockReturnValuesForFetchLegacyGasPriceEstimates = [
-        buildMockReturnValueForLegacyFetchGasPriceEstimates(),
-      ];
       const defaultConstructorOptions = {
         getIsEIP1559Compatible: jest.fn().mockResolvedValue(false),
         getCurrentNetworkLegacyGasAPICompatibility: jest
           .fn()
           .mockReturnValue(true),
-        mockReturnValuesForFetchLegacyGasPriceEstimates,
       };
+      const mockDetermineGasFeeCalculations = buildMockGasFeeStateLegacy();
+
+      beforeEach(() => {
+        mockedDetermineGasFeeCalculations.mockResolvedValue(
+          mockDetermineGasFeeCalculations,
+        );
+      });
 
       it('should update the state with a fetched set of estimates', async () => {
         setupGasFeeController(defaultConstructorOptions);
 
         await gasFeeController._fetchGasFeeEstimateData();
 
-        expect(gasFeeController.state.gasFeeEstimates).toStrictEqual(
-          mockReturnValuesForFetchLegacyGasPriceEstimates[0],
+        expect(gasFeeController.state).toMatchObject(
+          mockDetermineGasFeeCalculations,
         );
-
-        expect(gasFeeController.state.estimatedGasFeeTimeBounds).toStrictEqual(
-          {},
-        );
-
-        expect(gasFeeController.state.gasEstimateType).toStrictEqual('legacy');
       });
 
       it('should return the same data that it puts into state', async () => {
@@ -579,88 +532,77 @@ describe('GasFeeController', () => {
 
         const estimateData = await gasFeeController._fetchGasFeeEstimateData();
 
-        expect(estimateData.gasFeeEstimates).toStrictEqual(
-          mockReturnValuesForFetchLegacyGasPriceEstimates[0],
-        );
-
-        expect(estimateData.estimatedGasFeeTimeBounds).toStrictEqual({});
-
-        expect(estimateData.gasEstimateType).toStrictEqual('legacy');
+        expect(estimateData).toMatchObject(mockDetermineGasFeeCalculations);
       });
 
-      it('should call fetchLegacyGasPriceEstimates correctly when getChainId returns a number input', async () => {
+      it('should call determineGasFeeCalculations correctly when getChainId returns a number input', async () => {
         setupGasFeeController({
           ...defaultConstructorOptions,
           legacyAPIEndpoint: 'http://legacy.endpoint/<chain_id>',
           getChainId: jest.fn().mockReturnValue(1),
-          clientId: '123',
         });
 
         await gasFeeController._fetchGasFeeEstimateData();
 
-        expect(fetchLegacyGasPriceEstimates).toHaveBeenCalledWith(
-          'http://legacy.endpoint/1',
-          '123',
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledWith(
+          expect.objectContaining({
+            fetchLegacyGasPriceEstimatesUrl: 'http://legacy.endpoint/1',
+          }),
         );
       });
 
-      it('should call fetchLegacyGasPriceEstimates correctly when getChainId returns a hexstring input', async () => {
+      it('should call determineGasFeeCalculations correctly when getChainId returns a hexstring input', async () => {
         setupGasFeeController({
           ...defaultConstructorOptions,
           legacyAPIEndpoint: 'http://legacy.endpoint/<chain_id>',
           getChainId: jest.fn().mockReturnValue('0x1'),
-          clientId: '123',
         });
 
         await gasFeeController._fetchGasFeeEstimateData();
 
-        expect(fetchLegacyGasPriceEstimates).toHaveBeenCalledWith(
-          'http://legacy.endpoint/1',
-          '123',
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledWith(
+          expect.objectContaining({
+            fetchLegacyGasPriceEstimatesUrl: 'http://legacy.endpoint/1',
+          }),
         );
       });
 
-      it('should call fetchLegacyGasPriceEstimates correctly when getChainId returns a numeric string input', async () => {
+      it('should call determineGasFeeCalculations correctly when getChainId returns a numeric string input', async () => {
         setupGasFeeController({
           ...defaultConstructorOptions,
           legacyAPIEndpoint: 'http://legacy.endpoint/<chain_id>',
           getChainId: jest.fn().mockReturnValue('1'),
-          clientId: '123',
         });
 
         await gasFeeController._fetchGasFeeEstimateData();
 
-        expect(fetchLegacyGasPriceEstimates).toHaveBeenCalledWith(
-          'http://legacy.endpoint/1',
-          '123',
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledWith(
+          expect.objectContaining({
+            fetchLegacyGasPriceEstimatesUrl: 'http://legacy.endpoint/1',
+          }),
         );
       });
     });
 
     describe('when on any network supporting EIP-1559', () => {
-      const mockReturnValuesForFetchGasEstimates = [
-        buildMockReturnValueForFetchGasEstimates(),
-      ];
       const defaultConstructorOptions = {
         getIsEIP1559Compatible: jest.fn().mockResolvedValue(true),
-        mockReturnValuesForFetchGasEstimates,
       };
+      const mockDetermineGasFeeCalculations = buildMockGasFeeStateFeeMarket();
+
+      beforeEach(() => {
+        mockedDetermineGasFeeCalculations.mockResolvedValue(
+          mockDetermineGasFeeCalculations,
+        );
+      });
 
       it('should update the state with a fetched set of estimates', async () => {
         setupGasFeeController(defaultConstructorOptions);
 
         await gasFeeController._fetchGasFeeEstimateData();
 
-        expect(gasFeeController.state.gasFeeEstimates).toStrictEqual(
-          mockReturnValuesForFetchGasEstimates[0],
-        );
-
-        expect(gasFeeController.state.estimatedGasFeeTimeBounds).toStrictEqual(
-          {},
-        );
-
-        expect(gasFeeController.state.gasEstimateType).toStrictEqual(
-          'fee-market',
+        expect(gasFeeController.state).toMatchObject(
+          mockDetermineGasFeeCalculations,
         );
       });
 
@@ -669,60 +611,54 @@ describe('GasFeeController', () => {
 
         const estimateData = await gasFeeController._fetchGasFeeEstimateData();
 
-        expect(estimateData.gasFeeEstimates).toStrictEqual(
-          mockReturnValuesForFetchGasEstimates[0],
-        );
-
-        expect(estimateData.estimatedGasFeeTimeBounds).toStrictEqual({});
-
-        expect(estimateData.gasEstimateType).toStrictEqual('fee-market');
+        expect(estimateData).toMatchObject(mockDetermineGasFeeCalculations);
       });
 
-      it('should call fetchGasEstimates correctly when getChainId returns a number input', async () => {
+      it('should call determineGasFeeCalculations correctly when getChainId returns a number input', async () => {
         setupGasFeeController({
           ...defaultConstructorOptions,
           EIP1559APIEndpoint: 'http://eip-1559.endpoint/<chain_id>',
           getChainId: jest.fn().mockReturnValue(1),
-          clientId: '123',
         });
 
         await gasFeeController._fetchGasFeeEstimateData();
 
-        expect(fetchGasEstimates).toHaveBeenCalledWith(
-          'http://eip-1559.endpoint/1',
-          '123',
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledWith(
+          expect.objectContaining({
+            fetchGasEstimatesUrl: 'http://eip-1559.endpoint/1',
+          }),
         );
       });
 
-      it('should call fetchGasEstimates correctly when getChainId returns a hexstring input', async () => {
+      it('should call determineGasFeeCalculations correctly when getChainId returns a hexstring input', async () => {
         setupGasFeeController({
           ...defaultConstructorOptions,
           EIP1559APIEndpoint: 'http://eip-1559.endpoint/<chain_id>',
           getChainId: jest.fn().mockReturnValue('0x1'),
-          clientId: '123',
         });
 
         await gasFeeController._fetchGasFeeEstimateData();
 
-        expect(fetchGasEstimates).toHaveBeenCalledWith(
-          'http://eip-1559.endpoint/1',
-          '123',
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledWith(
+          expect.objectContaining({
+            fetchGasEstimatesUrl: 'http://eip-1559.endpoint/1',
+          }),
         );
       });
 
-      it('should call fetchGasEstimates correctly when getChainId returns a numeric string input', async () => {
+      it('should call determineGasFeeCalculations correctly when getChainId returns a numeric string input', async () => {
         setupGasFeeController({
           ...defaultConstructorOptions,
           EIP1559APIEndpoint: 'http://eip-1559.endpoint/<chain_id>',
           getChainId: jest.fn().mockReturnValue('1'),
-          clientId: '123',
         });
 
         await gasFeeController._fetchGasFeeEstimateData();
 
-        expect(fetchGasEstimates).toHaveBeenCalledWith(
-          'http://eip-1559.endpoint/1',
-          '123',
+        expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledWith(
+          expect.objectContaining({
+            fetchGasEstimatesUrl: 'http://eip-1559.endpoint/1',
+          }),
         );
       });
     });

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -11,11 +11,12 @@ import type {
   NetworkState,
 } from '../network/NetworkController';
 import {
-  fetchGasEstimates as defaultFetchGasEstimates,
-  fetchEthGasPriceEstimate as defaultFetchEthGasPriceEstimate,
-  fetchLegacyGasPriceEstimates as defaultFetchLegacyGasPriceEstimates,
+  fetchGasEstimates,
+  fetchLegacyGasPriceEstimates,
+  fetchEthGasPriceEstimate,
   calculateTimeEstimate,
 } from './gas-util';
+import determineGasFeeCalculations from './determineGasFeeCalculations';
 
 const GAS_FEE_API = 'https://mock-gas-server.herokuapp.com/';
 export const LEGACY_GAS_PRICES_API_URL = `https://api.metaswap.codefi.network/gasPrices`;
@@ -216,12 +217,6 @@ export class GasFeeController extends BaseController<
 
   private EIP1559APIEndpoint: string;
 
-  private fetchGasEstimates;
-
-  private fetchEthGasPriceEstimate;
-
-  private fetchLegacyGasPriceEstimates;
-
   private getCurrentNetworkEIP1559Compatibility;
 
   private getCurrentNetworkLegacyGasAPICompatibility;
@@ -243,12 +238,6 @@ export class GasFeeController extends BaseController<
    * @param options.interval - The time in milliseconds to wait between polls.
    * @param options.messenger - The controller messenger.
    * @param options.state - The initial state.
-   * @param options.fetchGasEstimates - The function to use to fetch gas estimates. This option is
-   * primarily for testing purposes.
-   * @param options.fetchEthGasPriceEstimate - The function to use to fetch gas price estimates.
-   * This option is primarily for testing purposes.
-   * @param options.fetchLegacyGasPriceEstimates - The function to use to fetch legacy gas price
-   * estimates. This option is primarily for testing purposes.
    * @param options.getCurrentNetworkEIP1559Compatibility - Determines whether or not the current
    * network is EIP-1559 compatible.
    * @param options.getCurrentNetworkLegacyGasAPICompatibility - Determines whether or not the
@@ -270,9 +259,6 @@ export class GasFeeController extends BaseController<
     interval = 15000,
     messenger,
     state,
-    fetchGasEstimates = defaultFetchGasEstimates,
-    fetchEthGasPriceEstimate = defaultFetchEthGasPriceEstimate,
-    fetchLegacyGasPriceEstimates = defaultFetchLegacyGasPriceEstimates,
     getCurrentNetworkEIP1559Compatibility,
     getCurrentAccountEIP1559Compatibility,
     getChainId,
@@ -286,9 +272,6 @@ export class GasFeeController extends BaseController<
     interval?: number;
     messenger: GasFeeMessenger;
     state?: GasFeeState;
-    fetchGasEstimates?: typeof defaultFetchGasEstimates;
-    fetchEthGasPriceEstimate?: typeof defaultFetchEthGasPriceEstimate;
-    fetchLegacyGasPriceEstimates?: typeof defaultFetchLegacyGasPriceEstimates;
     getCurrentNetworkEIP1559Compatibility: () => Promise<boolean>;
     getCurrentNetworkLegacyGasAPICompatibility: () => boolean;
     getCurrentAccountEIP1559Compatibility?: () => boolean;
@@ -306,9 +289,6 @@ export class GasFeeController extends BaseController<
       state: { ...defaultState, ...state },
     });
     this.intervalDelay = interval;
-    this.fetchGasEstimates = fetchGasEstimates;
-    this.fetchEthGasPriceEstimate = fetchEthGasPriceEstimate;
-    this.fetchLegacyGasPriceEstimates = fetchLegacyGasPriceEstimates;
     this.pollTokens = new Set();
     this.getCurrentNetworkEIP1559Compatibility = getCurrentNetworkEIP1559Compatibility;
     this.getCurrentNetworkLegacyGasAPICompatibility = getCurrentNetworkLegacyGasAPICompatibility;
@@ -388,66 +368,35 @@ export class GasFeeController extends BaseController<
       isEIP1559Compatible = false;
     }
 
-    let newState: GasFeeState = {
-      gasFeeEstimates: {},
-      estimatedGasFeeTimeBounds: {},
-      gasEstimateType: GAS_ESTIMATE_TYPES.NONE,
-    };
-
-    try {
-      if (isEIP1559Compatible) {
-        const estimates = await this.fetchGasEstimates(
-          this.EIP1559APIEndpoint.replace('<chain_id>', `${chainId}`),
-          this.clientId,
-        );
-        const {
-          suggestedMaxPriorityFeePerGas,
-          suggestedMaxFeePerGas,
-        } = estimates.medium;
-        const estimatedGasFeeTimeBounds = this.getTimeEstimate(
-          suggestedMaxPriorityFeePerGas,
-          suggestedMaxFeePerGas,
-        );
-        newState = {
-          gasFeeEstimates: estimates,
-          estimatedGasFeeTimeBounds,
-          gasEstimateType: GAS_ESTIMATE_TYPES.FEE_MARKET,
-        };
-      } else if (isLegacyGasAPICompatible) {
-        const estimates = await this.fetchLegacyGasPriceEstimates(
-          this.legacyAPIEndpoint.replace('<chain_id>', `${chainId}`),
-          this.clientId,
-        );
-        newState = {
-          gasFeeEstimates: estimates,
-          estimatedGasFeeTimeBounds: {},
-          gasEstimateType: GAS_ESTIMATE_TYPES.LEGACY,
-        };
-      } else {
-        throw new Error('Main gas fee/price estimation failed. Use fallback');
-      }
-    } catch {
-      try {
-        const estimates = await this.fetchEthGasPriceEstimate(this.ethQuery);
-        newState = {
-          gasFeeEstimates: estimates,
-          estimatedGasFeeTimeBounds: {},
-          gasEstimateType: GAS_ESTIMATE_TYPES.ETH_GASPRICE,
-        };
-      } catch (error) {
-        throw new Error(
-          `Gas fee/price estimation failed. Message: ${error.message}`,
-        );
-      }
-    }
+    const gasFeeCalculations = await determineGasFeeCalculations({
+      isEIP1559Compatible,
+      isLegacyGasAPICompatible,
+      fetchGasEstimates,
+      fetchGasEstimatesUrl: this.EIP1559APIEndpoint.replace(
+        '<chain_id>',
+        `${chainId}`,
+      ),
+      fetchLegacyGasPriceEstimates,
+      fetchLegacyGasPriceEstimatesUrl: this.legacyAPIEndpoint.replace(
+        '<chain_id>',
+        `${chainId}`,
+      ),
+      fetchEthGasPriceEstimate,
+      calculateTimeEstimate,
+      clientId: this.clientId,
+      ethQuery: this.ethQuery,
+    });
 
     if (shouldUpdateState) {
-      this.update(() => {
-        return newState;
+      this.update((state) => {
+        state.gasFeeEstimates = gasFeeCalculations.gasFeeEstimates;
+        state.estimatedGasFeeTimeBounds =
+          gasFeeCalculations.estimatedGasFeeTimeBounds;
+        state.gasEstimateType = gasFeeCalculations.gasEstimateType;
       });
     }
 
-    return newState;
+    return gasFeeCalculations;
   }
 
   /**

--- a/src/gas/determineGasFeeCalculations.test.ts
+++ b/src/gas/determineGasFeeCalculations.test.ts
@@ -1,0 +1,278 @@
+import { mocked } from 'ts-jest/utils';
+import determineGasFeeCalculations from './determineGasFeeCalculations';
+import {
+  unknownString,
+  GasFeeEstimates,
+  LegacyGasPriceEstimate,
+  EthGasPriceEstimate,
+  EstimatedGasFeeTimeBounds,
+} from './GasFeeController';
+import {
+  fetchGasEstimates,
+  fetchLegacyGasPriceEstimates,
+  fetchEthGasPriceEstimate,
+  calculateTimeEstimate,
+} from './gas-util';
+
+jest.mock('./gas-util');
+
+const mockedFetchGasEstimates = mocked(fetchGasEstimates, true);
+const mockedFetchLegacyGasPriceEstimates = mocked(
+  fetchLegacyGasPriceEstimates,
+  true,
+);
+const mockedFetchEthGasPriceEstimate = mocked(fetchEthGasPriceEstimate, true);
+const mockedCalculateTimeEstimate = mocked(calculateTimeEstimate, true);
+
+/**
+ * Builds mock data for the `fetchGasEstimates` function. All of the data here is filled in to make
+ * the gas fee estimation code function in a way that represents a reasonably happy path; it does
+ * not necessarily match the real world.
+ *
+ * @returns The mock data.
+ */
+function buildMockDataForFetchGasEstimates(): GasFeeEstimates {
+  return {
+    low: {
+      minWaitTimeEstimate: 10000,
+      maxWaitTimeEstimate: 20000,
+      suggestedMaxPriorityFeePerGas: '1',
+      suggestedMaxFeePerGas: '10',
+    },
+    medium: {
+      minWaitTimeEstimate: 30000,
+      maxWaitTimeEstimate: 40000,
+      suggestedMaxPriorityFeePerGas: '1.5',
+      suggestedMaxFeePerGas: '20',
+    },
+    high: {
+      minWaitTimeEstimate: 50000,
+      maxWaitTimeEstimate: 60000,
+      suggestedMaxPriorityFeePerGas: '2',
+      suggestedMaxFeePerGas: '30',
+    },
+    estimatedBaseFee: '100',
+  };
+}
+
+/**
+ * Builds mock data for the `fetchLegacyGasPriceEstimates` function. All of the data here is filled
+ * in to make the gas fee estimation code function in a way that represents a reasonably happy path;
+ * it does not necessarily match the real world.
+ *
+ * @returns The mock data.
+ */
+function buildMockDataForFetchLegacyGasPriceEstimates(): LegacyGasPriceEstimate {
+  return {
+    low: '10',
+    medium: '20',
+    high: '30',
+  };
+}
+
+/**
+ * Builds mock data for the `fetchEthGasPriceEstimate` function. All of the data here is filled in
+ * to make the gas fee estimation code function in a way that represents a reasonably happy path; it
+ * does not necessarily match the real world.
+ *
+ * @returns The mock data.
+ */
+function buildMockDataForFetchEthGasPriceEstimate(): EthGasPriceEstimate {
+  return {
+    gasPrice: '100',
+  };
+}
+
+/**
+ * Builds mock data for the `calculateTimeEstimate` function. All of the data here is filled in to
+ * make the gas fee estimation code function in a way that represents a reasonably happy path; it
+ * does not necessarily match the real world.
+ *
+ * @returns The mock data.
+ */
+function buildMockDataForCalculateTimeEstimate(): EstimatedGasFeeTimeBounds {
+  return {
+    lowerTimeBound: null,
+    upperTimeBound: 'unknown' as unknownString,
+  };
+}
+
+describe('determineGasFeeCalculations', () => {
+  const options = {
+    isEIP1559Compatible: false,
+    isLegacyGasAPICompatible: false,
+    fetchGasEstimates: mockedFetchGasEstimates,
+    fetchGasEstimatesUrl: 'http://doesnt-matter',
+    fetchLegacyGasPriceEstimates: mockedFetchLegacyGasPriceEstimates,
+    fetchLegacyGasPriceEstimatesUrl: 'http://doesnt-matter',
+    fetchEthGasPriceEstimate: mockedFetchEthGasPriceEstimate,
+    calculateTimeEstimate: mockedCalculateTimeEstimate,
+    clientId: 'some-client-id',
+    ethQuery: {},
+  };
+
+  describe('when isEIP1559Compatible is true', () => {
+    beforeEach(() => {
+      Object.assign(options, {
+        fetchGasEstimatesUrl: 'http://some-fetch-gas-estimates-url',
+        isEIP1559Compatible: true,
+        isLegacyGasAPICompatible: false,
+      });
+    });
+
+    describe('assuming neither fetchGasEstimates nor calculateTimeEstimate throw errors', () => {
+      it('returns a combination of the fetched fee and time estimates', async () => {
+        const gasFeeEstimates = buildMockDataForFetchGasEstimates();
+        mockedFetchGasEstimates.mockResolvedValue(gasFeeEstimates);
+        const estimatedGasFeeTimeBounds = buildMockDataForCalculateTimeEstimate();
+        mockedCalculateTimeEstimate.mockReturnValue(estimatedGasFeeTimeBounds);
+
+        const gasFeeCalculations = await determineGasFeeCalculations(options);
+
+        expect(gasFeeCalculations).toStrictEqual({
+          gasFeeEstimates,
+          estimatedGasFeeTimeBounds,
+          gasEstimateType: 'fee-market',
+        });
+      });
+    });
+
+    describe('when fetchGasEstimates throws an error', () => {
+      beforeEach(() => {
+        mockedFetchGasEstimates.mockImplementation(() => {
+          throw new Error('Some API failure');
+        });
+      });
+
+      describe('assuming fetchEthGasPriceEstimate does not throw an error', () => {
+        it('returns the fetched fee estimates and an empty set of time estimates', async () => {
+          const gasFeeEstimates = buildMockDataForFetchEthGasPriceEstimate();
+          mockedFetchEthGasPriceEstimate.mockResolvedValue(gasFeeEstimates);
+
+          const gasFeeCalculations = await determineGasFeeCalculations(options);
+
+          expect(gasFeeCalculations).toStrictEqual({
+            gasFeeEstimates,
+            estimatedGasFeeTimeBounds: {},
+            gasEstimateType: 'eth_gasPrice',
+          });
+        });
+      });
+
+      describe('when fetchEthGasPriceEstimate throws an error', () => {
+        it('throws an error that wraps that error', async () => {
+          mockedFetchEthGasPriceEstimate.mockImplementation(() => {
+            throw new Error('fetchEthGasPriceEstimate failed');
+          });
+
+          const promise = determineGasFeeCalculations(options);
+
+          await expect(promise).rejects.toThrow(
+            'Gas fee/price estimation failed. Message: fetchEthGasPriceEstimate failed',
+          );
+        });
+      });
+    });
+  });
+
+  describe('when isEIP1559Compatible is false but isLegacyGasAPICompatible is true', () => {
+    beforeEach(() => {
+      Object.assign(options, {
+        isEIP1559Compatible: false,
+        isLegacyGasAPICompatible: true,
+        fetchLegacyGasPriceEstimatesUrl:
+          'http://some-legacy-gas-price-estimates-url',
+      });
+    });
+
+    describe('assuming fetchLegacyGasPriceEstimates does not throw an error', () => {
+      it('returns the fetched fee estimates and an empty set of time estimates', async () => {
+        const gasFeeEstimates = buildMockDataForFetchLegacyGasPriceEstimates();
+        mockedFetchLegacyGasPriceEstimates.mockResolvedValue(gasFeeEstimates);
+
+        const gasFeeCalculations = await determineGasFeeCalculations(options);
+
+        expect(gasFeeCalculations).toStrictEqual({
+          gasFeeEstimates,
+          estimatedGasFeeTimeBounds: {},
+          gasEstimateType: 'legacy',
+        });
+      });
+    });
+
+    describe('when fetchLegacyGasPriceEstimates throws an error', () => {
+      beforeEach(() => {
+        mockedFetchLegacyGasPriceEstimates.mockImplementation(() => {
+          throw new Error('Some API failure');
+        });
+      });
+
+      describe('assuming fetchEthGasPriceEstimate does not throw an error', () => {
+        it('returns the fetched fee estimates and an empty set of time estimates', async () => {
+          const gasFeeEstimates = buildMockDataForFetchEthGasPriceEstimate();
+          mockedFetchEthGasPriceEstimate.mockResolvedValue(gasFeeEstimates);
+
+          const gasFeeCalculations = await determineGasFeeCalculations(options);
+
+          expect(gasFeeCalculations).toStrictEqual({
+            gasFeeEstimates,
+            estimatedGasFeeTimeBounds: {},
+            gasEstimateType: 'eth_gasPrice',
+          });
+        });
+      });
+
+      describe('when calling fetchEthGasPriceEstimate throws an error', () => {
+        it('throws an error that wraps that error', async () => {
+          mockedFetchEthGasPriceEstimate.mockImplementation(() => {
+            throw new Error('fetchEthGasPriceEstimate failed');
+          });
+
+          const promise = determineGasFeeCalculations(options);
+
+          await expect(promise).rejects.toThrow(
+            'Gas fee/price estimation failed. Message: fetchEthGasPriceEstimate failed',
+          );
+        });
+      });
+    });
+  });
+
+  describe('when neither isEIP1559Compatible nor isLegacyGasAPICompatible is true', () => {
+    beforeEach(() => {
+      Object.assign(options, {
+        isEIP1559Compatible: false,
+        isLegacyGasAPICompatible: false,
+      });
+    });
+
+    describe('assuming fetchEthGasPriceEstimate does not throw an error', () => {
+      it('returns the fetched fee estimates and an empty set of time estimates', async () => {
+        const gasFeeEstimates = buildMockDataForFetchEthGasPriceEstimate();
+        mockedFetchEthGasPriceEstimate.mockResolvedValue(gasFeeEstimates);
+
+        const gasFeeCalculations = await determineGasFeeCalculations(options);
+
+        expect(gasFeeCalculations).toStrictEqual({
+          gasFeeEstimates,
+          estimatedGasFeeTimeBounds: {},
+          gasEstimateType: 'eth_gasPrice',
+        });
+      });
+    });
+
+    describe('when calling fetchEthGasPriceEstimate throws an error', () => {
+      it('throws an error that wraps that error', async () => {
+        mockedFetchEthGasPriceEstimate.mockImplementation(() => {
+          throw new Error('fetchEthGasPriceEstimate failed');
+        });
+
+        const promise = determineGasFeeCalculations(options);
+
+        await expect(promise).rejects.toThrow(
+          'Gas fee/price estimation failed. Message: fetchEthGasPriceEstimate failed',
+        );
+      });
+    });
+  });
+});

--- a/src/gas/determineGasFeeCalculations.ts
+++ b/src/gas/determineGasFeeCalculations.ts
@@ -1,0 +1,110 @@
+import {
+  GAS_ESTIMATE_TYPES,
+  EstimatedGasFeeTimeBounds,
+  EthGasPriceEstimate,
+  GasFeeEstimates,
+  GasFeeState as GasFeeCalculations,
+  LegacyGasPriceEstimate,
+} from './GasFeeController';
+
+/**
+ * Obtains a set of max base and priority fee estimates along with time estimates so that we
+ * can present them to users when they are sending transactions or making swaps.
+ *
+ * @param args - The arguments.
+ * @param args.isEIP1559Compatible - Governs whether or not we can use an EIP-1559-only method to
+ * produce estimates.
+ * @param args.isLegacyGasAPICompatible - Governs whether or not we can use a non-EIP-1559 method to
+ * produce estimates (for instance, testnets do not support estimates altogether).
+ * @param args.fetchGasEstimates - A function that fetches gas estimates using an EIP-1559-specific
+ * API.
+ * @param args.fetchGasEstimatesUrl - The URL for the API we can use to obtain EIP-1559-specific
+ * estimates.
+ * @param args.fetchLegacyGasPriceEstimates - A function that fetches gas estimates using an
+ * non-EIP-1559-specific API.
+ * @param args.fetchLegacyGasPriceEstimatesUrl - The URL for the API we can use to obtain
+ * non-EIP-1559-specific estimates.
+ * @param args.fetchEthGasPriceEstimate - A function that fetches gas estimates using
+ * `eth_gasPrice`.
+ * @param args.calculateTimeEstimate - A function that determine time estimate bounds.
+ * @param args.clientId - An identifier that an API can use to know who is asking for estimates.
+ * @param args.ethQuery - An EthQuery instance we can use to talk to Ethereum directly.
+ * @returns The gas fee calculations.
+ */
+export default async function determineGasFeeCalculations({
+  isEIP1559Compatible,
+  isLegacyGasAPICompatible,
+  fetchGasEstimates,
+  fetchGasEstimatesUrl,
+  fetchLegacyGasPriceEstimates,
+  fetchLegacyGasPriceEstimatesUrl,
+  fetchEthGasPriceEstimate,
+  calculateTimeEstimate,
+  clientId,
+  ethQuery,
+}: {
+  isEIP1559Compatible: boolean;
+  isLegacyGasAPICompatible: boolean;
+  fetchGasEstimates: (
+    url: string,
+    clientId?: string,
+  ) => Promise<GasFeeEstimates>;
+  fetchGasEstimatesUrl: string;
+  fetchLegacyGasPriceEstimates: (
+    url: string,
+    clientId?: string,
+  ) => Promise<LegacyGasPriceEstimate>;
+  fetchLegacyGasPriceEstimatesUrl: string;
+  fetchEthGasPriceEstimate: (ethQuery: any) => Promise<EthGasPriceEstimate>;
+  calculateTimeEstimate: (
+    maxPriorityFeePerGas: string,
+    maxFeePerGas: string,
+    gasFeeEstimates: GasFeeEstimates,
+  ) => EstimatedGasFeeTimeBounds;
+  clientId: string | undefined;
+  ethQuery: any;
+}): Promise<GasFeeCalculations> {
+  try {
+    if (isEIP1559Compatible) {
+      const estimates = await fetchGasEstimates(fetchGasEstimatesUrl, clientId);
+      const {
+        suggestedMaxPriorityFeePerGas,
+        suggestedMaxFeePerGas,
+      } = estimates.medium;
+      const estimatedGasFeeTimeBounds = calculateTimeEstimate(
+        suggestedMaxPriorityFeePerGas,
+        suggestedMaxFeePerGas,
+        estimates,
+      );
+      return {
+        gasFeeEstimates: estimates,
+        estimatedGasFeeTimeBounds,
+        gasEstimateType: GAS_ESTIMATE_TYPES.FEE_MARKET,
+      };
+    } else if (isLegacyGasAPICompatible) {
+      const estimates = await fetchLegacyGasPriceEstimates(
+        fetchLegacyGasPriceEstimatesUrl,
+        clientId,
+      );
+      return {
+        gasFeeEstimates: estimates,
+        estimatedGasFeeTimeBounds: {},
+        gasEstimateType: GAS_ESTIMATE_TYPES.LEGACY,
+      };
+    }
+    throw new Error('Main gas fee/price estimation failed. Use fallback');
+  } catch {
+    try {
+      const estimates = await fetchEthGasPriceEstimate(ethQuery);
+      return {
+        gasFeeEstimates: estimates,
+        estimatedGasFeeTimeBounds: {},
+        gasEstimateType: GAS_ESTIMATE_TYPES.ETH_GASPRICE,
+      };
+    } catch (error) {
+      throw new Error(
+        `Gas fee/price estimation failed. Message: ${error.message}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
We would like to introduce another fallback to how we estimate gas fees
in a future commit — namely, we want to use `eth_feeHistory` for
EIP-1559 networks if the usual API is down. To do this, the existing
code around gas fee estimates needs to be refactored. This is the first
in a two-part refactor, extracting the majority of the code in
`GasFeeController._fetchGasFeeEstimateData` to `gas-util`. In addition
to making room for more changes, this also allows us to test this code
in isolation from the polling code that already exists in
GasFeeController.

Note that I am using the term "calculations" to encompass the data that
`_fetchGasFeeEstimateData` returns. This is because `gasFeeEstimates` is
an intermediate value that can also be packaged with
`estimatedGasFeeTimeBounds`, so "estimates" could be confusing. Also, I
replaced "fetch" with "determine" as in the future we may be performing
calculations that APIs have done for us in the past ("fetch" seems like
a more low-level action).

---

Refs #600.