### PR TITLE
Remove polling start call in detection controllers' constructors

### DIFF
--- a/src/assets/CollectibleDetectionController.test.ts
+++ b/src/assets/CollectibleDetectionController.test.ts
@@ -204,7 +204,7 @@ describe('CollectibleDetectionController', () => {
         CollectibleDetectionController.prototype,
         'detectCollectibles',
       );
-      new CollectibleDetectionController(
+      const collectiblesDetectionController = new CollectibleDetectionController(
         {
           onCollectiblesStateChange: (listener) =>
             collectiblesController.subscribe(listener),
@@ -219,6 +219,8 @@ describe('CollectibleDetectionController', () => {
         },
         { interval: 10 },
       );
+      collectiblesDetectionController.start();
+
       expect(mockCollectibles.calledOnce).toBe(true);
       setTimeout(() => {
         expect(mockCollectibles.calledTwice).toBe(true);

--- a/src/assets/CollectibleDetectionController.ts
+++ b/src/assets/CollectibleDetectionController.ts
@@ -245,7 +245,6 @@ export class CollectibleDetectionController extends BaseController<
     });
     this.getOpenSeaApiKey = getOpenSeaApiKey;
     this.addCollectible = addCollectible;
-    this.start();
   }
 
   /**

--- a/src/assets/TokenDetectionController.test.ts
+++ b/src/assets/TokenDetectionController.test.ts
@@ -176,7 +176,7 @@ describe('TokenDetectionController', () => {
         TokenDetectionController.prototype,
         'detectTokens',
       );
-      new TokenDetectionController(
+      const tokenDetectionController = new TokenDetectionController(
         {
           onTokensStateChange: (listener) =>
             tokensController.subscribe(listener),
@@ -192,6 +192,8 @@ describe('TokenDetectionController', () => {
         },
         { interval: 10 },
       );
+      tokenDetectionController.start();
+
       expect(mockTokens.calledOnce).toBe(true);
       setTimeout(() => {
         expect(mockTokens.calledTwice).toBe(true);

--- a/src/assets/TokenDetectionController.ts
+++ b/src/assets/TokenDetectionController.ts
@@ -117,7 +117,6 @@ export class TokenDetectionController extends BaseController<
       this.configure({ networkType: provider.type });
     });
     this.getBalancesInSingleCall = getBalancesInSingleCall;
-    this.start();
   }
 
   /**


### PR DESCRIPTION
- BREAKING: Removes call to start polling from the constructors of CollectibleDetectionController and TokenDetectionController.
  - Consumers of either of these Controllers who wish to immediately start polling upon instantiation will need to call the start method on the controller right after instantiating the controller.

