### PR TITLE
Refactor and backfill GasFeeController tests

### DIFF
--- a/src/gas/GasFeeController.test.ts
+++ b/src/gas/GasFeeController.test.ts
@@ -1,15 +1,19 @@
-import { stub } from 'sinon';
-import nock from 'nock';
+import { useFakeTimers, SinonFakeTimers } from 'sinon';
+import { mocked } from 'ts-jest/utils';
 import { ControllerMessenger } from '../ControllerMessenger';
 import {
+  EstimatedGasFeeTimeBounds,
   GasFeeController,
-  GetGasFeeState,
+  GasFeeEstimates,
   GasFeeStateChange,
+  GetGasFeeState,
   LegacyGasPriceEstimate,
 } from './GasFeeController';
+import { calculateTimeEstimate } from './gas-util';
 
-const TEST_GAS_FEE_API = 'https://mock-gas-server.herokuapp.com/<chain_id>';
-const TEST_LEGACY_FEE_API = 'https://test/<chain_id>';
+const mockedCalculateTimeEstimate = mocked(calculateTimeEstimate);
+
+jest.mock('./gas-util');
 
 const name = 'GasFeeController';
 
@@ -33,214 +37,694 @@ function getRestrictedMessenger() {
   return messenger;
 }
 
+/**
+ * Builds a mock return value for the `fetchGasEstimates` function that GasFeeController takes. All
+ * of the values here are filled in to satisfy the GasFeeEstimates type as well as the gas fee
+ * estimate logic within GasFeeController and are not intended to represent any particular scenario.
+ *
+ * @param args - The arguments.
+ * @param args.modifier - A number you can use to build a unique return value in the event that
+ * `fetchGasEstimates` is called multiple times. All data points will be multiplied by this number.
+ * @returns The mock data.
+ */
+function buildMockReturnValueForFetchGasEstimates({
+  modifier = 1,
+} = {}): GasFeeEstimates {
+  return {
+    low: {
+      minWaitTimeEstimate: 10000 * modifier,
+      maxWaitTimeEstimate: 20000 * modifier,
+      suggestedMaxPriorityFeePerGas: modifier.toString(),
+      suggestedMaxFeePerGas: (10 * modifier).toString(),
+    },
+    medium: {
+      minWaitTimeEstimate: 30000 * modifier,
+      maxWaitTimeEstimate: 40000 * modifier,
+      suggestedMaxPriorityFeePerGas: (1.5 * modifier).toString(),
+      suggestedMaxFeePerGas: (20 * modifier).toString(),
+    },
+    high: {
+      minWaitTimeEstimate: 50000 * modifier,
+      maxWaitTimeEstimate: 60000 * modifier,
+      suggestedMaxPriorityFeePerGas: (2 * modifier).toString(),
+      suggestedMaxFeePerGas: (30 * modifier).toString(),
+    },
+    estimatedBaseFee: (100 * modifier).toString(),
+  };
+}
+
+/**
+ * Builds a mock return value for the `legacyFetchGasPriceEstimates` function that GasFeeController
+ * takes. All of the values here are filled in to satisfy the LegacyGasPriceEstimate type as well as
+ * the gas fee estimate logic in GasFeeController and are not intended to represent any particular
+ * scenario.
+ *
+ * @param args - The arguments.
+ * @param args.modifier - A number you can use to build a unique return value in the event that
+ * `legacyFetchGasPriceEstimates` is called multiple times. All data points will be multiplied by
+ * this number.
+ * @returns The mock data.
+ */
+function buildMockReturnValueForLegacyFetchGasPriceEstimates({
+  modifier = 1,
+} = {}): LegacyGasPriceEstimate {
+  return {
+    low: (10 * modifier).toString(),
+    medium: (20 * modifier).toString(),
+    high: (30 * modifier).toString(),
+  };
+}
+
+/**
+ * Builds a mock returnv alue for the `calculateTimeEstimate` function that GasFeeController takes.
+ * All of the values here are filled in to satisfy the EstimatedGasFeeTimeBounds type and are not
+ * intended to represent any particular scenario.
+ *
+ * @returns The mock data.
+ */
+function buildMockReturnValueForCalculateTimeEstimate(): EstimatedGasFeeTimeBounds {
+  return {
+    lowerTimeBound: 0,
+    upperTimeBound: 0,
+  };
+}
+
+/**
+ * Returns a Jest mock function for a fetch* function that GasFeeController takes which is
+ * configured to return the given mock data.
+ *
+ * @param mockReturnValues - A set of values that the mock function should return, for all of the
+ * expected invocations of that function.
+ * @returns The Jest mock function.
+ */
+function createMockForFetchMethod(mockReturnValues: any[]) {
+  const mock = jest.fn();
+
+  if (mockReturnValues.length === 1) {
+    mock.mockReturnValue(mockReturnValues[0]);
+  } else {
+    mockReturnValues.forEach((response: any) => {
+      mock.mockImplementationOnce(() => Promise.resolve(response));
+    });
+  }
+
+  return mock;
+}
+
 describe('GasFeeController', () => {
+  let clock: SinonFakeTimers;
   let gasFeeController: GasFeeController;
-  let getCurrentNetworkLegacyGasAPICompatibility: jest.Mock<boolean>;
-  let getIsEIP1559Compatible: jest.Mock<Promise<boolean>>;
-  let getChainId: jest.Mock<`0x${string}` | `${number}` | number>;
-  let mockGasFeeRequest: any;
-  const mockRequestHandler = jest.fn();
+  let fetchGasEstimates: jest.Mock<any>;
+  let fetchLegacyGasPriceEstimates: jest.Mock<any>;
 
-  beforeAll(() => {
-    nock.disableNetConnect();
-  });
-
-  afterAll(() => {
-    nock.enableNetConnect();
-  });
-
-  beforeEach(() => {
-    getChainId = jest.fn().mockImplementation(() => '0x1');
+  /**
+   * Builds an instance of GasFeeController for use in testing, and then makes it available in
+   * tests along with mocks for fetch* functions passed to GasFeeController.
+   *
+   * @param options - The options.
+   * @param options.getChainId - Sets getChainId on the GasFeeController.
+   * @param options.getIsEIP1559Compatible - Sets getCurrentNetworkEIP1559Compatibility on the
+   * GasFeeController.
+   * @param options.getCurrentNetworkLegacyGasAPICompatibility - Sets
+   * getCurrentNetworkLegacyGasAPICompatibility on the GasFeeController.
+   * @param options.mockReturnValuesForFetchGasEstimates - Specifies mock data for one or more
+   * invocations of `fetchGasEstimates`.
+   * @param options.mockReturnValuesForFetchLegacyGasPriceEstimates - Specifies mock data for one or
+   * more invocations of `fetchLegacyGasPriceEstimates`.
+   * @param options.legacyAPIEndpoint - Sets legacyAPIEndpoint on the GasFeeController.
+   * @param options.EIP1559APIEndpoint - Sets EIP1559APIEndpoint on the GasFeeController.
+   * @param options.clientId - Sets clientId on the GasFeeController.
+   */
+  function setupGasFeeController({
+    getChainId = jest.fn().mockReturnValue('0x1'),
+    getIsEIP1559Compatible = jest.fn().mockResolvedValue(true),
     getCurrentNetworkLegacyGasAPICompatibility = jest
       .fn()
-      .mockImplementation(() => false);
+      .mockReturnValue(false),
+    mockReturnValuesForFetchGasEstimates = [
+      buildMockReturnValueForFetchGasEstimates(),
+    ],
+    mockReturnValuesForFetchLegacyGasPriceEstimates = [
+      buildMockReturnValueForLegacyFetchGasPriceEstimates(),
+    ],
+    legacyAPIEndpoint = 'http://legacy.endpoint/<chain_id>',
+    EIP1559APIEndpoint = 'http://eip-1559.endpoint/<chain_id>',
+    clientId,
+  }: {
+    getChainId?: jest.Mock<`0x${string}` | `${number}` | number>;
+    getIsEIP1559Compatible?: jest.Mock<Promise<boolean>>;
+    getCurrentNetworkLegacyGasAPICompatibility?: jest.Mock<boolean>;
+    mockReturnValuesForFetchGasEstimates?: any[];
+    mockReturnValuesForFetchLegacyGasPriceEstimates?: any[];
+    legacyAPIEndpoint?: string;
+    EIP1559APIEndpoint?: string;
+    clientId?: string;
+  } = {}) {
+    fetchGasEstimates = createMockForFetchMethod(
+      mockReturnValuesForFetchGasEstimates,
+    );
 
-    getIsEIP1559Compatible = jest
-      .fn()
-      .mockImplementation(() => Promise.resolve(true));
-
-    mockGasFeeRequest = nock(TEST_GAS_FEE_API.replace('<chain_id>', '1'))
-      .get(/.+/u)
-      .reply(200, {
-        low: {
-          minWaitTimeEstimate: 60000,
-          maxWaitTimeEstimate: 600000,
-          suggestedMaxPriorityFeePerGas: '1',
-          suggestedMaxFeePerGas: '35',
-        },
-        medium: {
-          minWaitTimeEstimate: 15000,
-          maxWaitTimeEstimate: 60000,
-          suggestedMaxPriorityFeePerGas: '1.8',
-          suggestedMaxFeePerGas: '38',
-        },
-        high: {
-          minWaitTimeEstimate: 0,
-          maxWaitTimeEstimate: 15000,
-          suggestedMaxPriorityFeePerGas: '2',
-          suggestedMaxFeePerGas: '50',
-        },
-        estimatedBaseFee: '28',
-      })
-      .persist();
-    mockGasFeeRequest.on('request', mockRequestHandler);
-
-    nock(TEST_LEGACY_FEE_API.replace('<chain_id>', '0x1'))
-      .get(/.+/u)
-      .reply(200, {
-        SafeGasPrice: '22',
-        ProposeGasPrice: '25',
-        FastGasPrice: '30',
-      })
-      .persist();
+    fetchLegacyGasPriceEstimates = createMockForFetchMethod(
+      mockReturnValuesForFetchLegacyGasPriceEstimates,
+    );
 
     gasFeeController = new GasFeeController({
-      interval: 10000,
       messenger: getRestrictedMessenger(),
-      getProvider: () => stub(),
+      getProvider: jest.fn(),
       getChainId,
-      legacyAPIEndpoint: TEST_LEGACY_FEE_API,
-      EIP1559APIEndpoint: TEST_GAS_FEE_API,
-      onNetworkStateChange: () => stub(),
+      fetchGasEstimates,
+      fetchLegacyGasPriceEstimates,
+      fetchEthGasPriceEstimate: jest.fn().mockResolvedValue({ gasPrice: '1' }),
+      onNetworkStateChange: jest.fn(),
       getCurrentNetworkLegacyGasAPICompatibility,
       getCurrentNetworkEIP1559Compatibility: getIsEIP1559Compatible, // change this for networkController.state.properties.isEIP1559Compatible ???
+      legacyAPIEndpoint,
+      EIP1559APIEndpoint,
+      clientId,
     });
+  }
+
+  beforeEach(() => {
+    clock = useFakeTimers();
   });
 
   afterEach(() => {
-    nock.cleanAll();
-    jest.clearAllMocks();
+    clock.uninstall();
     gasFeeController.destroy();
+    jest.clearAllMocks();
   });
 
-  it('should initialize', async () => {
-    expect(gasFeeController.name).toBe(name);
+  describe('constructor', () => {
+    beforeEach(() => {
+      setupGasFeeController();
+    });
+
+    it('should set the name of the controller to GasFeeController', () => {
+      expect(gasFeeController.name).toBe(name);
+    });
   });
 
   describe('getGasFeeEstimatesAndStartPolling', () => {
-    it('should fetch estimates and start polling', async () => {
-      expect(gasFeeController.state.gasFeeEstimates).toStrictEqual({});
-      const result = await gasFeeController.getGasFeeEstimatesAndStartPolling(
-        undefined,
-      );
-      expect(result).toHaveLength(36);
-      expect(gasFeeController.state.gasFeeEstimates).toHaveProperty('low');
-      expect(gasFeeController.state.gasFeeEstimates).toHaveProperty('medium');
-      expect(gasFeeController.state.gasFeeEstimates).toHaveProperty('high');
-      expect(gasFeeController.state.gasFeeEstimates).toHaveProperty(
-        'estimatedBaseFee',
-      );
+    describe('if never called before', () => {
+      describe('and called with undefined', () => {
+        it('should update the state with a fetched set of estimates', async () => {
+          const mockReturnValuesForFetchGasEstimates = [
+            buildMockReturnValueForFetchGasEstimates(),
+          ];
+          setupGasFeeController({
+            mockReturnValuesForFetchGasEstimates,
+          });
+
+          await gasFeeController.getGasFeeEstimatesAndStartPolling(undefined);
+
+          expect(gasFeeController.state.gasFeeEstimates).toStrictEqual(
+            mockReturnValuesForFetchGasEstimates[0],
+          );
+
+          expect(
+            gasFeeController.state.estimatedGasFeeTimeBounds,
+          ).toStrictEqual({});
+
+          expect(gasFeeController.state.gasEstimateType).toStrictEqual(
+            'fee-market',
+          );
+        });
+
+        it('should continue updating the state with all estimate data (including new time estimates because of a subsequent request) on a set interval', async () => {
+          const mockReturnValuesForFetchGasEstimates = [
+            buildMockReturnValueForFetchGasEstimates({ modifier: 1 }),
+            buildMockReturnValueForFetchGasEstimates({ modifier: 1.5 }),
+          ];
+          setupGasFeeController({
+            mockReturnValuesForFetchGasEstimates,
+          });
+          const estimatedGasFeeTimeBounds = buildMockReturnValueForCalculateTimeEstimate();
+          mockedCalculateTimeEstimate.mockReturnValue(
+            estimatedGasFeeTimeBounds,
+          );
+
+          await gasFeeController.getGasFeeEstimatesAndStartPolling(undefined);
+          await clock.nextAsync();
+
+          expect(gasFeeController.state.gasFeeEstimates).toStrictEqual(
+            mockReturnValuesForFetchGasEstimates[1],
+          );
+
+          expect(
+            gasFeeController.state.estimatedGasFeeTimeBounds,
+          ).toStrictEqual(estimatedGasFeeTimeBounds);
+
+          expect(gasFeeController.state.gasEstimateType).toStrictEqual(
+            'fee-market',
+          );
+        });
+      });
+
+      describe('and called with a previously unseen token', () => {
+        it('should make a request to fetch estimates', async () => {
+          setupGasFeeController();
+
+          await gasFeeController.getGasFeeEstimatesAndStartPolling(
+            'some-previously-unseen-token',
+          );
+
+          expect(fetchGasEstimates.mock.calls).toHaveLength(1);
+        });
+
+        it('should make further requests on a set interval', async () => {
+          setupGasFeeController();
+
+          await gasFeeController.getGasFeeEstimatesAndStartPolling(
+            'some-previously-unseen-token',
+          );
+          await clock.nextAsync();
+
+          expect(fetchGasEstimates.mock.calls).toHaveLength(2);
+        });
+      });
     });
 
-    it('should not fetch estimates if the controller is already polling, and should still return the passed token', async () => {
-      const pollToken = 'token';
+    describe('if called twice with undefined', () => {
+      it('should not make another request to fetch estimates', async () => {
+        setupGasFeeController();
 
-      const firstCallPromise = gasFeeController.getGasFeeEstimatesAndStartPolling(
-        undefined,
-      );
-      const secondCallPromise = gasFeeController.getGasFeeEstimatesAndStartPolling(
-        pollToken,
-      );
+        await gasFeeController.getGasFeeEstimatesAndStartPolling(undefined);
+        await gasFeeController.getGasFeeEstimatesAndStartPolling(undefined);
 
-      const result1 = await firstCallPromise;
-      const result2 = await secondCallPromise;
+        expect(fetchGasEstimates.mock.calls).toHaveLength(1);
+      });
 
-      expect(mockRequestHandler).toHaveBeenCalledTimes(1);
-      expect(result1).toHaveLength(36);
-      expect(result2).toStrictEqual(pollToken);
+      it('should not make more than one request per set interval', async () => {
+        setupGasFeeController();
+
+        await gasFeeController.getGasFeeEstimatesAndStartPolling(undefined);
+        await gasFeeController.getGasFeeEstimatesAndStartPolling(undefined);
+        await clock.nextAsync();
+        await clock.nextAsync();
+
+        expect(fetchGasEstimates.mock.calls).toHaveLength(3);
+      });
     });
 
-    it('should cause the fetching new estimates if called after the poll tokens are cleared, and then should not cause additional new fetches when subsequently called', async () => {
-      const pollToken = 'token';
+    describe('if called once with undefined and again with the same token', () => {
+      it('should make another request to fetch estimates', async () => {
+        setupGasFeeController();
 
-      const firstCallPromise = gasFeeController.getGasFeeEstimatesAndStartPolling(
-        undefined,
-      );
-      const secondCallPromise = gasFeeController.getGasFeeEstimatesAndStartPolling(
-        pollToken,
-      );
+        const pollToken = await gasFeeController.getGasFeeEstimatesAndStartPolling(
+          undefined,
+        );
+        await gasFeeController.getGasFeeEstimatesAndStartPolling(pollToken);
 
-      await firstCallPromise;
-      await secondCallPromise;
+        expect(fetchGasEstimates.mock.calls).toHaveLength(2);
+      });
 
-      expect(mockRequestHandler).toHaveBeenCalledTimes(1);
+      it('should not make more than one request per set interval', async () => {
+        setupGasFeeController();
 
-      gasFeeController.stopPolling();
+        const pollToken = await gasFeeController.getGasFeeEstimatesAndStartPolling(
+          undefined,
+        );
+        await gasFeeController.getGasFeeEstimatesAndStartPolling(pollToken);
+        await clock.nextAsync();
+        await clock.nextAsync();
 
-      const result3 = await gasFeeController.getGasFeeEstimatesAndStartPolling(
-        undefined,
-      );
-      expect(result3).toHaveLength(36);
-      expect(mockRequestHandler).toHaveBeenCalledTimes(2);
+        expect(fetchGasEstimates.mock.calls).toHaveLength(4);
+      });
+    });
 
-      const result4 = await gasFeeController.getGasFeeEstimatesAndStartPolling(
-        undefined,
-      );
-      expect(result4).toHaveLength(36);
-      expect(mockRequestHandler).toHaveBeenCalledTimes(2);
+    describe('if called twice, both with previously unseen tokens', () => {
+      it('should not make another request to fetch estimates', async () => {
+        setupGasFeeController();
+
+        await gasFeeController.getGasFeeEstimatesAndStartPolling(
+          'some-previously-unseen-token-1',
+        );
+
+        await gasFeeController.getGasFeeEstimatesAndStartPolling(
+          'some-previously-unseen-token-2',
+        );
+
+        expect(fetchGasEstimates.mock.calls).toHaveLength(1);
+      });
+
+      it('should not make more than one request per set interval', async () => {
+        setupGasFeeController();
+
+        await gasFeeController.getGasFeeEstimatesAndStartPolling(
+          'some-previously-unseen-token-1',
+        );
+
+        await gasFeeController.getGasFeeEstimatesAndStartPolling(
+          'some-previously-unseen-token-2',
+        );
+        await clock.nextAsync();
+        await clock.nextAsync();
+
+        expect(fetchGasEstimates.mock.calls).toHaveLength(3);
+      });
     });
   });
 
-  describe('when on any network supporting legacy gas estimation api', () => {
-    it('should _fetchGasFeeEstimateData', async () => {
-      getCurrentNetworkLegacyGasAPICompatibility.mockImplementation(() => true);
-      getIsEIP1559Compatible.mockImplementation(() => Promise.resolve(false));
-      expect(gasFeeController.state.gasFeeEstimates).toStrictEqual({});
-      const estimates = await gasFeeController._fetchGasFeeEstimateData();
-      expect(estimates).toHaveProperty('gasFeeEstimates');
-      expect(
-        (gasFeeController.state.gasFeeEstimates as LegacyGasPriceEstimate).high,
-      ).toBe('30');
+  describe('disconnectPoller', () => {
+    describe('assuming that getGasFeeEstimatesAndStartPolling was already called exactly once', () => {
+      describe('given the same token as the result of the first call', () => {
+        it('should prevent requests from being made periodically', async () => {
+          setupGasFeeController();
+          const pollToken = await gasFeeController.getGasFeeEstimatesAndStartPolling(
+            undefined,
+          );
+          await clock.nextAsync();
+          expect(fetchGasEstimates.mock.calls).toHaveLength(2);
+
+          gasFeeController.disconnectPoller(pollToken);
+
+          await clock.nextAsync();
+          expect(fetchGasEstimates.mock.calls).toHaveLength(2);
+        });
+
+        it('should make it so that a second call to getGasFeeEstimatesAndStartPolling with the same token has the same effect as the inaugural call', async () => {
+          setupGasFeeController();
+          const pollToken = await gasFeeController.getGasFeeEstimatesAndStartPolling(
+            undefined,
+          );
+          await clock.nextAsync();
+          expect(fetchGasEstimates.mock.calls).toHaveLength(2);
+
+          gasFeeController.disconnectPoller(pollToken);
+
+          await gasFeeController.getGasFeeEstimatesAndStartPolling(pollToken);
+          await clock.nextAsync();
+          expect(fetchGasEstimates.mock.calls).toHaveLength(4);
+        });
+      });
+
+      describe('given a previously unseen token', () => {
+        it('should not prevent requests from being made periodically', async () => {
+          setupGasFeeController();
+          await gasFeeController.getGasFeeEstimatesAndStartPolling(undefined);
+          await clock.nextAsync();
+          expect(fetchGasEstimates.mock.calls).toHaveLength(2);
+
+          gasFeeController.disconnectPoller('some-previously-unseen-token');
+
+          await clock.nextAsync();
+          expect(fetchGasEstimates.mock.calls).toHaveLength(3);
+        });
+      });
+    });
+
+    describe('if getGasFeeEstimatesAndStartPolling was called twice with different tokens', () => {
+      it('should not prevent requests from being made periodically', async () => {
+        setupGasFeeController();
+        const pollToken1 = await gasFeeController.getGasFeeEstimatesAndStartPolling(
+          undefined,
+        );
+        await gasFeeController.getGasFeeEstimatesAndStartPolling(undefined);
+        await clock.nextAsync();
+        expect(fetchGasEstimates.mock.calls).toHaveLength(2);
+
+        gasFeeController.disconnectPoller(pollToken1);
+
+        await clock.nextAsync();
+        expect(fetchGasEstimates.mock.calls).toHaveLength(3);
+      });
+    });
+
+    describe('if getGasFeeEstimatesAndStartPolling was never called', () => {
+      it('should not throw an error', () => {
+        setupGasFeeController();
+        expect(() =>
+          gasFeeController.disconnectPoller('some-token'),
+        ).not.toThrow();
+      });
     });
   });
 
-  describe('getChainId', () => {
-    it('should work with a number input', async () => {
-      getChainId.mockImplementation(() => 1);
-      getCurrentNetworkLegacyGasAPICompatibility.mockImplementation(() => true);
-      getIsEIP1559Compatible.mockImplementation(() => Promise.resolve(false));
-      expect(gasFeeController.state.gasFeeEstimates).toStrictEqual({});
-      const estimates = await gasFeeController._fetchGasFeeEstimateData();
-      expect(estimates).toHaveProperty('gasFeeEstimates');
-      expect(
-        (gasFeeController.state.gasFeeEstimates as LegacyGasPriceEstimate).high,
-      ).toBe('30');
+  describe('stopPolling', () => {
+    describe('assuming that getGasFeeEstimatesAndStartPolling was already called once', () => {
+      it('should prevent requests from being made periodically', async () => {
+        setupGasFeeController();
+        await gasFeeController.getGasFeeEstimatesAndStartPolling(undefined);
+        await clock.nextAsync();
+        expect(fetchGasEstimates.mock.calls).toHaveLength(2);
+
+        gasFeeController.stopPolling();
+
+        await clock.nextAsync();
+        expect(fetchGasEstimates.mock.calls).toHaveLength(2);
+      });
+
+      it('should make it so that a second call to getGasFeeEstimatesAndStartPolling with the same token has the same effect as the inaugural call', async () => {
+        setupGasFeeController();
+        const pollToken = await gasFeeController.getGasFeeEstimatesAndStartPolling(
+          undefined,
+        );
+        await clock.nextAsync();
+        expect(fetchGasEstimates.mock.calls).toHaveLength(2);
+
+        gasFeeController.stopPolling();
+
+        await gasFeeController.getGasFeeEstimatesAndStartPolling(pollToken);
+        await clock.nextAsync();
+        expect(fetchGasEstimates.mock.calls).toHaveLength(4);
+      });
+
+      it('should revert the state back to its original form', async () => {
+        setupGasFeeController();
+        await gasFeeController.getGasFeeEstimatesAndStartPolling(undefined);
+
+        gasFeeController.stopPolling();
+
+        expect(gasFeeController.state.gasFeeEstimates).toStrictEqual({});
+        expect(gasFeeController.state.estimatedGasFeeTimeBounds).toStrictEqual(
+          {},
+        );
+
+        expect(gasFeeController.state.gasEstimateType).toStrictEqual('none');
+      });
     });
 
-    it('should work with a hexstring input', async () => {
-      getChainId.mockImplementation(() => '0x1');
-      getCurrentNetworkLegacyGasAPICompatibility.mockImplementation(() => true);
-      getIsEIP1559Compatible.mockImplementation(() => Promise.resolve(false));
-      expect(gasFeeController.state.gasFeeEstimates).toStrictEqual({});
-      const estimates = await gasFeeController._fetchGasFeeEstimateData();
-      expect(estimates).toHaveProperty('gasFeeEstimates');
-      expect(
-        (gasFeeController.state.gasFeeEstimates as LegacyGasPriceEstimate).high,
-      ).toBe('30');
+    describe('if getGasFeeEstimatesAndStartPolling was called multiple times with the same token (thereby restarting the polling once)', () => {
+      it('should prevent requests from being made periodically', async () => {
+        setupGasFeeController();
+        const pollToken = await gasFeeController.getGasFeeEstimatesAndStartPolling(
+          undefined,
+        );
+        await gasFeeController.getGasFeeEstimatesAndStartPolling(pollToken);
+        await clock.nextAsync();
+        expect(fetchGasEstimates.mock.calls).toHaveLength(3);
+
+        gasFeeController.stopPolling();
+
+        await clock.nextAsync();
+        expect(fetchGasEstimates.mock.calls).toHaveLength(3);
+      });
+
+      it('should make it so that another call to getGasFeeEstimatesAndStartPolling with a previously generated token has the same effect as the inaugural call', async () => {
+        setupGasFeeController();
+        const pollToken = await gasFeeController.getGasFeeEstimatesAndStartPolling(
+          undefined,
+        );
+        await gasFeeController.getGasFeeEstimatesAndStartPolling(pollToken);
+        await clock.nextAsync();
+        expect(fetchGasEstimates.mock.calls).toHaveLength(3);
+
+        gasFeeController.stopPolling();
+
+        await gasFeeController.getGasFeeEstimatesAndStartPolling(pollToken);
+        await clock.nextAsync();
+        expect(fetchGasEstimates.mock.calls).toHaveLength(5);
+      });
     });
 
-    it('should work with a numeric string input', async () => {
-      getChainId.mockImplementation(() => '1');
-      getCurrentNetworkLegacyGasAPICompatibility.mockImplementation(() => true);
-      getIsEIP1559Compatible.mockImplementation(() => Promise.resolve(false));
-      expect(gasFeeController.state.gasFeeEstimates).toStrictEqual({});
-      const estimates = await gasFeeController._fetchGasFeeEstimateData();
-      expect(estimates).toHaveProperty('gasFeeEstimates');
-      expect(
-        (gasFeeController.state.gasFeeEstimates as LegacyGasPriceEstimate).high,
-      ).toBe('30');
+    describe('if getGasFeeEstimatesAndStartPolling was never called', () => {
+      it('should not throw an error', () => {
+        setupGasFeeController();
+        expect(() => gasFeeController.stopPolling()).not.toThrow();
+      });
     });
   });
 
-  describe('when on any network supporting EIP-1559', () => {
-    it('should _fetchGasFeeEstimateData', async () => {
-      getCurrentNetworkLegacyGasAPICompatibility.mockImplementation(() => true);
-      expect(gasFeeController.state.gasFeeEstimates).toStrictEqual({});
-      const estimates = await gasFeeController._fetchGasFeeEstimateData();
-      expect(estimates).toHaveProperty('gasFeeEstimates');
-      expect(gasFeeController.state.gasFeeEstimates).toHaveProperty(
-        'estimatedBaseFee',
-      );
+  describe('_fetchGasFeeEstimateData', () => {
+    describe('when on any network supporting legacy gas estimation api', () => {
+      const mockReturnValuesForFetchLegacyGasPriceEstimates = [
+        buildMockReturnValueForLegacyFetchGasPriceEstimates(),
+      ];
+      const defaultConstructorOptions = {
+        getIsEIP1559Compatible: jest.fn().mockResolvedValue(false),
+        getCurrentNetworkLegacyGasAPICompatibility: jest
+          .fn()
+          .mockReturnValue(true),
+        mockReturnValuesForFetchLegacyGasPriceEstimates,
+      };
+
+      it('should update the state with a fetched set of estimates', async () => {
+        setupGasFeeController(defaultConstructorOptions);
+
+        await gasFeeController._fetchGasFeeEstimateData();
+
+        expect(gasFeeController.state.gasFeeEstimates).toStrictEqual(
+          mockReturnValuesForFetchLegacyGasPriceEstimates[0],
+        );
+
+        expect(gasFeeController.state.estimatedGasFeeTimeBounds).toStrictEqual(
+          {},
+        );
+
+        expect(gasFeeController.state.gasEstimateType).toStrictEqual('legacy');
+      });
+
+      it('should return the same data that it puts into state', async () => {
+        setupGasFeeController(defaultConstructorOptions);
+
+        const estimateData = await gasFeeController._fetchGasFeeEstimateData();
+
+        expect(estimateData.gasFeeEstimates).toStrictEqual(
+          mockReturnValuesForFetchLegacyGasPriceEstimates[0],
+        );
+
+        expect(estimateData.estimatedGasFeeTimeBounds).toStrictEqual({});
+
+        expect(estimateData.gasEstimateType).toStrictEqual('legacy');
+      });
+
+      it('should call fetchLegacyGasPriceEstimates correctly when getChainId returns a number input', async () => {
+        setupGasFeeController({
+          ...defaultConstructorOptions,
+          legacyAPIEndpoint: 'http://legacy.endpoint/<chain_id>',
+          getChainId: jest.fn().mockReturnValue(1),
+          clientId: '123',
+        });
+
+        await gasFeeController._fetchGasFeeEstimateData();
+
+        expect(fetchLegacyGasPriceEstimates).toHaveBeenCalledWith(
+          'http://legacy.endpoint/1',
+          '123',
+        );
+      });
+
+      it('should call fetchLegacyGasPriceEstimates correctly when getChainId returns a hexstring input', async () => {
+        setupGasFeeController({
+          ...defaultConstructorOptions,
+          legacyAPIEndpoint: 'http://legacy.endpoint/<chain_id>',
+          getChainId: jest.fn().mockReturnValue('0x1'),
+          clientId: '123',
+        });
+
+        await gasFeeController._fetchGasFeeEstimateData();
+
+        expect(fetchLegacyGasPriceEstimates).toHaveBeenCalledWith(
+          'http://legacy.endpoint/1',
+          '123',
+        );
+      });
+
+      it('should call fetchLegacyGasPriceEstimates correctly when getChainId returns a numeric string input', async () => {
+        setupGasFeeController({
+          ...defaultConstructorOptions,
+          legacyAPIEndpoint: 'http://legacy.endpoint/<chain_id>',
+          getChainId: jest.fn().mockReturnValue('1'),
+          clientId: '123',
+        });
+
+        await gasFeeController._fetchGasFeeEstimateData();
+
+        expect(fetchLegacyGasPriceEstimates).toHaveBeenCalledWith(
+          'http://legacy.endpoint/1',
+          '123',
+        );
+      });
+    });
+
+    describe('when on any network supporting EIP-1559', () => {
+      const mockReturnValuesForFetchGasEstimates = [
+        buildMockReturnValueForFetchGasEstimates(),
+      ];
+      const defaultConstructorOptions = {
+        getIsEIP1559Compatible: jest.fn().mockResolvedValue(true),
+        mockReturnValuesForFetchGasEstimates,
+      };
+
+      it('should update the state with a fetched set of estimates', async () => {
+        setupGasFeeController(defaultConstructorOptions);
+
+        await gasFeeController._fetchGasFeeEstimateData();
+
+        expect(gasFeeController.state.gasFeeEstimates).toStrictEqual(
+          mockReturnValuesForFetchGasEstimates[0],
+        );
+
+        expect(gasFeeController.state.estimatedGasFeeTimeBounds).toStrictEqual(
+          {},
+        );
+
+        expect(gasFeeController.state.gasEstimateType).toStrictEqual(
+          'fee-market',
+        );
+      });
+
+      it('should return the same data that it puts into state', async () => {
+        setupGasFeeController(defaultConstructorOptions);
+
+        const estimateData = await gasFeeController._fetchGasFeeEstimateData();
+
+        expect(estimateData.gasFeeEstimates).toStrictEqual(
+          mockReturnValuesForFetchGasEstimates[0],
+        );
+
+        expect(estimateData.estimatedGasFeeTimeBounds).toStrictEqual({});
+
+        expect(estimateData.gasEstimateType).toStrictEqual('fee-market');
+      });
+
+      it('should call fetchGasEstimates correctly when getChainId returns a number input', async () => {
+        setupGasFeeController({
+          ...defaultConstructorOptions,
+          EIP1559APIEndpoint: 'http://eip-1559.endpoint/<chain_id>',
+          getChainId: jest.fn().mockReturnValue(1),
+          clientId: '123',
+        });
+
+        await gasFeeController._fetchGasFeeEstimateData();
+
+        expect(fetchGasEstimates).toHaveBeenCalledWith(
+          'http://eip-1559.endpoint/1',
+          '123',
+        );
+      });
+
+      it('should call fetchGasEstimates correctly when getChainId returns a hexstring input', async () => {
+        setupGasFeeController({
+          ...defaultConstructorOptions,
+          EIP1559APIEndpoint: 'http://eip-1559.endpoint/<chain_id>',
+          getChainId: jest.fn().mockReturnValue('0x1'),
+          clientId: '123',
+        });
+
+        await gasFeeController._fetchGasFeeEstimateData();
+
+        expect(fetchGasEstimates).toHaveBeenCalledWith(
+          'http://eip-1559.endpoint/1',
+          '123',
+        );
+      });
+
+      it('should call fetchGasEstimates correctly when getChainId returns a numeric string input', async () => {
+        setupGasFeeController({
+          ...defaultConstructorOptions,
+          EIP1559APIEndpoint: 'http://eip-1559.endpoint/<chain_id>',
+          getChainId: jest.fn().mockReturnValue('1'),
+          clientId: '123',
+        });
+
+        await gasFeeController._fetchGasFeeEstimateData();
+
+        expect(fetchGasEstimates).toHaveBeenCalledWith(
+          'http://eip-1559.endpoint/1',
+          '123',
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
The tests for GasFeeController are currently lacking in a few ways:

* `nock` is being used to test that requests are being used to obtain
  data; however, GasFeeController takes functions as arguments which can
  be used to stub out those requests, thereby removing the need for
  `nock`.
* The logic within `getGasFeeEstimatesAndStartPolling` is not being
  fully exercised, specifically the polling code.
* There are no tests for `disconnectPoller`.
* There are no explicit tests for `stopPolling`.
* The logic within `_fetchGasFeeEstimateData` is not being fully
  exercised, specifically with regard to  how the result of `getChainId`
  changes the URL that ends up being hit for both EIP-1559 and
  non-EIP-1559 flows.
* There are tests categorized under a `getChainId` describe block which
  are actually for `_fetchGasFeeEstimateData`.

This commit attempts to address these issues so that future changes to
GasFeeController do not break existing behavior.