### PR TITLE
Add new method `addCollectibleVerifyOwnership`

### DIFF
--- a/src/assets/CollectibleDetectionController.test.ts
+++ b/src/assets/CollectibleDetectionController.test.ts
@@ -53,6 +53,10 @@ describe('CollectibleDetectionController', () => {
       getCollectiblesState: () => collectiblesController.state,
     });
 
+    sandbox
+      .stub(collectiblesController, 'isCollectibleOwner' as any)
+      .returns(true);
+
     nock(OPEN_SEA_HOST)
       .get(`${OPEN_SEA_PATH}/assets?owner=0x2&offset=0&limit=50`)
       .reply(200, {

--- a/src/assets/CollectibleDetectionController.test.ts
+++ b/src/assets/CollectibleDetectionController.test.ts
@@ -53,10 +53,6 @@ describe('CollectibleDetectionController', () => {
       getCollectiblesState: () => collectiblesController.state,
     });
 
-    sandbox
-      .stub(collectiblesController, 'isCollectibleOwner' as any)
-      .returns(true);
-
     nock(OPEN_SEA_HOST)
       .get(`${OPEN_SEA_PATH}/assets?owner=0x2&offset=0&limit=50`)
       .reply(200, {

--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -187,403 +187,491 @@ describe('CollectiblesController', () => {
     });
   });
 
-  it('should add collectible and collectible contract', async () => {
-    await collectiblesController.addCollectible('0x01', '1', {
-      name: 'name',
-      image: 'image',
-      description: 'description',
-      standard: 'standard',
+  describe('addCollectible', () => {
+    it('should add collectible and collectible contract', async () => {
+      await collectiblesController.addCollectible('0x01', '1', {
+        name: 'name',
+        image: 'image',
+        description: 'description',
+        standard: 'standard',
+      });
+
+      expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+        address: '0x01',
+        description: 'description',
+        image: 'image',
+        name: 'name',
+        tokenId: '1',
+        standard: 'standard',
+      });
+
+      expect(
+        collectiblesController.state.collectibleContracts[0],
+      ).toStrictEqual({
+        address: '0x01',
+        description: 'Description',
+        logo: 'url',
+        name: 'Name',
+        symbol: 'FOO',
+        totalSupply: 0,
+      });
     });
 
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
-      address: '0x01',
-      description: 'description',
-      image: 'image',
-      name: 'name',
-      tokenId: '1',
-      standard: 'standard',
+    it('should update collectible if image is different', async () => {
+      await collectiblesController.addCollectible('0x01', '1', {
+        name: 'name',
+        image: 'image',
+        description: 'description',
+        standard: 'standard',
+      });
+
+      expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+        address: '0x01',
+        description: 'description',
+        image: 'image',
+        name: 'name',
+        standard: 'standard',
+        tokenId: '1',
+      });
+
+      await collectiblesController.addCollectible('0x01', '1', {
+        name: 'name',
+        image: 'image-updated',
+        description: 'description',
+        standard: 'standard',
+      });
+
+      expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+        address: '0x01',
+        description: 'description',
+        image: 'image-updated',
+        name: 'name',
+        tokenId: '1',
+        standard: 'standard',
+      });
     });
 
-    expect(collectiblesController.state.collectibleContracts[0]).toStrictEqual({
-      address: '0x01',
-      description: 'Description',
-      logo: 'url',
-      name: 'Name',
-      symbol: 'FOO',
-      totalSupply: 0,
+    it('should not duplicate collectible nor collectible contract if already added', async () => {
+      await collectiblesController.addCollectible('0x01', '1', {
+        name: 'name',
+        image: 'image',
+        description: 'description',
+        standard: 'standard',
+      });
+
+      await collectiblesController.addCollectible('0x01', '1', {
+        name: 'name',
+        image: 'image',
+        description: 'description',
+        standard: 'standard',
+      });
+      expect(collectiblesController.state.collectibles).toHaveLength(1);
+      expect(collectiblesController.state.collectibleContracts).toHaveLength(1);
+    });
+
+    it('should not add collectible contract if collectible contract already exists', async () => {
+      await collectiblesController.addCollectible('0x01', '1', {
+        name: 'name',
+        image: 'image',
+        description: 'description',
+        standard: 'standard',
+      });
+
+      await collectiblesController.addCollectible('0x01', '2', {
+        name: 'name',
+        image: 'image',
+        description: 'description',
+        standard: 'standard',
+      });
+      expect(collectiblesController.state.collectibles).toHaveLength(2);
+      expect(collectiblesController.state.collectibleContracts).toHaveLength(1);
+    });
+
+    it('should add collectible and get information from OpenSea', async () => {
+      await collectiblesController.addCollectible('0x01', '1');
+      expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+        address: '0x01',
+        description: 'Description',
+        imageOriginal: 'url',
+        image: 'url',
+        name: 'Name',
+        standard: 'ERC1155',
+        tokenId: '1',
+        collectionName: 'Collection Name',
+        collectionImage: 'collection.url',
+      });
+    });
+
+    it('should add collectible erc1155 and get collectible contract information from contract', async () => {
+      assetsContract.configure({ provider: MAINNET_PROVIDER });
+      await collectiblesController.addCollectible(
+        ERC1155_COLLECTIBLE_ADDRESS,
+        ERC1155_COLLECTIBLE_ID,
+      );
+
+      expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+        address: ERC1155_COLLECTIBLE_ADDRESS,
+        image: 'image (from contract uri)',
+        name: 'name (from contract uri)',
+        description: 'description',
+        tokenId:
+          '40815311521795738946686668571398122012172359753720345430028676522525371400193',
+        collectionName: 'collection',
+        imageOriginal: 'image.uri',
+        numberOfSales: 1,
+        standard: 'ERC1155',
+      });
+    });
+
+    it('should add collectible erc721 and get collectible contract information from contract and OpenSea', async () => {
+      assetsContract.configure({ provider: MAINNET_PROVIDER });
+
+      sandbox
+        .stub(
+          collectiblesController,
+          'getCollectibleContractInformationFromApi' as any,
+        )
+        .returns(undefined);
+
+      await collectiblesController.addCollectible(ERC721_KUDOSADDRESS, '1203');
+      expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+        address: ERC721_KUDOSADDRESS,
+        image: 'Kudos Image (from uri)',
+        name: 'Kudos Name (from uri)',
+        description: 'Kudos Description (from uri)',
+        tokenId: '1203',
+        collectionImage: 'collection.url',
+        collectionName: 'Collection Name',
+        imageOriginal: 'Kudos url',
+        standard: 'ERC721',
+      });
+
+      expect(
+        collectiblesController.state.collectibleContracts[0],
+      ).toStrictEqual({
+        address: ERC721_KUDOSADDRESS,
+        name: 'KudosToken',
+        symbol: 'KDO',
+      });
+    });
+
+    it('should add collectible erc721 and get collectible contract information only from contract', async () => {
+      assetsContract.configure({ provider: MAINNET_PROVIDER });
+
+      sandbox
+        .stub(
+          collectiblesController,
+          'getCollectibleContractInformationFromApi' as any,
+        )
+        .returns(undefined);
+
+      sandbox
+        .stub(collectiblesController, 'getCollectibleInformationFromApi' as any)
+        .returns(undefined);
+      await collectiblesController.addCollectible(ERC721_KUDOSADDRESS, '1203');
+      expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+        address: ERC721_KUDOSADDRESS,
+        image: 'Kudos Image (from uri)',
+        name: 'Kudos Name (from uri)',
+        description: 'Kudos Description (from uri)',
+        tokenId: '1203',
+        standard: 'ERC721',
+      });
+
+      expect(
+        collectiblesController.state.collectibleContracts[0],
+      ).toStrictEqual({
+        address: ERC721_KUDOSADDRESS,
+        name: 'KudosToken',
+        symbol: 'KDO',
+      });
+    });
+
+    it('should add collectible by provider type', async () => {
+      const firstNetworkType = 'rinkeby';
+      const secondNetworkType = 'ropsten';
+      sandbox
+        .stub(collectiblesController, 'getCollectibleInformation' as any)
+        .returns({ name: 'name', image: 'url', description: 'description' });
+
+      network.update({
+        provider: {
+          type: firstNetworkType,
+          chainId: NetworksChainId[firstNetworkType],
+        },
+      });
+      await collectiblesController.addCollectible('0x01', '1234');
+      network.update({
+        provider: {
+          type: secondNetworkType,
+          chainId: NetworksChainId[secondNetworkType],
+        },
+      });
+      expect(collectiblesController.state.collectibles).toHaveLength(0);
+      network.update({
+        provider: {
+          type: firstNetworkType,
+          chainId: NetworksChainId[firstNetworkType],
+        },
+      });
+
+      expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+        address: '0x01',
+        description: 'description',
+        image: 'url',
+        name: 'name',
+        tokenId: '1234',
+      });
+    });
+
+    it('should not add collectibles with no contract information when auto detecting', async () => {
+      await collectiblesController.addCollectible(
+        '0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab',
+        '123',
+        undefined,
+        true,
+      );
+      expect(collectiblesController.state.collectibles).toStrictEqual([]);
+      expect(collectiblesController.state.collectibleContracts).toStrictEqual(
+        [],
+      );
+
+      await collectiblesController.addCollectible(
+        ERC721_KUDOSADDRESS,
+        '1203',
+        undefined,
+        true,
+      );
+
+      expect(collectiblesController.state.collectibles).toStrictEqual([
+        {
+          address: ERC721_KUDOSADDRESS,
+          description: 'Kudos Description',
+          imageOriginal: 'Kudos url',
+          name: 'Kudos Name',
+          image: null,
+          standard: 'ERC721',
+          tokenId: '1203',
+          collectionImage: 'collection.url',
+          collectionName: 'Collection Name',
+        },
+      ]);
+
+      expect(collectiblesController.state.collectibleContracts).toStrictEqual([
+        {
+          address: ERC721_KUDOSADDRESS,
+          description: 'Kudos Description',
+          logo: 'Kudos url',
+          name: 'Kudos',
+          symbol: 'KDO',
+          totalSupply: 10,
+        },
+      ]);
+    });
+
+    it('should not add duplicate collectibles to the ignoredCollectibles list', async () => {
+      await collectiblesController.addCollectible('0x01', '1', {
+        name: 'name',
+        image: 'image',
+        description: 'description',
+        standard: 'standard',
+      });
+
+      await collectiblesController.addCollectible('0x01', '2', {
+        name: 'name',
+        image: 'image',
+        description: 'description',
+        standard: 'standard',
+      });
+
+      expect(collectiblesController.state.collectibles).toHaveLength(2);
+      expect(collectiblesController.state.ignoredCollectibles).toHaveLength(0);
+
+      collectiblesController.removeAndIgnoreCollectible('0x01', '1');
+      expect(collectiblesController.state.collectibles).toHaveLength(1);
+      expect(collectiblesController.state.ignoredCollectibles).toHaveLength(1);
+
+      await collectiblesController.addCollectible('0x01', '1', {
+        name: 'name',
+        image: 'image',
+        description: 'description',
+        standard: 'standard',
+      });
+      expect(collectiblesController.state.collectibles).toHaveLength(2);
+      expect(collectiblesController.state.ignoredCollectibles).toHaveLength(1);
+
+      collectiblesController.removeAndIgnoreCollectible('0x01', '1');
+      expect(collectiblesController.state.collectibles).toHaveLength(1);
+      expect(collectiblesController.state.ignoredCollectibles).toHaveLength(1);
+    });
+
+    it('should add collectible with metadata hosted in IPFS', async () => {
+      assetsContract.configure({ provider: MAINNET_PROVIDER });
+      await collectiblesController.addCollectible(
+        ERC1155_DEPRESSIONIST_ADDRESS,
+        ERC1155_DEPRESSIONIST_ID,
+      );
+
+      expect(
+        collectiblesController.state.collectibleContracts[0],
+      ).toStrictEqual({
+        address: '0x18E8E76aeB9E2d9FA2A2b88DD9CF3C8ED45c3660',
+        name: "Maltjik.jpg's Depressionists",
+        symbol: 'DPNS',
+      });
+
+      expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+        address: '0x18E8E76aeB9E2d9FA2A2b88DD9CF3C8ED45c3660',
+        tokenId: '36',
+        image: 'image',
+        name: 'name',
+        description: 'description',
+        standard: 'ERC721',
+      });
     });
   });
 
-  it('should update collectible if image is different', async () => {
-    await collectiblesController.addCollectible('0x01', '1', {
-      name: 'name',
-      image: 'image',
-      description: 'description',
-      standard: 'standard',
-    });
-
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
-      address: '0x01',
-      description: 'description',
-      image: 'image',
-      name: 'name',
-      standard: 'standard',
-      tokenId: '1',
-    });
-
-    await collectiblesController.addCollectible('0x01', '1', {
-      name: 'name',
-      image: 'image-updated',
-      description: 'description',
-      standard: 'standard',
-    });
-
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
-      address: '0x01',
-      description: 'description',
-      image: 'image-updated',
-      name: 'name',
-      tokenId: '1',
-      standard: 'standard',
-    });
-  });
-
-  it('should not duplicate collectible nor collectible contract if already added', async () => {
-    await collectiblesController.addCollectible('0x01', '1', {
-      name: 'name',
-      image: 'image',
-      description: 'description',
-      standard: 'standard',
-    });
-
-    await collectiblesController.addCollectible('0x01', '1', {
-      name: 'name',
-      image: 'image',
-      description: 'description',
-      standard: 'standard',
-    });
-    expect(collectiblesController.state.collectibles).toHaveLength(1);
-    expect(collectiblesController.state.collectibleContracts).toHaveLength(1);
-  });
-
-  it('should not add collectible contract if collectible contract already exists', async () => {
-    await collectiblesController.addCollectible('0x01', '1', {
-      name: 'name',
-      image: 'image',
-      description: 'description',
-      standard: 'standard',
-    });
-
-    await collectiblesController.addCollectible('0x01', '2', {
-      name: 'name',
-      image: 'image',
-      description: 'description',
-      standard: 'standard',
-    });
-    expect(collectiblesController.state.collectibles).toHaveLength(2);
-    expect(collectiblesController.state.collectibleContracts).toHaveLength(1);
-  });
-
-  it('should add collectible and get information from OpenSea', async () => {
-    await collectiblesController.addCollectible('0x01', '1');
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
-      address: '0x01',
-      description: 'Description',
-      imageOriginal: 'url',
-      image: 'url',
-      name: 'Name',
-      standard: 'ERC1155',
-      tokenId: '1',
-      collectionName: 'Collection Name',
-      collectionImage: 'collection.url',
-    });
-  });
-
-  it('should add collectible erc1155 and get collectible contract information from contract', async () => {
-    assetsContract.configure({ provider: MAINNET_PROVIDER });
-    await collectiblesController.addCollectible(
-      ERC1155_COLLECTIBLE_ADDRESS,
-      ERC1155_COLLECTIBLE_ID,
-    );
-
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
-      address: ERC1155_COLLECTIBLE_ADDRESS,
-      image: 'image (from contract uri)',
-      name: 'name (from contract uri)',
-      description: 'description',
-      tokenId:
-        '40815311521795738946686668571398122012172359753720345430028676522525371400193',
-      collectionName: 'collection',
-      imageOriginal: 'image.uri',
-      numberOfSales: 1,
-      standard: 'ERC1155',
-    });
-  });
-
-  it('should add collectible erc721 and get collectible contract information from contract and OpenSea', async () => {
-    assetsContract.configure({ provider: MAINNET_PROVIDER });
-
-    sandbox
-      .stub(
-        collectiblesController,
-        'getCollectibleContractInformationFromApi' as any,
-      )
-      .returns(undefined);
-
-    await collectiblesController.addCollectible(ERC721_KUDOSADDRESS, '1203');
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
-      address: ERC721_KUDOSADDRESS,
-      image: 'Kudos Image (from uri)',
-      name: 'Kudos Name (from uri)',
-      description: 'Kudos Description (from uri)',
-      tokenId: '1203',
-      collectionImage: 'collection.url',
-      collectionName: 'Collection Name',
-      imageOriginal: 'Kudos url',
-      standard: 'ERC721',
-    });
-
-    expect(collectiblesController.state.collectibleContracts[0]).toStrictEqual({
-      address: ERC721_KUDOSADDRESS,
-      name: 'KudosToken',
-      symbol: 'KDO',
-    });
-  });
-
-  it('should add collectible erc721 and get collectible contract information only from contract', async () => {
-    assetsContract.configure({ provider: MAINNET_PROVIDER });
-
-    sandbox
-      .stub(
-        collectiblesController,
-        'getCollectibleContractInformationFromApi' as any,
-      )
-      .returns(undefined);
-
-    sandbox
-      .stub(collectiblesController, 'getCollectibleInformationFromApi' as any)
-      .returns(undefined);
-    await collectiblesController.addCollectible(ERC721_KUDOSADDRESS, '1203');
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
-      address: ERC721_KUDOSADDRESS,
-      image: 'Kudos Image (from uri)',
-      name: 'Kudos Name (from uri)',
-      description: 'Kudos Description (from uri)',
-      tokenId: '1203',
-      standard: 'ERC721',
-    });
-
-    expect(collectiblesController.state.collectibleContracts[0]).toStrictEqual({
-      address: ERC721_KUDOSADDRESS,
-      name: 'KudosToken',
-      symbol: 'KDO',
-    });
-  });
-
-  it('should add collectible by selected address', async () => {
-    const firstAddress = '0x123';
-    const secondAddress = '0x321';
-    sandbox
-      .stub(collectiblesController, 'getCollectibleInformation' as any)
-      .returns({ name: 'name', image: 'url', description: 'description' });
-    preferences.update({ selectedAddress: firstAddress });
-    await collectiblesController.addCollectibleVerifyOwnership('0x01', '1234');
-    preferences.update({ selectedAddress: secondAddress });
-    await collectiblesController.addCollectibleVerifyOwnership('0x02', '4321');
-    preferences.update({ selectedAddress: firstAddress });
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
-      address: '0x01',
-      description: 'description',
-      image: 'url',
-      name: 'name',
-      tokenId: '1234',
-    });
-  });
-
-  it('should throw an error if selected address is not owner of input collectible', async () => {
-    sandbox.restore();
-    sandbox
-      .stub(collectiblesController, 'isCollectibleOwner' as any)
-      .returns(false);
-    const firstAddress = '0x123';
-    preferences.update({ selectedAddress: firstAddress });
-    const result = async () =>
+  describe('addCollectibleVerifyOwnership', () => {
+    it('should add collectible by selected address', async () => {
+      const firstAddress = '0x123';
+      const secondAddress = '0x321';
+      sandbox
+        .stub(collectiblesController, 'getCollectibleInformation' as any)
+        .returns({ name: 'name', image: 'url', description: 'description' });
+      preferences.update({ selectedAddress: firstAddress });
       await collectiblesController.addCollectibleVerifyOwnership(
         '0x01',
         '1234',
       );
-    const error = 'This collectible is not owned by the user';
-    expect(result).rejects.toThrow(error);
-  });
-
-  it('should add collectible by provider type', async () => {
-    const firstNetworkType = 'rinkeby';
-    const secondNetworkType = 'ropsten';
-    sandbox
-      .stub(collectiblesController, 'getCollectibleInformation' as any)
-      .returns({ name: 'name', image: 'url', description: 'description' });
-
-    network.update({
-      provider: {
-        type: firstNetworkType,
-        chainId: NetworksChainId[firstNetworkType],
-      },
-    });
-    await collectiblesController.addCollectible('0x01', '1234');
-    network.update({
-      provider: {
-        type: secondNetworkType,
-        chainId: NetworksChainId[secondNetworkType],
-      },
-    });
-    expect(collectiblesController.state.collectibles).toHaveLength(0);
-    network.update({
-      provider: {
-        type: firstNetworkType,
-        chainId: NetworksChainId[firstNetworkType],
-      },
+      preferences.update({ selectedAddress: secondAddress });
+      await collectiblesController.addCollectibleVerifyOwnership(
+        '0x02',
+        '4321',
+      );
+      preferences.update({ selectedAddress: firstAddress });
+      expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+        address: '0x01',
+        description: 'description',
+        image: 'url',
+        name: 'name',
+        tokenId: '1234',
+      });
     });
 
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
-      address: '0x01',
-      description: 'description',
-      image: 'url',
-      name: 'name',
-      tokenId: '1234',
+    it('should throw an error if selected address is not owner of input collectible', async () => {
+      sandbox.restore();
+      sandbox
+        .stub(collectiblesController, 'isCollectibleOwner' as any)
+        .returns(false);
+      const firstAddress = '0x123';
+      preferences.update({ selectedAddress: firstAddress });
+      const result = async () =>
+        await collectiblesController.addCollectibleVerifyOwnership(
+          '0x01',
+          '1234',
+        );
+      const error = 'This collectible is not owned by the user';
+      await expect(result).rejects.toThrow(error);
     });
   });
 
-  it('should not add collectibles with no contract information when auto detecting', async () => {
-    await collectiblesController.addCollectible(
-      '0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab',
-      '123',
-      undefined,
-      true,
-    );
-    expect(collectiblesController.state.collectibles).toStrictEqual([]);
-    expect(collectiblesController.state.collectibleContracts).toStrictEqual([]);
-    await collectiblesController.addCollectible(
-      ERC721_KUDOSADDRESS,
-      '1203',
-      undefined,
-      true,
-    );
-
-    expect(collectiblesController.state.collectibles).toStrictEqual([
-      {
-        address: ERC721_KUDOSADDRESS,
-        description: 'Kudos Description',
-        imageOriginal: 'Kudos url',
-        name: 'Kudos Name',
-        image: null,
-        standard: 'ERC721',
-        tokenId: '1203',
-        collectionImage: 'collection.url',
-        collectionName: 'Collection Name',
-      },
-    ]);
-
-    expect(collectiblesController.state.collectibleContracts).toStrictEqual([
-      {
-        address: ERC721_KUDOSADDRESS,
-        description: 'Kudos Description',
-        logo: 'Kudos url',
-        name: 'Kudos',
-        symbol: 'KDO',
-        totalSupply: 10,
-      },
-    ]);
-  });
-
-  it('should remove collectible and collectible contract', async () => {
-    await collectiblesController.addCollectible('0x01', '1', {
-      name: 'name',
-      image: 'image',
-      description: 'description',
-      standard: 'standard',
-    });
-    collectiblesController.removeCollectible('0x01', '1');
-    expect(collectiblesController.state.collectibles).toHaveLength(0);
-    expect(collectiblesController.state.collectibleContracts).toHaveLength(0);
-  });
-
-  it('should not remove collectible contract if collectible still exists', async () => {
-    await collectiblesController.addCollectible('0x01', '1', {
-      name: 'name',
-      image: 'image',
-      description: 'description',
-      standard: 'standard',
+  describe('RemoveCollectible', () => {
+    it('should remove collectible and collectible contract', async () => {
+      await collectiblesController.addCollectible('0x01', '1', {
+        name: 'name',
+        image: 'image',
+        description: 'description',
+        standard: 'standard',
+      });
+      collectiblesController.removeCollectible('0x01', '1');
+      expect(collectiblesController.state.collectibles).toHaveLength(0);
+      expect(collectiblesController.state.collectibleContracts).toHaveLength(0);
     });
 
-    await collectiblesController.addCollectible('0x01', '2', {
-      name: 'name',
-      image: 'image',
-      description: 'description',
-      standard: 'standard',
-    });
-    collectiblesController.removeCollectible('0x01', '1');
-    expect(collectiblesController.state.collectibles).toHaveLength(1);
-    expect(collectiblesController.state.collectibleContracts).toHaveLength(1);
-  });
+    it('should not remove collectible contract if collectible still exists', async () => {
+      await collectiblesController.addCollectible('0x01', '1', {
+        name: 'name',
+        image: 'image',
+        description: 'description',
+        standard: 'standard',
+      });
 
-  it('should remove collectible by selected address', async () => {
-    sandbox
-      .stub(collectiblesController, 'getCollectibleInformation' as any)
-      .returns({ name: 'name', image: 'url', description: 'description' });
-    const firstAddress = '0x123';
-    const secondAddress = '0x321';
-    preferences.update({ selectedAddress: firstAddress });
-    await collectiblesController.addCollectibleVerifyOwnership('0x02', '4321');
-    preferences.update({ selectedAddress: secondAddress });
-    await collectiblesController.addCollectibleVerifyOwnership('0x01', '1234');
-    collectiblesController.removeCollectible('0x01', '1234');
-    expect(collectiblesController.state.collectibles).toHaveLength(0);
-    preferences.update({ selectedAddress: firstAddress });
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
-      address: '0x02',
-      description: 'description',
-      image: 'url',
-      name: 'name',
-      tokenId: '4321',
-    });
-  });
-
-  it('should remove collectible by provider type', async () => {
-    sandbox
-      .stub(collectiblesController, 'getCollectibleInformation' as any)
-      .returns({ name: 'name', image: 'url', description: 'description' });
-    const firstNetworkType = 'rinkeby';
-    const secondNetworkType = 'ropsten';
-    network.update({
-      provider: {
-        type: firstNetworkType,
-        chainId: NetworksChainId[firstNetworkType],
-      },
-    });
-    await collectiblesController.addCollectible('0x02', '4321');
-    network.update({
-      provider: {
-        type: secondNetworkType,
-        chainId: NetworksChainId[secondNetworkType],
-      },
-    });
-    await collectiblesController.addCollectible('0x01', '1234');
-    // collectiblesController.removeToken('0x01');
-    collectiblesController.removeCollectible('0x01', '1234');
-    expect(collectiblesController.state.collectibles).toHaveLength(0);
-    network.update({
-      provider: {
-        type: firstNetworkType,
-        chainId: NetworksChainId[firstNetworkType],
-      },
+      await collectiblesController.addCollectible('0x01', '2', {
+        name: 'name',
+        image: 'image',
+        description: 'description',
+        standard: 'standard',
+      });
+      collectiblesController.removeCollectible('0x01', '1');
+      expect(collectiblesController.state.collectibles).toHaveLength(1);
+      expect(collectiblesController.state.collectibleContracts).toHaveLength(1);
     });
 
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
-      address: '0x02',
-      description: 'description',
-      image: 'url',
-      name: 'name',
-      tokenId: '4321',
+    it('should remove collectible by selected address', async () => {
+      sandbox
+        .stub(collectiblesController, 'getCollectibleInformation' as any)
+        .returns({ name: 'name', image: 'url', description: 'description' });
+      const firstAddress = '0x123';
+      const secondAddress = '0x321';
+      preferences.update({ selectedAddress: firstAddress });
+      await collectiblesController.addCollectibleVerifyOwnership(
+        '0x02',
+        '4321',
+      );
+      preferences.update({ selectedAddress: secondAddress });
+      await collectiblesController.addCollectibleVerifyOwnership(
+        '0x01',
+        '1234',
+      );
+      collectiblesController.removeCollectible('0x01', '1234');
+      expect(collectiblesController.state.collectibles).toHaveLength(0);
+      preferences.update({ selectedAddress: firstAddress });
+      expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+        address: '0x02',
+        description: 'description',
+        image: 'url',
+        name: 'name',
+        tokenId: '4321',
+      });
+    });
+
+    it('should remove collectible by provider type', async () => {
+      sandbox
+        .stub(collectiblesController, 'getCollectibleInformation' as any)
+        .returns({ name: 'name', image: 'url', description: 'description' });
+      const firstNetworkType = 'rinkeby';
+      const secondNetworkType = 'ropsten';
+      network.update({
+        provider: {
+          type: firstNetworkType,
+          chainId: NetworksChainId[firstNetworkType],
+        },
+      });
+      await collectiblesController.addCollectible('0x02', '4321');
+      network.update({
+        provider: {
+          type: secondNetworkType,
+          chainId: NetworksChainId[secondNetworkType],
+        },
+      });
+      await collectiblesController.addCollectible('0x01', '1234');
+      // collectiblesController.removeToken('0x01');
+      collectiblesController.removeCollectible('0x01', '1234');
+      expect(collectiblesController.state.collectibles).toHaveLength(0);
+      network.update({
+        provider: {
+          type: firstNetworkType,
+          chainId: NetworksChainId[firstNetworkType],
+        },
+      });
+
+      expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+        address: '0x02',
+        description: 'description',
+        image: 'url',
+        name: 'name',
+        tokenId: '4321',
+      });
     });
   });
 
@@ -596,42 +684,6 @@ describe('CollectiblesController', () => {
       provider: { type: networkType, chainId: NetworksChainId[networkType] },
     });
     expect(network.state.provider.type).toStrictEqual(networkType);
-  });
-
-  it('should not add duplicate collectibles to the ignoredCollectibles list', async () => {
-    await collectiblesController.addCollectible('0x01', '1', {
-      name: 'name',
-      image: 'image',
-      description: 'description',
-      standard: 'standard',
-    });
-
-    await collectiblesController.addCollectible('0x01', '2', {
-      name: 'name',
-      image: 'image',
-      description: 'description',
-      standard: 'standard',
-    });
-
-    expect(collectiblesController.state.collectibles).toHaveLength(2);
-    expect(collectiblesController.state.ignoredCollectibles).toHaveLength(0);
-
-    collectiblesController.removeAndIgnoreCollectible('0x01', '1');
-    expect(collectiblesController.state.collectibles).toHaveLength(1);
-    expect(collectiblesController.state.ignoredCollectibles).toHaveLength(1);
-
-    await collectiblesController.addCollectible('0x01', '1', {
-      name: 'name',
-      image: 'image',
-      description: 'description',
-      standard: 'standard',
-    });
-    expect(collectiblesController.state.collectibles).toHaveLength(2);
-    expect(collectiblesController.state.ignoredCollectibles).toHaveLength(1);
-
-    collectiblesController.removeAndIgnoreCollectible('0x01', '1');
-    expect(collectiblesController.state.collectibles).toHaveLength(1);
-    expect(collectiblesController.state.ignoredCollectibles).toHaveLength(1);
   });
 
   it('should be able to clear the ignoredCollectibles list', async () => {
@@ -658,83 +710,62 @@ describe('CollectiblesController', () => {
     expect(collectiblesController.openSeaApiKey).toBe('new-api-key');
   });
 
-  it('should verify the ownership of an ERC-721 collectible with the correct owner address', async () => {
-    assetsContract.configure({ provider: MAINNET_PROVIDER });
-    const isOwner = await collectiblesController.isCollectibleOwner(
-      OWNER_ADDRESS,
-      ERC721_COLLECTIBLE_ADDRESS,
-      String(ERC721_COLLECTIBLE_ID),
-    );
-    expect(isOwner).toBe(true);
-  });
-
-  it('should not verify the ownership of an ERC-721 collectible with the wrong owner address', async () => {
-    sandbox.restore();
-    assetsContract.configure({ provider: MAINNET_PROVIDER });
-    const isOwner = await collectiblesController.isCollectibleOwner(
-      '0x0000000000000000000000000000000000000000',
-      ERC721_COLLECTIBLE_ADDRESS,
-      String(ERC721_COLLECTIBLE_ID),
-    );
-    expect(isOwner).toBe(false);
-  });
-
-  it('should verify the ownership of an ERC-1155 collectible with the correct owner address', async () => {
-    assetsContract.configure({ provider: MAINNET_PROVIDER });
-    const isOwner = await collectiblesController.isCollectibleOwner(
-      OWNER_ADDRESS,
-      ERC1155_COLLECTIBLE_ADDRESS,
-      ERC1155_COLLECTIBLE_ID,
-    );
-    expect(isOwner).toBe(true);
-  });
-
-  it('should not verify the ownership of an ERC-1155 collectible with the wrong owner address', async () => {
-    sandbox.restore();
-    assetsContract.configure({ provider: MAINNET_PROVIDER });
-    const isOwner = await collectiblesController.isCollectibleOwner(
-      '0x0000000000000000000000000000000000000000',
-      ERC1155_COLLECTIBLE_ADDRESS,
-      ERC1155_COLLECTIBLE_ID,
-    );
-    expect(isOwner).toBe(false);
-  });
-
-  it('should throw an error for an unsupported standard', async () => {
-    sandbox.restore();
-    assetsContract.configure({ provider: MAINNET_PROVIDER });
-    const error =
-      'Unable to verify ownership. Probably because the standard is not supported or the chain is incorrect';
-    const result = async () => {
-      await collectiblesController.isCollectibleOwner(
-        '0x0000000000000000000000000000000000000000',
-        CRYPTOPUNK_ADDRESS,
-        '0',
+  describe('isCollectibleOwner', () => {
+    it('should verify the ownership of an ERC-721 collectible with the correct owner address', async () => {
+      assetsContract.configure({ provider: MAINNET_PROVIDER });
+      const isOwner = await collectiblesController.isCollectibleOwner(
+        OWNER_ADDRESS,
+        ERC721_COLLECTIBLE_ADDRESS,
+        String(ERC721_COLLECTIBLE_ID),
       );
-    };
-    await expect(result).rejects.toThrow(error);
-  });
-
-  it('should add collectible with metadata hosted in IPFS', async () => {
-    assetsContract.configure({ provider: MAINNET_PROVIDER });
-    await collectiblesController.addCollectible(
-      ERC1155_DEPRESSIONIST_ADDRESS,
-      ERC1155_DEPRESSIONIST_ID,
-    );
-
-    expect(collectiblesController.state.collectibleContracts[0]).toStrictEqual({
-      address: '0x18E8E76aeB9E2d9FA2A2b88DD9CF3C8ED45c3660',
-      name: "Maltjik.jpg's Depressionists",
-      symbol: 'DPNS',
+      expect(isOwner).toBe(true);
     });
 
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
-      address: '0x18E8E76aeB9E2d9FA2A2b88DD9CF3C8ED45c3660',
-      tokenId: '36',
-      image: 'image',
-      name: 'name',
-      description: 'description',
-      standard: 'ERC721',
+    it('should not verify the ownership of an ERC-721 collectible with the wrong owner address', async () => {
+      sandbox.restore();
+      assetsContract.configure({ provider: MAINNET_PROVIDER });
+      const isOwner = await collectiblesController.isCollectibleOwner(
+        '0x0000000000000000000000000000000000000000',
+        ERC721_COLLECTIBLE_ADDRESS,
+        String(ERC721_COLLECTIBLE_ID),
+      );
+      expect(isOwner).toBe(false);
+    });
+
+    it('should verify the ownership of an ERC-1155 collectible with the correct owner address', async () => {
+      assetsContract.configure({ provider: MAINNET_PROVIDER });
+      const isOwner = await collectiblesController.isCollectibleOwner(
+        OWNER_ADDRESS,
+        ERC1155_COLLECTIBLE_ADDRESS,
+        ERC1155_COLLECTIBLE_ID,
+      );
+      expect(isOwner).toBe(true);
+    });
+
+    it('should not verify the ownership of an ERC-1155 collectible with the wrong owner address', async () => {
+      sandbox.restore();
+      assetsContract.configure({ provider: MAINNET_PROVIDER });
+      const isOwner = await collectiblesController.isCollectibleOwner(
+        '0x0000000000000000000000000000000000000000',
+        ERC1155_COLLECTIBLE_ADDRESS,
+        ERC1155_COLLECTIBLE_ID,
+      );
+      expect(isOwner).toBe(false);
+    });
+
+    it('should throw an error for an unsupported standard', async () => {
+      sandbox.restore();
+      assetsContract.configure({ provider: MAINNET_PROVIDER });
+      const error =
+        'Unable to verify ownership. Probably because the standard is not supported or the chain is incorrect';
+      const result = async () => {
+        await collectiblesController.isCollectibleOwner(
+          '0x0000000000000000000000000000000000000000',
+          CRYPTOPUNK_ADDRESS,
+          '0',
+        );
+      };
+      await expect(result).rejects.toThrow(error);
     });
   });
 });

--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -217,6 +217,26 @@ describe('CollectiblesController', () => {
       });
     });
 
+    it('should add collectible by selected address', async () => {
+      const firstAddress = '0x123';
+      const secondAddress = '0x321';
+      sandbox
+        .stub(collectiblesController, 'getCollectibleInformation' as any)
+        .returns({ name: 'name', image: 'url', description: 'description' });
+      preferences.update({ selectedAddress: firstAddress });
+      await collectiblesController.addCollectible('0x01', '1234');
+      preferences.update({ selectedAddress: secondAddress });
+      await collectiblesController.addCollectible('0x02', '4321');
+      preferences.update({ selectedAddress: firstAddress });
+      expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+        address: '0x01',
+        description: 'description',
+        image: 'url',
+        name: 'name',
+        tokenId: '1234',
+      });
+    });
+
     it('should update collectible if image is different', async () => {
       await collectiblesController.addCollectible('0x01', '1', {
         name: 'name',
@@ -532,7 +552,7 @@ describe('CollectiblesController', () => {
   });
 
   describe('addCollectibleVerifyOwnership', () => {
-    it('should add collectible by selected address', async () => {
+    it('should verify ownership by selected address and add collectible', async () => {
       const firstAddress = '0x123';
       const secondAddress = '0x321';
       sandbox

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -881,6 +881,21 @@ export class CollectiblesController extends BaseController<
   }
 
   /**
+   * Verifies currently selected address owns entered collectible address/tokenId combo and
+   * adds the collectible and respective collectible contract to the stored collectible and collectible contracts lists.
+   *
+   * @param address - Hex address of the collectible contract.
+   * @param tokenId - The collectible identifier.
+   */
+  async addCollectibleVerifyOwnership(address: string, tokenId: string) {
+    const { selectedAddress } = this.config;
+    if (!(await this.isCollectibleOwner(selectedAddress, address, tokenId))) {
+      throw new Error('This collectible is not owned by the user');
+    }
+    await this.addCollectible(address, tokenId);
+  }
+
+  /**
    * Adds a collectible and respective collectible contract to the stored collectible and collectible contracts lists.
    *
    * @param address - Hex address of the collectible contract.


### PR DESCRIPTION
It seemed to not make much sense to make a call to the CollectiblesController in the background to validate ownership, immediately before calling the same controller to add that collectible. This PR adds a new method `addCollectibleVerifyOwnership` which wraps the addCollectible method together with the validation step.
