### PR TITLE
[WIP] Refactor try/catch code in determineGasFeeSuggestions

### DIFF
--- a/src/gas/determineGasFeeSuggestions.test.ts
+++ b/src/gas/determineGasFeeSuggestions.test.ts
@@ -1,0 +1,294 @@
+import determineGasFeeSuggestions from './determineGasFeeSuggestions';
+import {
+  unknownString,
+  GasFeeEstimates,
+  LegacyGasPriceEstimate,
+  EthGasPriceEstimate,
+  EstimatedGasFeeTimeBounds,
+} from './GasFeeController';
+
+/**
+ * Builds mock data for the `fetchGasEstimates` function. All of the data here is filled in to make
+ * the gas fee estimation code function in a way that represents a reasonably happy path; it does
+ * not necessarily match the real world.
+ *
+ * @returns The mock data.
+ */
+function buildMockDataForFetchGasEstimates(): GasFeeEstimates {
+  return {
+    low: {
+      minWaitTimeEstimate: 10000,
+      maxWaitTimeEstimate: 20000,
+      suggestedMaxPriorityFeePerGas: '1',
+      suggestedMaxFeePerGas: '10',
+    },
+    medium: {
+      minWaitTimeEstimate: 30000,
+      maxWaitTimeEstimate: 40000,
+      suggestedMaxPriorityFeePerGas: '1.5',
+      suggestedMaxFeePerGas: '20',
+    },
+    high: {
+      minWaitTimeEstimate: 50000,
+      maxWaitTimeEstimate: 60000,
+      suggestedMaxPriorityFeePerGas: '2',
+      suggestedMaxFeePerGas: '30',
+    },
+    estimatedBaseFee: '100',
+  };
+}
+
+/**
+ * Builds mock data for the `fetchLegacyGasPriceEstimates` function. All of the data here is filled
+ * in to make the gas fee estimation code function in a way that represents a reasonably happy path;
+ * it does not necessarily match the real world.
+ *
+ * @returns The mock data.
+ */
+function buildMockDataForFetchLegacyGasPriceEstimates(): LegacyGasPriceEstimate {
+  return {
+    low: '10',
+    medium: '20',
+    high: '30',
+  };
+}
+
+/**
+ * Builds mock data for the `fetchEthGasPriceEstimate` function. All of the data here is filled in
+ * to make the gas fee estimation code function in a way that represents a reasonably happy path; it
+ * does not necessarily match the real world.
+ *
+ * @returns The mock data.
+ */
+function buildMockDataForFetchEthGasPriceEstimate(): EthGasPriceEstimate {
+  return {
+    gasPrice: '100',
+  };
+}
+
+/**
+ * Builds mock data for the `calculateTimeEstimate` function. All of the data here is filled in to
+ * make the gas fee estimation code function in a way that represents a reasonably happy path; it
+ * does not necessarily match the real world.
+ *
+ * @returns The mock data.
+ */
+function buildMockDataForCalculateTimeEstimate(): EstimatedGasFeeTimeBounds {
+  return {
+    lowerTimeBound: null,
+    upperTimeBound: 'unknown' as unknownString,
+  };
+}
+
+describe('determineGasFeeSuggestions', () => {
+  let options: any;
+  let fetchGasEstimates: jest.SpyInstance<any>;
+  let calculateTimeEstimate: jest.SpyInstance<any>;
+  let fetchLegacyGasPriceEstimates: jest.SpyInstance<any>;
+  let fetchEthGasPriceEstimate: jest.SpyInstance<any>;
+
+  beforeEach(() => {
+    fetchGasEstimates = jest
+      .fn()
+      .mockResolvedValue(buildMockDataForFetchGasEstimates());
+
+    calculateTimeEstimate = jest
+      .fn()
+      .mockReturnValue(buildMockDataForCalculateTimeEstimate());
+
+    fetchLegacyGasPriceEstimates = jest
+      .fn()
+      .mockResolvedValue(buildMockDataForFetchLegacyGasPriceEstimates());
+
+    fetchEthGasPriceEstimate = jest
+      .fn()
+      .mockResolvedValue(buildMockDataForFetchEthGasPriceEstimate());
+  });
+
+  describe('when isEIP1559Compatible is true', () => {
+    beforeEach(() => {
+      options = {
+        isEIP1559Compatible: true,
+        isLegacyGasAPICompatible: false,
+        fetchGasEstimates,
+        fetchGasEstimatesUrl: 'http://some-fetch-gas-estimates-url',
+        fetchLegacyGasPriceEstimates,
+        fetchLegacyGasPriceEstimatesUrl: 'http://doesnt-matter',
+        fetchEthGasPriceEstimate,
+        calculateTimeEstimate,
+        clientId: 'some-client-id',
+        ethQuery: {},
+      };
+    });
+
+    describe('assuming neither fetchGasEstimates nor calculateTimeEstimate throw errors', () => {
+      it('returns a combination of the fetched fee and time estimates', async () => {
+        const gasFeeEstimates = buildMockDataForFetchGasEstimates();
+        fetchGasEstimates.mockResolvedValue(gasFeeEstimates);
+        const estimatedGasFeeTimeBounds = buildMockDataForCalculateTimeEstimate();
+        calculateTimeEstimate.mockReturnValue(estimatedGasFeeTimeBounds);
+
+        const gasFeeSuggestions = await determineGasFeeSuggestions(options);
+
+        expect(gasFeeSuggestions).toStrictEqual({
+          gasFeeEstimates,
+          estimatedGasFeeTimeBounds,
+          gasEstimateType: 'fee-market',
+        });
+      });
+    });
+
+    describe('when fetchGasEstimates throws an error', () => {
+      beforeEach(() => {
+        fetchGasEstimates.mockImplementation(() => {
+          throw new Error('Some API failure');
+        });
+      });
+
+      describe('assuming fetchEthGasPriceEstimate does not throw an error', () => {
+        it('returns the fetched fee estimates and an empty set of time estimates', async () => {
+          const gasFeeEstimates = buildMockDataForFetchEthGasPriceEstimate();
+          fetchEthGasPriceEstimate.mockResolvedValue(gasFeeEstimates);
+
+          const gasFeeSuggestions = await determineGasFeeSuggestions(options);
+
+          expect(gasFeeSuggestions).toStrictEqual({
+            gasFeeEstimates,
+            estimatedGasFeeTimeBounds: {},
+            gasEstimateType: 'eth_gasPrice',
+          });
+        });
+      });
+
+      describe('when fetchEthGasPriceEstimate throws an error', () => {
+        it('throws an error that wraps that error', async () => {
+          fetchEthGasPriceEstimate.mockImplementation(() => {
+            throw new Error('fetchEthGasPriceEstimate failed');
+          });
+
+          const promise = determineGasFeeSuggestions(options);
+
+          await expect(promise).rejects.toThrow(
+            'Gas fee/price estimation failed. Message: fetchEthGasPriceEstimate failed',
+          );
+        });
+      });
+    });
+  });
+
+  describe('when isEIP1559Compatible is false but isLegacyGasAPICompatible is true', () => {
+    beforeEach(() => {
+      options = {
+        isEIP1559Compatible: false,
+        isLegacyGasAPICompatible: true,
+        fetchGasEstimates,
+        fetchGasEstimatesUrl: 'http://doesnt-matter',
+        fetchLegacyGasPriceEstimates,
+        fetchLegacyGasPriceEstimatesUrl:
+          'http://some-legacy-gas-price-estimates-url',
+        fetchEthGasPriceEstimate,
+        calculateTimeEstimate,
+        clientId: 'some-client-id',
+        ethQuery: {},
+      };
+    });
+
+    describe('assuming fetchLegacyGasPriceEstimates does not throw an error', () => {
+      it('returns the fetched fee estimates and an empty set of time estimates', async () => {
+        const gasFeeEstimates = buildMockDataForFetchLegacyGasPriceEstimates();
+        fetchLegacyGasPriceEstimates.mockResolvedValue(gasFeeEstimates);
+
+        const gasFeeSuggestions = await determineGasFeeSuggestions(options);
+
+        expect(gasFeeSuggestions).toStrictEqual({
+          gasFeeEstimates,
+          estimatedGasFeeTimeBounds: {},
+          gasEstimateType: 'legacy',
+        });
+      });
+    });
+
+    describe('when fetchLegacyGasPriceEstimates throws an error', () => {
+      beforeEach(() => {
+        fetchLegacyGasPriceEstimates.mockImplementation(() => {
+          throw new Error('Some API failure');
+        });
+      });
+
+      describe('assuming fetchEthGasPriceEstimate does not throw an error', () => {
+        it('returns the fetched fee estimates and an empty set of time estimates', async () => {
+          const gasFeeEstimates = buildMockDataForFetchEthGasPriceEstimate();
+          fetchEthGasPriceEstimate.mockResolvedValue(gasFeeEstimates);
+
+          const gasFeeSuggestions = await determineGasFeeSuggestions(options);
+
+          expect(gasFeeSuggestions).toStrictEqual({
+            gasFeeEstimates,
+            estimatedGasFeeTimeBounds: {},
+            gasEstimateType: 'eth_gasPrice',
+          });
+        });
+      });
+
+      describe('when calling fetchEthGasPriceEstimate throws an error', () => {
+        it('throws an error that wraps that error', async () => {
+          fetchEthGasPriceEstimate.mockImplementation(() => {
+            throw new Error('fetchEthGasPriceEstimate failed');
+          });
+
+          const promise = determineGasFeeSuggestions(options);
+
+          await expect(promise).rejects.toThrow(
+            'Gas fee/price estimation failed. Message: fetchEthGasPriceEstimate failed',
+          );
+        });
+      });
+    });
+  });
+
+  describe('when neither isEIP1559Compatible nor isLegacyGasAPICompatible is true', () => {
+    beforeEach(() => {
+      options = {
+        isEIP1559Compatible: false,
+        isLegacyGasAPICompatible: false,
+        fetchGasEstimates,
+        fetchGasEstimatesUrl: 'http://doesnt-matter',
+        fetchLegacyGasPriceEstimates,
+        fetchLegacyGasPriceEstimatesUrl: 'http://doesnt-matter',
+        fetchEthGasPriceEstimate,
+        calculateTimeEstimate,
+        clientId: 'some-client-id',
+        ethQuery: {},
+      };
+    });
+
+    describe('assuming fetchEthGasPriceEstimate does not throw an error', () => {
+      it('returns the fetched fee estimates and an empty set of time estimates', async () => {
+        const gasFeeEstimates = buildMockDataForFetchEthGasPriceEstimate();
+        fetchEthGasPriceEstimate.mockResolvedValue(gasFeeEstimates);
+
+        const gasFeeSuggestions = await determineGasFeeSuggestions(options);
+
+        expect(gasFeeSuggestions).toStrictEqual({
+          gasFeeEstimates,
+          estimatedGasFeeTimeBounds: {},
+          gasEstimateType: 'eth_gasPrice',
+        });
+      });
+    });
+
+    describe('when calling fetchEthGasPriceEstimate throws an error', () => {
+      it('throws an error that wraps that error', async () => {
+        fetchEthGasPriceEstimate.mockImplementation(() => {
+          throw new Error('fetchEthGasPriceEstimate failed');
+        });
+
+        const promise = determineGasFeeSuggestions(options);
+
+        await expect(promise).rejects.toThrow(
+          'Gas fee/price estimation failed. Message: fetchEthGasPriceEstimate failed',
+        );
+      });
+    });
+  });
+});

--- a/src/gas/determineGasFeeSuggestions.test.ts
+++ b/src/gas/determineGasFeeSuggestions.test.ts
@@ -169,7 +169,44 @@ describe('determineGasFeeSuggestions', () => {
           const promise = determineGasFeeSuggestions(options);
 
           await expect(promise).rejects.toThrow(
-            'Gas fee/price estimation failed. Message: fetchEthGasPriceEstimate failed',
+            'Could not generate gas fee suggestions: fetchEthGasPriceEstimate failed',
+          );
+        });
+      });
+    });
+
+    describe('when fetchGasEstimates does not throw an error, but calculateTimeEstimate throws an error', () => {
+      beforeEach(() => {
+        calculateTimeEstimate.mockImplementation(() => {
+          throw new Error('Some API failure');
+        });
+      });
+
+      describe('assuming fetchEthGasPriceEstimate does not throw an error', () => {
+        it('returns the fetched fee estimates and an empty set of time estimates', async () => {
+          const gasFeeEstimates = buildMockDataForFetchEthGasPriceEstimate();
+          fetchEthGasPriceEstimate.mockResolvedValue(gasFeeEstimates);
+
+          const gasFeeSuggestions = await determineGasFeeSuggestions(options);
+
+          expect(gasFeeSuggestions).toStrictEqual({
+            gasFeeEstimates,
+            estimatedGasFeeTimeBounds: {},
+            gasEstimateType: 'eth_gasPrice',
+          });
+        });
+      });
+
+      describe('when fetchEthGasPriceEstimate throws an error', () => {
+        it('throws an error that wraps that error', async () => {
+          fetchEthGasPriceEstimate.mockImplementation(() => {
+            throw new Error('fetchEthGasPriceEstimate failed');
+          });
+
+          const promise = determineGasFeeSuggestions(options);
+
+          await expect(promise).rejects.toThrow(
+            'Could not generate gas fee suggestions: fetchEthGasPriceEstimate failed',
           );
         });
       });
@@ -239,7 +276,7 @@ describe('determineGasFeeSuggestions', () => {
           const promise = determineGasFeeSuggestions(options);
 
           await expect(promise).rejects.toThrow(
-            'Gas fee/price estimation failed. Message: fetchEthGasPriceEstimate failed',
+            'Could not generate gas fee suggestions: fetchEthGasPriceEstimate failed',
           );
         });
       });
@@ -286,7 +323,7 @@ describe('determineGasFeeSuggestions', () => {
         const promise = determineGasFeeSuggestions(options);
 
         await expect(promise).rejects.toThrow(
-          'Gas fee/price estimation failed. Message: fetchEthGasPriceEstimate failed',
+          'Could not generate gas fee suggestions: fetchEthGasPriceEstimate failed',
         );
       });
     });

--- a/src/gas/determineGasFeeSuggestions.ts
+++ b/src/gas/determineGasFeeSuggestions.ts
@@ -1,0 +1,110 @@
+import {
+  GAS_ESTIMATE_TYPES,
+  EstimatedGasFeeTimeBounds,
+  EthGasPriceEstimate,
+  GasFeeEstimates,
+  GasFeeState as GasFeeSuggestions,
+  LegacyGasPriceEstimate,
+} from './GasFeeController';
+
+/**
+ * Obtains a set of max base and priority fee estimates along with time estimates so that we
+ * can present them to users when they are sending transactions or making swaps.
+ *
+ * @param args - The arguments.
+ * @param args.isEIP1559Compatible - Governs whether or not we can use an EIP-1559-only method to
+ * produce estimates.
+ * @param args.isLegacyGasAPICompatible - Governs whether or not we can use a non-EIP-1559 method to
+ * produce estimates (for instance, testnets do not support estimates altogether).
+ * @param args.fetchGasEstimates - A function that fetches gas estimates using an EIP-1559-specific
+ * API.
+ * @param args.fetchGasEstimatesUrl - The URL for the API we can use to obtain EIP-1559-specific
+ * estimates.
+ * @param args.fetchLegacyGasPriceEstimates - A function that fetches gas estimates using an
+ * non-EIP-1559-specific API.
+ * @param args.fetchLegacyGasPriceEstimatesUrl - The URL for the API we can use to obtain
+ * non-EIP-1559-specific estimates.
+ * @param args.fetchEthGasPriceEstimate - A function that fetches gas estimates using
+ * `eth_gasPrice`.
+ * @param args.calculateTimeEstimate - A function that determine time estimate bounds.
+ * @param args.clientId - An identifier that an API can use to know who is asking for estimates.
+ * @param args.ethQuery - An EthQuery instance we can use to talk to Ethereum directly.
+ * @returns The gas fee suggestions.
+ */
+export default async function determineGasFeeSuggestions({
+  isEIP1559Compatible,
+  isLegacyGasAPICompatible,
+  fetchGasEstimates,
+  fetchGasEstimatesUrl,
+  fetchLegacyGasPriceEstimates,
+  fetchLegacyGasPriceEstimatesUrl,
+  fetchEthGasPriceEstimate,
+  calculateTimeEstimate,
+  clientId,
+  ethQuery,
+}: {
+  isEIP1559Compatible: boolean;
+  isLegacyGasAPICompatible: boolean;
+  fetchGasEstimates: (
+    url: string,
+    clientId?: string,
+  ) => Promise<GasFeeEstimates>;
+  fetchGasEstimatesUrl: string;
+  fetchLegacyGasPriceEstimates: (
+    url: string,
+    clientId?: string,
+  ) => Promise<LegacyGasPriceEstimate>;
+  fetchLegacyGasPriceEstimatesUrl: string;
+  fetchEthGasPriceEstimate: (ethQuery: any) => Promise<EthGasPriceEstimate>;
+  calculateTimeEstimate: (
+    maxPriorityFeePerGas: string,
+    maxFeePerGas: string,
+    gasFeeEstimates: GasFeeEstimates,
+  ) => EstimatedGasFeeTimeBounds;
+  clientId: string | undefined;
+  ethQuery: any;
+}): Promise<GasFeeSuggestions> {
+  try {
+    if (isEIP1559Compatible) {
+      const estimates = await fetchGasEstimates(fetchGasEstimatesUrl, clientId);
+      const {
+        suggestedMaxPriorityFeePerGas,
+        suggestedMaxFeePerGas,
+      } = estimates.medium;
+      const estimatedGasFeeTimeBounds = calculateTimeEstimate(
+        suggestedMaxPriorityFeePerGas,
+        suggestedMaxFeePerGas,
+        estimates,
+      );
+      return {
+        gasFeeEstimates: estimates,
+        estimatedGasFeeTimeBounds,
+        gasEstimateType: GAS_ESTIMATE_TYPES.FEE_MARKET,
+      };
+    } else if (isLegacyGasAPICompatible) {
+      const estimates = await fetchLegacyGasPriceEstimates(
+        fetchLegacyGasPriceEstimatesUrl,
+        clientId,
+      );
+      return {
+        gasFeeEstimates: estimates,
+        estimatedGasFeeTimeBounds: {},
+        gasEstimateType: GAS_ESTIMATE_TYPES.LEGACY,
+      };
+    }
+    throw new Error('Main gas fee/price estimation failed. Use fallback');
+  } catch {
+    try {
+      const estimates = await fetchEthGasPriceEstimate(ethQuery);
+      return {
+        gasFeeEstimates: estimates,
+        estimatedGasFeeTimeBounds: {},
+        gasEstimateType: GAS_ESTIMATE_TYPES.ETH_GASPRICE,
+      };
+    } catch (error) {
+      throw new Error(
+        `Gas fee/price estimation failed. Message: ${error.message}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
The current method of using try/catch statements in
`determineGasFeeSuggestions` doesn't scale well. This commit converts
this code to a chain of promises instead so that we can add more
fallbacks without decreasing the readability of the code.