### PR TITLE
[FIX] Mobile backwards compatibility

### DIFF
--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -25,7 +25,7 @@ import type {
   ApiCollectibleLastSale,
 } from './CollectibleDetectionController';
 import type { AssetsContractController } from './AssetsContractController';
-import { compareCollectiblesMetadata } from './assetsUtil';
+import { compareCollectibles, compareCollectiblesMetadata } from './assetsUtil';
 
 /**
  * @type Collectible
@@ -475,10 +475,10 @@ export class CollectiblesController extends BaseController<
       address = toChecksumHexAddress(address);
       const { allCollectibles, collectibles } = this.state;
       const { chainId, selectedAddress } = this.config;
-      const existingEntry: Collectible | undefined = collectibles.find(
-        (collectible) =>
-          collectible.address.toLowerCase() === address.toLowerCase() &&
-          collectible.tokenId === tokenId,
+      const existingEntry:
+        | Collectible
+        | undefined = collectibles.find((collectible) =>
+        compareCollectibles(collectible, address, tokenId),
       );
 
       if (existingEntry) {
@@ -486,12 +486,10 @@ export class CollectiblesController extends BaseController<
           collectibleMetadata,
           existingEntry,
         );
-        if (differentMetadata) {
+        if (differentMetadata || typeof existingEntry.tokenId === 'number') {
           // TODO: Switch to indexToUpdate
-          const indexToRemove = collectibles.findIndex(
-            (collectible) =>
-              collectible.address.toLowerCase() === address.toLowerCase() &&
-              collectible.tokenId === tokenId,
+          const indexToRemove = collectibles.findIndex((collectible) =>
+            compareCollectibles(collectible, address, tokenId),
           );
           /* istanbul ignore next */
           if (indexToRemove !== -1) {

--- a/src/assets/assetsUtil.test.ts
+++ b/src/assets/assetsUtil.test.ts
@@ -2,6 +2,68 @@ import * as assetsUtil from './assetsUtil';
 import { Collectible, CollectibleMetadata } from './CollectiblesController';
 
 describe('assetsUtil', () => {
+  describe('compareCollectibles', () => {
+    it('should resolve true if address and token ID matches', () => {
+      const addressToCompare = 'address';
+      const tokenIdToCompare = '123';
+      const collectible: Collectible = {
+        address: 'address',
+        tokenId: '123',
+        name: 'collectible',
+        description: 'description',
+        image: 'image',
+        standard: 'std',
+      };
+      expect(
+        assetsUtil.compareCollectibles(
+          collectible,
+          addressToCompare,
+          tokenIdToCompare,
+        ),
+      ).toStrictEqual(true);
+    });
+
+    it('should resolve false if the address is not the same', () => {
+      const addressToCompare = 'dif_address';
+      const tokenIdToCompare = '123';
+      const collectible: Collectible = {
+        address: 'address',
+        tokenId: '123',
+        name: 'collectible',
+        description: 'description',
+        image: 'image',
+        standard: 'std',
+      };
+      expect(
+        assetsUtil.compareCollectibles(
+          collectible,
+          addressToCompare,
+          tokenIdToCompare,
+        ),
+      ).toStrictEqual(false);
+    });
+
+    it('should resolve false if the token ID is not the same', () => {
+      const addressToCompare = 'address';
+      const tokenIdToCompare = '456';
+      const collectible: Collectible = {
+        address: 'address',
+        tokenId: '123',
+        name: 'collectible',
+        description: 'description',
+        image: 'image',
+        standard: 'std',
+      };
+      expect(
+        assetsUtil.compareCollectibles(
+          collectible,
+          addressToCompare,
+          tokenIdToCompare,
+        ),
+      ).toStrictEqual(false);
+    });
+  });
+
   describe('compareCollectiblesMetadata', () => {
     it('should resolve true if any key is different', () => {
       const collectibleMetadata: CollectibleMetadata = {

--- a/src/assets/assetsUtil.ts
+++ b/src/assets/assetsUtil.ts
@@ -1,6 +1,28 @@
 import { Collectible, CollectibleMetadata } from './CollectiblesController';
 
 /**
+ * Compares a collectible address and token ID to the values addressToCompare and tokenIdToCompare.
+ * The conversion to a String is needed to solve a backwards compatibility issue caused by token IDs
+ * being stored as Number.
+ *
+ * @param collectible - Collectible object.
+ * @param addressToCompare - Address to compare with.
+ * @param tokenIdToCompare - Token ID to compare with.
+ * @returns Boolean indicating if the values match the collectible data.
+ */
+export function compareCollectibles(
+  collectible: Collectible,
+  addressToCompare: string,
+  tokenIdToCompare: string,
+) {
+  return (
+    collectible.address.toLowerCase() === addressToCompare.toLowerCase() &&
+    (collectible.tokenId === tokenIdToCompare ||
+      String(collectible.tokenId) === tokenIdToCompare)
+  );
+}
+
+/**
  * Compares collectible metadata entries to any collectible entry.
  * We need this method when comparing a new fetched collectible metadata, in case a entry changed to a defined value,
  * there's a need to update the collectible in state.
@@ -22,6 +44,7 @@ export function compareCollectiblesMetadata(
     'animation',
     'animationOriginal',
     'externalLink',
+    'standard',
   ];
   const differentValues = keys.reduce((value, key) => {
     if (


### PR DESCRIPTION
# Description

With version 18.0.0 there was a change on the data type for the property `tokenId`, the data type is now a `String` instead of a `Number`. This change introduced some backwards compatibility issues in the app that are fixed by this PR.

# Tasks

- [x] Check `tokenId` for both data types
- [x] Add test cases
- [x] Update unit tests 