### PR TITLE
Fix update conversionDate return

### DIFF
--- a/src/assets/CurrencyRateController.test.ts
+++ b/src/assets/CurrencyRateController.test.ts
@@ -305,7 +305,7 @@ describe('CurrencyRateController', () => {
     await controller.updateExchangeRate();
 
     expect(controller.state).toStrictEqual({
-      conversionDate: getStubbedDate() / 1000,
+      conversionDate: null,
       conversionRate: null,
       currentCurrency: '',
       nativeCurrency: 'BNB',

--- a/src/assets/CurrencyRateController.ts
+++ b/src/assets/CurrencyRateController.ts
@@ -18,7 +18,7 @@ import type { RestrictedControllerMessenger } from '../ControllerMessenger';
  * @property usdConversionRate - Conversion rate from usd to the current currency
  */
 export type CurrencyRateState = {
-  conversionDate: number;
+  conversionDate: number | null;
   conversionRate: number | null;
   currentCurrency: string;
   nativeCurrency: string;
@@ -200,7 +200,7 @@ export class CurrencyRateController extends BaseController<
       pendingNativeCurrency,
     } = this.state;
 
-    const conversionDate: number = Date.now() / 1000;
+    let conversionDate: number | null = null;
     let conversionRate: number | null = null;
     let usdConversionRate: number | null = null;
     const currentCurrency = pendingCurrentCurrency ?? stateCurrentCurrency;
@@ -221,6 +221,7 @@ export class CurrencyRateController extends BaseController<
           nativeCurrency,
           this.includeUsdRate,
         ));
+        conversionDate = Date.now() / 1000;
       }
     } catch (error) {
       if (!error.message.includes('market does not exist for this coin pair')) {


### PR DESCRIPTION
**Update the conversionDate return *

- conversionDate value was always returned even when the fetch getPricingURL was failing (offline for example). Then, the extension is receiving the conversion date if there is no network. 
-  This issue is relate to https://github.com/MetaMask/metamask-extension/issues/10741. 

**FIXES:**  The purpose of this PR is to return a good timestamp if the fetch was a success otherwise null (like current conversionRate value )

**BREAKING:** Metamask extension now has to update the SettingsTab component. This is currently in progress in the PR https://github.com/MetaMask/metamask-extension/pull/12422   
