### PR TITLE
Pull in networkCongestion along with gas estimates

### DIFF
--- a/src/gas/GasFeeController.test.ts
+++ b/src/gas/GasFeeController.test.ts
@@ -76,6 +76,7 @@ function buildMockGasFeeStateFeeMarket({
         suggestedMaxFeePerGas: (30 * modifier).toString(),
       },
       estimatedBaseFee: (100 * modifier).toString(),
+      networkCongestion: 0.1 * modifier,
     },
     estimatedGasFeeTimeBounds: {
       lowerTimeBound: 1000 * modifier,

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -118,6 +118,8 @@ export type Eip1559GasFee = {
  * @property medium - A GasFee for a recommended combination of tip and maxFee
  * @property high - A GasFee for a high combination of tip and maxFee
  * @property estimatedBaseFee - An estimate of what the base fee will be for the pending/next block. A GWEI dec number
+ * @property networkCongestion - A normalized number that can be used to gauge the congestion
+ * level of the network, with 0 meaning not congested and 1 meaning extremely congested
  */
 
 export type GasFeeEstimates = {
@@ -125,6 +127,7 @@ export type GasFeeEstimates = {
   medium: Eip1559GasFee;
   high: Eip1559GasFee;
   estimatedBaseFee: string;
+  networkCongestion: number;
 };
 
 const metadata = {

--- a/src/gas/determineGasFeeCalculations.test.ts
+++ b/src/gas/determineGasFeeCalculations.test.ts
@@ -58,6 +58,7 @@ function buildMockDataForFetchGasEstimates(): GasFeeEstimates {
       suggestedMaxFeePerGas: '30',
     },
     estimatedBaseFee: '100',
+    networkCongestion: 0.5,
   };
 }
 

--- a/src/gas/fetchBlockFeeHistory.ts
+++ b/src/gas/fetchBlockFeeHistory.ts
@@ -48,7 +48,7 @@ export type EthFeeHistoryResponse = {
  * used for the block, indexed by those percentiles. (See docs for {@link fetchBlockFeeHistory} for more
  * on how this works.)
  */
-type Block<Percentile extends number> = {
+export type Block<Percentile extends number> = {
   number: BN;
   baseFeePerGas: BN;
   gasUsedRatio: number;

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory.test.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory.test.ts
@@ -1,47 +1,79 @@
 import { BN } from 'ethereumjs-util';
 import { mocked } from 'ts-jest/utils';
+import { when } from 'jest-when';
 import fetchBlockFeeHistory from './fetchBlockFeeHistory';
 import fetchGasEstimatesViaEthFeeHistory from './fetchGasEstimatesViaEthFeeHistory';
 
 jest.mock('./fetchBlockFeeHistory');
 
-const mockedFetchFeeHistory = mocked(fetchBlockFeeHistory, true);
+const mockedFetchBlockFeeHistory = mocked(fetchBlockFeeHistory, true);
 
 describe('fetchGasEstimatesViaEthFeeHistory', () => {
-  it('calculates target fees for low, medium, and high transaction priority levels', async () => {
+  it('calculates target fees for low, medium, and high transaction priority levels, as well as the network congestion level', async () => {
     const ethQuery = {};
-    mockedFetchFeeHistory.mockResolvedValue([
-      {
-        number: new BN(1),
-        baseFeePerGas: new BN(0),
-        gasUsedRatio: 1,
-        priorityFeesByPercentile: {
-          10: new BN(0),
-          20: new BN(1_000_000_000),
-          30: new BN(0),
+    when(mockedFetchBlockFeeHistory)
+      .calledWith({
+        ethQuery,
+        numberOfBlocks: 5,
+        percentiles: [10, 20, 30],
+      })
+      .mockResolvedValue([
+        {
+          number: new BN(1),
+          baseFeePerGas: new BN(300_000_000_000),
+          gasUsedRatio: 1,
+          priorityFeesByPercentile: {
+            10: new BN(0),
+            20: new BN(1_000_000_000),
+            30: new BN(0),
+          },
         },
-      },
-      {
-        number: new BN(2),
-        baseFeePerGas: new BN(0),
-        gasUsedRatio: 1,
-        priorityFeesByPercentile: {
-          10: new BN(500_000_000),
-          20: new BN(1_600_000_000),
-          30: new BN(3_000_000_000),
+        {
+          number: new BN(2),
+          baseFeePerGas: new BN(100_000_000_000),
+          gasUsedRatio: 1,
+          priorityFeesByPercentile: {
+            10: new BN(500_000_000),
+            20: new BN(1_600_000_000),
+            30: new BN(3_000_000_000),
+          },
         },
-      },
-      {
-        number: new BN(3),
-        baseFeePerGas: new BN(100_000_000_000),
-        gasUsedRatio: 1,
-        priorityFeesByPercentile: {
-          10: new BN(500_000_000),
-          20: new BN(2_000_000_000),
-          30: new BN(3_000_000_000),
+        {
+          number: new BN(3),
+          baseFeePerGas: new BN(200_000_000_000),
+          gasUsedRatio: 1,
+          priorityFeesByPercentile: {
+            10: new BN(500_000_000),
+            20: new BN(2_000_000_000),
+            30: new BN(3_000_000_000),
+          },
         },
-      },
-    ]);
+      ])
+      .calledWith({
+        ethQuery,
+        numberOfBlocks: 20_000,
+        endBlock: new BN(3),
+      })
+      .mockResolvedValue([
+        {
+          number: new BN(1),
+          baseFeePerGas: new BN(300_000_000_000),
+          gasUsedRatio: 1,
+          priorityFeesByPercentile: {},
+        },
+        {
+          number: new BN(2),
+          baseFeePerGas: new BN(100_000_000_000),
+          gasUsedRatio: 1,
+          priorityFeesByPercentile: {},
+        },
+        {
+          number: new BN(3),
+          baseFeePerGas: new BN(200_000_000_000),
+          gasUsedRatio: 1,
+          priorityFeesByPercentile: {},
+        },
+      ]);
 
     const gasFeeEstimates = await fetchGasEstimatesViaEthFeeHistory(ethQuery);
 
@@ -50,21 +82,22 @@ describe('fetchGasEstimatesViaEthFeeHistory', () => {
         minWaitTimeEstimate: 15_000,
         maxWaitTimeEstimate: 30_000,
         suggestedMaxPriorityFeePerGas: '1',
-        suggestedMaxFeePerGas: '111',
+        suggestedMaxFeePerGas: '221',
       },
       medium: {
         minWaitTimeEstimate: 15_000,
         maxWaitTimeEstimate: 45_000,
         suggestedMaxPriorityFeePerGas: '1.552',
-        suggestedMaxFeePerGas: '121.552',
+        suggestedMaxFeePerGas: '241.552',
       },
       high: {
         minWaitTimeEstimate: 15_000,
         maxWaitTimeEstimate: 60_000,
         suggestedMaxPriorityFeePerGas: '2.94',
-        suggestedMaxFeePerGas: '127.94',
+        suggestedMaxFeePerGas: '252.94',
       },
-      estimatedBaseFee: '100',
+      estimatedBaseFee: '200',
+      networkCongestion: 0.5,
     });
   });
 });

--- a/src/gas/gas-util.ts
+++ b/src/gas/gas-util.ts
@@ -33,12 +33,11 @@ export async function fetchGasEstimates(
   url: string,
   clientId?: string,
 ): Promise<GasFeeEstimates> {
-  const estimates: GasFeeEstimates = await handleFetch(
+  const estimates = await handleFetch(
     url,
     clientId ? { headers: makeClientIdHeader(clientId) } : undefined,
   );
-  const normalizedEstimates: GasFeeEstimates = {
-    estimatedBaseFee: normalizeGWEIDecimalNumbers(estimates.estimatedBaseFee),
+  return {
     low: {
       ...estimates.low,
       suggestedMaxPriorityFeePerGas: normalizeGWEIDecimalNumbers(
@@ -66,8 +65,9 @@ export async function fetchGasEstimates(
         estimates.high.suggestedMaxFeePerGas,
       ),
     },
+    estimatedBaseFee: normalizeGWEIDecimalNumbers(estimates.estimatedBaseFee),
+    networkCongestion: estimates.networkCongestion,
   };
-  return normalizedEstimates;
 }
 
 /**


### PR DESCRIPTION
[The Metaswap API now includes a `networkCongestion` property when
requesting EIP-1559-compatible gas fee estimates.][1] This value, which is a
number from 0 to 1, where 0 represents "not congested" and 1 represents
"extremely congested", can be used to communicate the status of the
network to users when they are sending transactions.

This commit ensures that GasFeeController includes `networkCongestion`
as part of the state it persists, no matter if using the Metaswap API to
obtain this information or falling back to `eth_feeHistory`.

This is a part of the EIP-1559 v2 work.

[1]: https://gitlab.com/ConsenSys/codefi/products/metaswap/gas-api/-/commit/e5d56eded4a2d23118464a2c6df32c75a3b058e5