### PR TITLE
Add detection params (userAddress, chainId) and remove duplicate source of truth

### DIFF
--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -137,8 +137,6 @@ describe('ComposableController', () => {
         CollectiblesController: {
           allCollectibleContracts: {},
           allCollectibles: {},
-          collectibleContracts: [],
-          collectibles: [],
           ignoredCollectibles: [],
         },
         TokensController: {
@@ -217,8 +215,6 @@ describe('ComposableController', () => {
         allCollectibleContracts: {},
         allCollectibles: {},
         allTokens: {},
-        collectibleContracts: [],
-        collectibles: [],
         ensEntries: {},
         featureFlags: {},
         frequentRpcList: [],

--- a/src/assets/CollectibleDetectionController.test.ts
+++ b/src/assets/CollectibleDetectionController.test.ts
@@ -381,7 +381,7 @@ describe('CollectibleDetectionController', () => {
     const { chainId } = collectibleDetection.config;
     await collectibleDetection.detectCollectibles();
     const { allCollectibles } = collectiblesController.state;
-    expect(allCollectibles[selectedAddress]?.[chainId] || []).toStrictEqual([]);
+    expect(allCollectibles[selectedAddress]?.[chainId]).toBeUndefined();
   });
 
   it('should not detect and add collectibles to the wrong selectedAddress', async () => {
@@ -401,8 +401,8 @@ describe('CollectibleDetectionController', () => {
     expect(
       collectiblesController.state.allCollectibles[
         collectibleDetection.config.selectedAddress
-      ]?.[chainId] || [],
-    ).toStrictEqual([]);
+      ]?.[chainId],
+    ).toBeUndefined();
   });
 
   it('should not detect and add collectibles if preferences controller useCollectibleDetection is set to false', async () => {
@@ -415,10 +415,8 @@ describe('CollectibleDetectionController', () => {
     const { chainId } = collectiblesController.config;
     collectibleDetection.detectCollectibles();
     expect(
-      collectiblesController.state.allCollectibles[selectedAddress]?.[
-        chainId
-      ] || [],
-    ).toStrictEqual([]);
+      collectiblesController.state.allCollectibles[selectedAddress]?.[chainId],
+    ).toBeUndefined();
   });
 
   it('should not add collectible if collectible or collectible contract has no information to display', async () => {
@@ -486,15 +484,13 @@ describe('CollectibleDetectionController', () => {
     await collectibleDetection.detectCollectibles();
     // First fetch to API, only gets information from contract ending in HH
     expect(
-      collectiblesController.state.allCollectibles[selectedAddress]?.[
-        chainId
-      ] || [],
+      collectiblesController.state.allCollectibles[selectedAddress][chainId],
     ).toStrictEqual([collectibleHH2574]);
 
     expect(
-      collectiblesController.state.allCollectibleContracts[selectedAddress]?.[
+      collectiblesController.state.allCollectibleContracts[selectedAddress][
         chainId
-      ] || [],
+      ],
     ).toStrictEqual([collectibleContractHH]);
     // During next call of assets detection, API succeds returning contract ending in gg information
 
@@ -574,9 +570,9 @@ describe('CollectibleDetectionController', () => {
     // Now user should have respective collectibles
     await collectibleDetection.detectCollectibles();
     expect(
-      collectiblesController.state.allCollectibleContracts[selectedAddress]?.[
+      collectiblesController.state.allCollectibleContracts[selectedAddress][
         chainId
-      ] || [],
+      ],
     ).toStrictEqual([
       collectibleContractHH,
       collectibleContractII,
@@ -584,9 +580,7 @@ describe('CollectibleDetectionController', () => {
     ]);
 
     expect(
-      collectiblesController.state.allCollectibles[selectedAddress]?.[
-        chainId
-      ] || [],
+      collectiblesController.state.allCollectibles[selectedAddress][chainId],
     ).toStrictEqual([collectibleHH2574, collectibleII2577, collectibleGG2574]);
   });
 });

--- a/src/assets/CollectibleDetectionController.test.ts
+++ b/src/assets/CollectibleDetectionController.test.ts
@@ -194,6 +194,7 @@ describe('CollectibleDetectionController', () => {
     expect(collectibleDetection.config).toStrictEqual({
       interval: DEFAULT_INTERVAL,
       networkType: 'mainnet',
+      chainId: '1',
       selectedAddress: '',
     });
   });

--- a/src/assets/CollectibleDetectionController.test.ts
+++ b/src/assets/CollectibleDetectionController.test.ts
@@ -53,6 +53,8 @@ describe('CollectibleDetectionController', () => {
       getCollectiblesState: () => collectiblesController.state,
     });
 
+    collectiblesController.configure({ chainId: '1', selectedAddress: '0x1' });
+
     nock(OPEN_SEA_HOST)
       .get(`${OPEN_SEA_PATH}/assets?owner=0x2&offset=0&limit=50`)
       .reply(200, {
@@ -266,12 +268,19 @@ describe('CollectibleDetectionController', () => {
   });
 
   it('should detect and add collectibles correctly', async () => {
+    const selectedAddress = '0x1';
+
     collectibleDetection.configure({
       networkType: MAINNET,
-      selectedAddress: '0x1',
+      selectedAddress,
     });
+    const { chainId } = collectibleDetection.config;
+
     await collectibleDetection.detectCollectibles();
-    expect(collectiblesController.state.collectibles).toStrictEqual([
+
+    const collectibles =
+      collectiblesController.state.allCollectibles[selectedAddress][chainId];
+    expect(collectibles).toStrictEqual([
       {
         address: '0xebE4e5E773AFD2bAc25De0cFafa084CFb3cBf1eD',
         description: 'Description 2574',
@@ -286,10 +295,12 @@ describe('CollectibleDetectionController', () => {
   });
 
   it('should detect, add collectibles and do nor remove not detected collectibles correctly', async () => {
+    const selectedAddress = '0x1';
     collectibleDetection.configure({
       networkType: MAINNET,
-      selectedAddress: '0x1',
+      selectedAddress,
     });
+    const { chainId } = collectibleDetection.config;
 
     await collectiblesController.addCollectible(
       '0xebE4e5E773AFD2bAc25De0cFafa084CFb3cBf1eD',
@@ -301,8 +312,13 @@ describe('CollectibleDetectionController', () => {
         standard: 'ERC721',
       },
     );
+
     await collectibleDetection.detectCollectibles();
-    expect(collectiblesController.state.collectibles).toStrictEqual([
+
+    const collectibles =
+      collectiblesController.state.allCollectibles[selectedAddress][chainId];
+
+    expect(collectibles).toStrictEqual([
       {
         address: '0xebE4e5E773AFD2bAc25De0cFafa084CFb3cBf1eD',
         description: 'Description 2573',
@@ -325,26 +341,42 @@ describe('CollectibleDetectionController', () => {
   });
 
   it('should not autodetect collectibles that exist in the ignoreList', async () => {
+    const selectedAddress = '0x2';
     collectibleDetection.configure({
       networkType: MAINNET,
       selectedAddress: '0x2',
     });
+    collectiblesController.configure({ selectedAddress });
+
+    const { chainId } = collectibleDetection.config;
+
     await collectibleDetection.detectCollectibles();
-    expect(collectiblesController.state.collectibles).toHaveLength(1);
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][chainId],
+    ).toHaveLength(1);
     expect(collectiblesController.state.ignoredCollectibles).toHaveLength(0);
     collectiblesController.removeAndIgnoreCollectible(
-      '0x1d963688fe2209a98db35c67a041524822cf04ff',
+      '0x1d963688FE2209A98dB35C67A041524822Cf04ff',
       '2577',
     );
-    await collectibleDetection.detectCollectibles();
-    expect(collectiblesController.state.collectibles).toHaveLength(0);
+
     expect(collectiblesController.state.ignoredCollectibles).toHaveLength(1);
+    await collectibleDetection.detectCollectibles();
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][chainId],
+    ).toHaveLength(0);
   });
 
   it('should not detect and add collectibles if there is no selectedAddress', async () => {
-    collectibleDetection.configure({ networkType: MAINNET });
+    const selectedAddress = '';
+    collectibleDetection.configure({
+      networkType: MAINNET,
+      selectedAddress,
+    });
+    const { chainId } = collectibleDetection.config;
     await collectibleDetection.detectCollectibles();
-    expect(collectiblesController.state.collectibles).toStrictEqual([]);
+    const { allCollectibles } = collectiblesController.state;
+    expect(allCollectibles[selectedAddress]?.[chainId] || []).toStrictEqual([]);
   });
 
   it('should not detect and add collectibles to the wrong selectedAddress', async () => {
@@ -352,13 +384,20 @@ describe('CollectibleDetectionController', () => {
       networkType: MAINNET,
       selectedAddress: '0x9',
     });
+    const { chainId } = collectibleDetection.config;
+
     collectiblesController.configure({ selectedAddress: '0x9' });
     collectibleDetection.detectCollectibles();
     collectibleDetection.configure({ selectedAddress: '0x12' });
     collectiblesController.configure({ selectedAddress: '0x12' });
     await new Promise((res) => setTimeout(() => res(true), 1000));
     expect(collectibleDetection.config.selectedAddress).toStrictEqual('0x12');
-    expect(collectiblesController.state.collectibles).toStrictEqual([]);
+
+    expect(
+      collectiblesController.state.allCollectibles[
+        collectibleDetection.config.selectedAddress
+      ]?.[chainId] || [],
+    ).toStrictEqual([]);
   });
 
   it('should not add collectible if collectible or collectible contract has no information to display', async () => {
@@ -416,19 +455,26 @@ describe('CollectibleDetectionController', () => {
       symbol: 'II',
       totalSupply: 10,
     };
+
+    const selectedAddress = '0x1';
     collectibleDetection.configure({
-      selectedAddress: '0x1',
+      selectedAddress,
       networkType: MAINNET,
     });
+    const { chainId } = collectibleDetection.config;
     await collectibleDetection.detectCollectibles();
     // First fetch to API, only gets information from contract ending in HH
-    expect(collectiblesController.state.collectibles).toStrictEqual([
-      collectibleHH2574,
-    ]);
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress]?.[
+        chainId
+      ] || [],
+    ).toStrictEqual([collectibleHH2574]);
 
-    expect(collectiblesController.state.collectibleContracts).toStrictEqual([
-      collectibleContractHH,
-    ]);
+    expect(
+      collectiblesController.state.allCollectibleContracts[selectedAddress]?.[
+        chainId
+      ] || [],
+    ).toStrictEqual([collectibleContractHH]);
     // During next call of assets detection, API succeds returning contract ending in gg information
 
     nock(OPEN_SEA_HOST)
@@ -506,16 +552,20 @@ describe('CollectibleDetectionController', () => {
 
     // Now user should have respective collectibles
     await collectibleDetection.detectCollectibles();
-    expect(collectiblesController.state.collectibleContracts).toStrictEqual([
+    expect(
+      collectiblesController.state.allCollectibleContracts[selectedAddress]?.[
+        chainId
+      ] || [],
+    ).toStrictEqual([
       collectibleContractHH,
       collectibleContractII,
       collectibleContractGG,
     ]);
 
-    expect(collectiblesController.state.collectibles).toStrictEqual([
-      collectibleHH2574,
-      collectibleII2577,
-      collectibleGG2574,
-    ]);
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress]?.[
+        chainId
+      ] || [],
+    ).toStrictEqual([collectibleHH2574, collectibleII2577, collectibleGG2574]);
   });
 });

--- a/src/assets/CollectibleDetectionController.ts
+++ b/src/assets/CollectibleDetectionController.ts
@@ -391,7 +391,6 @@ export class CollectibleDetectionController extends BaseController<
               },
             );
             await this.addCollectible(address, token_id, collectibleMetadata, {
-              autodetected: true,
               address: selectedAddress,
               chainId: chainId as string,
             });

--- a/src/assets/CollectibleDetectionController.ts
+++ b/src/assets/CollectibleDetectionController.ts
@@ -391,7 +391,7 @@ export class CollectibleDetectionController extends BaseController<
               },
             );
             await this.addCollectible(address, token_id, collectibleMetadata, {
-              address: selectedAddress,
+              userAddress: selectedAddress,
               chainId: chainId as string,
             });
           }

--- a/src/assets/CollectibleDetectionController.ts
+++ b/src/assets/CollectibleDetectionController.ts
@@ -318,9 +318,9 @@ export class CollectibleDetectionController extends BaseController<
 
     let { chainId } = this.config;
     if (typeof chainId === 'string' && isHexString(chainId)) {
-      chainId = `${parseInt(chainId, 16)}` as `${number}`;
+      chainId = `${parseInt(chainId, 16)}` as const;
     } else if (typeof chainId === 'number') {
-      chainId = `${chainId}` as `${number}`;
+      chainId = `${chainId}` as const;
     }
 
     /* istanbul ignore else */

--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -495,7 +495,6 @@ describe('CollectiblesController', () => {
         '123',
         undefined,
         {
-          autodetected: true,
           address: selectedAddress,
           chainId,
         },
@@ -518,7 +517,6 @@ describe('CollectiblesController', () => {
         '1203',
         undefined,
         {
-          autodetected: true,
           address: selectedAddress,
           chainId,
         },

--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -495,7 +495,7 @@ describe('CollectiblesController', () => {
         '123',
         undefined,
         {
-          address: selectedAddress,
+          userAddress: selectedAddress,
           chainId,
         },
       );
@@ -517,7 +517,7 @@ describe('CollectiblesController', () => {
         '1203',
         undefined,
         {
-          address: selectedAddress,
+          userAddress: selectedAddress,
           chainId,
         },
       );

--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -175,13 +175,12 @@ describe('CollectiblesController', () => {
     expect(collectiblesController.state).toStrictEqual({
       allCollectibleContracts: {},
       allCollectibles: {},
-      collectibleContracts: [],
-      collectibles: [],
       ignoredCollectibles: [],
     });
   });
 
   it('should add collectible and collectible contract', async () => {
+    const { selectedAddress, chainId } = collectiblesController.config;
     await collectiblesController.addCollectible('0x01', '1', {
       name: 'name',
       image: 'image',
@@ -189,7 +188,9 @@ describe('CollectiblesController', () => {
       standard: 'standard',
     });
 
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][chainId][0],
+    ).toStrictEqual({
       address: '0x01',
       description: 'description',
       image: 'image',
@@ -198,7 +199,11 @@ describe('CollectiblesController', () => {
       standard: 'standard',
     });
 
-    expect(collectiblesController.state.collectibleContracts[0]).toStrictEqual({
+    expect(
+      collectiblesController.state.allCollectibleContracts[selectedAddress][
+        chainId
+      ][0],
+    ).toStrictEqual({
       address: '0x01',
       description: 'Description',
       logo: 'url',
@@ -209,6 +214,8 @@ describe('CollectiblesController', () => {
   });
 
   it('should update collectible if image is different', async () => {
+    const { selectedAddress, chainId } = collectiblesController.config;
+
     await collectiblesController.addCollectible('0x01', '1', {
       name: 'name',
       image: 'image',
@@ -216,7 +223,9 @@ describe('CollectiblesController', () => {
       standard: 'standard',
     });
 
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][chainId][0],
+    ).toStrictEqual({
       address: '0x01',
       description: 'description',
       image: 'image',
@@ -232,7 +241,9 @@ describe('CollectiblesController', () => {
       standard: 'standard',
     });
 
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][chainId][0],
+    ).toStrictEqual({
       address: '0x01',
       description: 'description',
       image: 'image-updated',
@@ -243,6 +254,7 @@ describe('CollectiblesController', () => {
   });
 
   it('should not duplicate collectible nor collectible contract if already added', async () => {
+    const { selectedAddress, chainId } = collectiblesController.config;
     await collectiblesController.addCollectible('0x01', '1', {
       name: 'name',
       image: 'image',
@@ -256,11 +268,21 @@ describe('CollectiblesController', () => {
       description: 'description',
       standard: 'standard',
     });
-    expect(collectiblesController.state.collectibles).toHaveLength(1);
-    expect(collectiblesController.state.collectibleContracts).toHaveLength(1);
+
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][chainId],
+    ).toHaveLength(1);
+
+    expect(
+      collectiblesController.state.allCollectibleContracts[selectedAddress][
+        chainId
+      ],
+    ).toHaveLength(1);
   });
 
   it('should not add collectible contract if collectible contract already exists', async () => {
+    const { selectedAddress, chainId } = collectiblesController.config;
+
     await collectiblesController.addCollectible('0x01', '1', {
       name: 'name',
       image: 'image',
@@ -274,13 +296,24 @@ describe('CollectiblesController', () => {
       description: 'description',
       standard: 'standard',
     });
-    expect(collectiblesController.state.collectibles).toHaveLength(2);
-    expect(collectiblesController.state.collectibleContracts).toHaveLength(1);
+
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][chainId],
+    ).toHaveLength(2);
+
+    expect(
+      collectiblesController.state.allCollectibleContracts[selectedAddress][
+        chainId
+      ],
+    ).toHaveLength(1);
   });
 
   it('should add collectible and get information from OpenSea', async () => {
+    const { selectedAddress, chainId } = collectiblesController.config;
     await collectiblesController.addCollectible('0x01', '1');
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][chainId][0],
+    ).toStrictEqual({
       address: '0x01',
       description: 'Description',
       imageOriginal: 'url',
@@ -295,12 +328,16 @@ describe('CollectiblesController', () => {
 
   it('should add collectible erc1155 and get collectible contract information from contract', async () => {
     assetsContract.configure({ provider: MAINNET_PROVIDER });
+    const { selectedAddress, chainId } = collectiblesController.config;
+
     await collectiblesController.addCollectible(
       ERC1155_COLLECTIBLE_ADDRESS,
       ERC1155_COLLECTIBLE_ID,
     );
 
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][chainId][0],
+    ).toStrictEqual({
       address: ERC1155_COLLECTIBLE_ADDRESS,
       image: 'image (from contract uri)',
       name: 'name (from contract uri)',
@@ -316,7 +353,7 @@ describe('CollectiblesController', () => {
 
   it('should add collectible erc721 and get collectible contract information from contract and OpenSea', async () => {
     assetsContract.configure({ provider: MAINNET_PROVIDER });
-
+    const { selectedAddress, chainId } = collectiblesController.config;
     sandbox
       .stub(
         collectiblesController,
@@ -325,7 +362,9 @@ describe('CollectiblesController', () => {
       .returns(undefined);
 
     await collectiblesController.addCollectible(ERC721_KUDOSADDRESS, '1203');
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][chainId][0],
+    ).toStrictEqual({
       address: ERC721_KUDOSADDRESS,
       image: 'Kudos Image (from uri)',
       name: 'Kudos Name (from uri)',
@@ -337,7 +376,11 @@ describe('CollectiblesController', () => {
       standard: 'ERC721',
     });
 
-    expect(collectiblesController.state.collectibleContracts[0]).toStrictEqual({
+    expect(
+      collectiblesController.state.allCollectibleContracts[selectedAddress][
+        chainId
+      ][0],
+    ).toStrictEqual({
       address: ERC721_KUDOSADDRESS,
       name: 'KudosToken',
       symbol: 'KDO',
@@ -346,7 +389,7 @@ describe('CollectiblesController', () => {
 
   it('should add collectible erc721 and get collectible contract information only from contract', async () => {
     assetsContract.configure({ provider: MAINNET_PROVIDER });
-
+    const { selectedAddress, chainId } = collectiblesController.config;
     sandbox
       .stub(
         collectiblesController,
@@ -358,7 +401,9 @@ describe('CollectiblesController', () => {
       .stub(collectiblesController, 'getCollectibleInformationFromApi' as any)
       .returns(undefined);
     await collectiblesController.addCollectible(ERC721_KUDOSADDRESS, '1203');
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][chainId][0],
+    ).toStrictEqual({
       address: ERC721_KUDOSADDRESS,
       image: 'Kudos Image (from uri)',
       name: 'Kudos Name (from uri)',
@@ -367,7 +412,11 @@ describe('CollectiblesController', () => {
       standard: 'ERC721',
     });
 
-    expect(collectiblesController.state.collectibleContracts[0]).toStrictEqual({
+    expect(
+      collectiblesController.state.allCollectibleContracts[selectedAddress][
+        chainId
+      ][0],
+    ).toStrictEqual({
       address: ERC721_KUDOSADDRESS,
       name: 'KudosToken',
       symbol: 'KDO',
@@ -375,8 +424,10 @@ describe('CollectiblesController', () => {
   });
 
   it('should add collectible by selected address', async () => {
+    const { chainId } = collectiblesController.config;
     const firstAddress = '0x123';
     const secondAddress = '0x321';
+
     sandbox
       .stub(collectiblesController, 'getCollectibleInformation' as any)
       .returns({ name: 'name', image: 'url', description: 'description' });
@@ -385,7 +436,9 @@ describe('CollectiblesController', () => {
     preferences.update({ selectedAddress: secondAddress });
     await collectiblesController.addCollectible('0x02', '4321');
     preferences.update({ selectedAddress: firstAddress });
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+    expect(
+      collectiblesController.state.allCollectibles[firstAddress][chainId][0],
+    ).toStrictEqual({
       address: '0x01',
       description: 'description',
       image: 'url',
@@ -397,6 +450,7 @@ describe('CollectiblesController', () => {
   it('should add collectible by provider type', async () => {
     const firstNetworkType = 'rinkeby';
     const secondNetworkType = 'ropsten';
+    const { selectedAddress } = collectiblesController.config;
     sandbox
       .stub(collectiblesController, 'getCollectibleInformation' as any)
       .returns({ name: 'name', image: 'url', description: 'description' });
@@ -414,7 +468,7 @@ describe('CollectiblesController', () => {
         chainId: NetworksChainId[secondNetworkType],
       },
     });
-    expect(collectiblesController.state.collectibles).toHaveLength(0);
+
     network.update({
       provider: {
         type: firstNetworkType,
@@ -422,7 +476,17 @@ describe('CollectiblesController', () => {
       },
     });
 
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress]?.[
+        NetworksChainId[secondNetworkType]
+      ] || [],
+    ).toHaveLength(0);
+
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][
+        NetworksChainId[firstNetworkType]
+      ][0],
+    ).toStrictEqual({
       address: '0x01',
       description: 'description',
       image: 'url',
@@ -432,30 +496,44 @@ describe('CollectiblesController', () => {
   });
 
   it('should not add collectibles with no contract information when auto detecting', async () => {
+    const { selectedAddress, chainId } = collectiblesController.config;
     await collectiblesController.addCollectible(
       '0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab',
       '123',
       undefined,
       {
         autodetected: true,
-        address: OWNER_ADDRESS,
-        chainId: NetworksChainId.mainnet,
+        address: selectedAddress,
+        chainId,
       },
     );
-    expect(collectiblesController.state.collectibles).toStrictEqual([]);
-    expect(collectiblesController.state.collectibleContracts).toStrictEqual([]);
+
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress]?.[
+        chainId
+      ] || [],
+    ).toStrictEqual([]);
+
+    expect(
+      collectiblesController.state.allCollectibleContracts[selectedAddress]?.[
+        chainId
+      ] || [],
+    ).toStrictEqual([]);
+
     await collectiblesController.addCollectible(
       ERC721_KUDOSADDRESS,
       '1203',
       undefined,
       {
         autodetected: true,
-        address: OWNER_ADDRESS,
-        chainId: NetworksChainId.mainnet,
+        address: selectedAddress,
+        chainId,
       },
     );
 
-    expect(collectiblesController.state.collectibles).toStrictEqual([
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][chainId],
+    ).toStrictEqual([
       {
         address: ERC721_KUDOSADDRESS,
         description: 'Kudos Description',
@@ -469,7 +547,11 @@ describe('CollectiblesController', () => {
       },
     ]);
 
-    expect(collectiblesController.state.collectibleContracts).toStrictEqual([
+    expect(
+      collectiblesController.state.allCollectibleContracts[selectedAddress]?.[
+        chainId
+      ] || [],
+    ).toStrictEqual([
       {
         address: ERC721_KUDOSADDRESS,
         description: 'Kudos Description',
@@ -482,6 +564,8 @@ describe('CollectiblesController', () => {
   });
 
   it('should remove collectible and collectible contract', async () => {
+    const { selectedAddress, chainId } = collectiblesController.config;
+
     await collectiblesController.addCollectible('0x01', '1', {
       name: 'name',
       image: 'image',
@@ -489,11 +573,20 @@ describe('CollectiblesController', () => {
       standard: 'standard',
     });
     collectiblesController.removeCollectible('0x01', '1');
-    expect(collectiblesController.state.collectibles).toHaveLength(0);
-    expect(collectiblesController.state.collectibleContracts).toHaveLength(0);
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][chainId],
+    ).toHaveLength(0);
+
+    expect(
+      collectiblesController.state.allCollectibleContracts[selectedAddress][
+        chainId
+      ],
+    ).toHaveLength(0);
   });
 
   it('should not remove collectible contract if collectible still exists', async () => {
+    const { selectedAddress, chainId } = collectiblesController.config;
+
     await collectiblesController.addCollectible('0x01', '1', {
       name: 'name',
       image: 'image',
@@ -508,11 +601,19 @@ describe('CollectiblesController', () => {
       standard: 'standard',
     });
     collectiblesController.removeCollectible('0x01', '1');
-    expect(collectiblesController.state.collectibles).toHaveLength(1);
-    expect(collectiblesController.state.collectibleContracts).toHaveLength(1);
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][chainId],
+    ).toHaveLength(1);
+
+    expect(
+      collectiblesController.state.allCollectibleContracts[selectedAddress][
+        chainId
+      ],
+    ).toHaveLength(1);
   });
 
   it('should remove collectible by selected address', async () => {
+    const { chainId } = collectiblesController.config;
     sandbox
       .stub(collectiblesController, 'getCollectibleInformation' as any)
       .returns({ name: 'name', image: 'url', description: 'description' });
@@ -523,9 +624,13 @@ describe('CollectiblesController', () => {
     preferences.update({ selectedAddress: secondAddress });
     await collectiblesController.addCollectible('0x01', '1234');
     collectiblesController.removeCollectible('0x01', '1234');
-    expect(collectiblesController.state.collectibles).toHaveLength(0);
+    expect(
+      collectiblesController.state.allCollectibles[secondAddress][chainId],
+    ).toHaveLength(0);
     preferences.update({ selectedAddress: firstAddress });
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+    expect(
+      collectiblesController.state.allCollectibles[firstAddress][chainId][0],
+    ).toStrictEqual({
       address: '0x02',
       description: 'description',
       image: 'url',
@@ -535,6 +640,8 @@ describe('CollectiblesController', () => {
   });
 
   it('should remove collectible by provider type', async () => {
+    const { selectedAddress } = collectiblesController.config;
+
     sandbox
       .stub(collectiblesController, 'getCollectibleInformation' as any)
       .returns({ name: 'name', image: 'url', description: 'description' });
@@ -556,7 +663,12 @@ describe('CollectiblesController', () => {
     await collectiblesController.addCollectible('0x01', '1234');
     // collectiblesController.removeToken('0x01');
     collectiblesController.removeCollectible('0x01', '1234');
-    expect(collectiblesController.state.collectibles).toHaveLength(0);
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][
+        NetworksChainId[secondNetworkType]
+      ],
+    ).toHaveLength(0);
+
     network.update({
       provider: {
         type: firstNetworkType,
@@ -564,7 +676,11 @@ describe('CollectiblesController', () => {
       },
     });
 
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][
+        NetworksChainId[firstNetworkType]
+      ][0],
+    ).toStrictEqual({
       address: '0x02',
       description: 'description',
       image: 'url',
@@ -585,6 +701,8 @@ describe('CollectiblesController', () => {
   });
 
   it('should not add duplicate collectibles to the ignoredCollectibles list', async () => {
+    const { selectedAddress, chainId } = collectiblesController.config;
+
     await collectiblesController.addCollectible('0x01', '1', {
       name: 'name',
       image: 'image',
@@ -599,11 +717,15 @@ describe('CollectiblesController', () => {
       standard: 'standard',
     });
 
-    expect(collectiblesController.state.collectibles).toHaveLength(2);
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][chainId],
+    ).toHaveLength(2);
     expect(collectiblesController.state.ignoredCollectibles).toHaveLength(0);
 
     collectiblesController.removeAndIgnoreCollectible('0x01', '1');
-    expect(collectiblesController.state.collectibles).toHaveLength(1);
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][chainId],
+    ).toHaveLength(1);
     expect(collectiblesController.state.ignoredCollectibles).toHaveLength(1);
 
     await collectiblesController.addCollectible('0x01', '1', {
@@ -612,15 +734,22 @@ describe('CollectiblesController', () => {
       description: 'description',
       standard: 'standard',
     });
-    expect(collectiblesController.state.collectibles).toHaveLength(2);
+
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][chainId],
+    ).toHaveLength(2);
     expect(collectiblesController.state.ignoredCollectibles).toHaveLength(1);
 
     collectiblesController.removeAndIgnoreCollectible('0x01', '1');
-    expect(collectiblesController.state.collectibles).toHaveLength(1);
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][chainId],
+    ).toHaveLength(1);
     expect(collectiblesController.state.ignoredCollectibles).toHaveLength(1);
   });
 
   it('should be able to clear the ignoredCollectibles list', async () => {
+    const { selectedAddress, chainId } = collectiblesController.config;
+
     await collectiblesController.addCollectible('0x02', '1', {
       name: 'name',
       image: 'image',
@@ -628,11 +757,15 @@ describe('CollectiblesController', () => {
       standard: 'standard',
     });
 
-    expect(collectiblesController.state.collectibles).toHaveLength(1);
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][chainId],
+    ).toHaveLength(1);
     expect(collectiblesController.state.ignoredCollectibles).toHaveLength(0);
 
     collectiblesController.removeAndIgnoreCollectible('0x02', '1');
-    expect(collectiblesController.state.collectibles).toHaveLength(0);
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][chainId],
+    ).toHaveLength(0);
     expect(collectiblesController.state.ignoredCollectibles).toHaveLength(1);
 
     collectiblesController.clearIgnoredCollectibles();
@@ -700,18 +833,25 @@ describe('CollectiblesController', () => {
 
   it('should add collectible with metadata hosted in IPFS', async () => {
     assetsContract.configure({ provider: MAINNET_PROVIDER });
+    const { selectedAddress, chainId } = collectiblesController.config;
     await collectiblesController.addCollectible(
       ERC1155_DEPRESSIONIST_ADDRESS,
       ERC1155_DEPRESSIONIST_ID,
     );
 
-    expect(collectiblesController.state.collectibleContracts[0]).toStrictEqual({
+    expect(
+      collectiblesController.state.allCollectibleContracts[selectedAddress][
+        chainId
+      ][0],
+    ).toStrictEqual({
       address: '0x18E8E76aeB9E2d9FA2A2b88DD9CF3C8ED45c3660',
       name: "Maltjik.jpg's Depressionists",
       symbol: 'DPNS',
     });
 
-    expect(collectiblesController.state.collectibles[0]).toStrictEqual({
+    expect(
+      collectiblesController.state.allCollectibles[selectedAddress][chainId][0],
+    ).toStrictEqual({
       address: '0x18E8E76aeB9E2d9FA2A2b88DD9CF3C8ED45c3660',
       tokenId: '36',
       image: 'image',

--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -472,8 +472,8 @@ describe('CollectiblesController', () => {
       expect(
         collectiblesController.state.allCollectibles[selectedAddress]?.[
           NetworksChainId[secondNetworkType]
-        ] || [],
-      ).toHaveLength(0);
+        ],
+      ).toBeUndefined();
 
       expect(
         collectiblesController.state.allCollectibles[selectedAddress][
@@ -503,14 +503,14 @@ describe('CollectiblesController', () => {
       expect(
         collectiblesController.state.allCollectibles[selectedAddress]?.[
           chainId
-        ] || [],
-      ).toStrictEqual([]);
+        ],
+      ).toBeUndefined();
 
       expect(
         collectiblesController.state.allCollectibleContracts[selectedAddress]?.[
           chainId
-        ] || [],
-      ).toStrictEqual([]);
+        ],
+      ).toBeUndefined();
 
       await collectiblesController.addCollectible(
         ERC721_KUDOSADDRESS,
@@ -539,9 +539,9 @@ describe('CollectiblesController', () => {
       ]);
 
       expect(
-        collectiblesController.state.allCollectibleContracts[selectedAddress]?.[
+        collectiblesController.state.allCollectibleContracts[selectedAddress][
           chainId
-        ] || [],
+        ],
       ).toStrictEqual([
         {
           address: ERC721_KUDOSADDRESS,

--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -436,7 +436,11 @@ describe('CollectiblesController', () => {
       '0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab',
       '123',
       undefined,
-      true,
+      {
+        autodetected: true,
+        address: OWNER_ADDRESS,
+        chainId: NetworksChainId.mainnet,
+      },
     );
     expect(collectiblesController.state.collectibles).toStrictEqual([]);
     expect(collectiblesController.state.collectibleContracts).toStrictEqual([]);
@@ -444,7 +448,11 @@ describe('CollectiblesController', () => {
       ERC721_KUDOSADDRESS,
       '1203',
       undefined,
-      true,
+      {
+        autodetected: true,
+        address: OWNER_ADDRESS,
+        chainId: NetworksChainId.mainnet,
+      },
     );
 
     expect(collectiblesController.state.collectibles).toStrictEqual([

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -119,7 +119,7 @@ export interface CollectibleMetadata {
 }
 
 interface DetectionParams {
-  address: string;
+  userAddress: string;
   chainId: string;
 }
 
@@ -487,7 +487,7 @@ export class CollectiblesController extends BaseController<
 
       if (detection) {
         chainId = detection.chainId;
-        selectedAddress = detection.address;
+        selectedAddress = detection.userAddress;
       } else {
         chainId = this.config.chainId;
         selectedAddress = this.config.selectedAddress;
@@ -566,7 +566,7 @@ export class CollectiblesController extends BaseController<
 
       if (detection) {
         chainId = detection.chainId;
-        selectedAddress = detection.address;
+        selectedAddress = detection.userAddress;
       } else {
         chainId = this.config.chainId;
         selectedAddress = this.config.selectedAddress;

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -469,7 +469,7 @@ export class CollectiblesController extends BaseController<
    * @param address - Hex address of the collectible contract.
    * @param tokenId - The collectible identifier.
    * @param collectibleMetadata - Collectible optional information (name, image and description).
-   * @param detection - An object containing the users currently selected address and the chainId used to ensure detected collectibles are added to the correct account.
+   * @param detection - The chain ID and address of the currently selected network and account at the moment the collectible was detected.
    * @returns Promise resolving to the current collectible list.
    */
   private async addIndividualCollectible(
@@ -550,7 +550,7 @@ export class CollectiblesController extends BaseController<
    * Adds a collectible contract to the stored collectible contracts list.
    *
    * @param address - Hex address of the collectible contract.
-   * @param detection - An object containing the users currently selected address and the chainId used to ensure detected collectibles are added to the correct account.
+   * @param detection - The chain ID and address of the currently selected network and account at the moment the collectible was detected.
    * @returns Promise resolving to the current collectible contracts list.
    */
   private async addCollectibleContract(
@@ -919,7 +919,7 @@ export class CollectiblesController extends BaseController<
    * @param address - Hex address of the collectible contract.
    * @param tokenId - The collectible identifier.
    * @param collectibleMetadata - Collectible optional metadata.
-   * @param detection - An object containing the users currently selected address and the chainId used to ensure detected collectibles are added to the correct account.
+   * @param detection - The chain ID and address of the currently selected network and account at the moment the collectible was detected.
    * @returns Promise resolving to the current collectible list.
    */
   async addCollectible(

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -119,7 +119,6 @@ export interface CollectibleMetadata {
 }
 
 interface DetectionParams {
-  autodetected: boolean;
   address: string;
   chainId: string;
 }
@@ -486,7 +485,7 @@ export class CollectiblesController extends BaseController<
       const { allCollectibles } = this.state;
       let chainId, selectedAddress;
 
-      if (detection?.autodetected) {
+      if (detection) {
         chainId = detection.chainId;
         selectedAddress = detection.address;
       } else {
@@ -565,7 +564,7 @@ export class CollectiblesController extends BaseController<
 
       let chainId, selectedAddress;
 
-      if (detection?.autodetected) {
+      if (detection) {
         chainId = detection.chainId;
         selectedAddress = detection.address;
       } else {

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -919,7 +919,7 @@ export class CollectiblesController extends BaseController<
    * @param address - Hex address of the collectible contract.
    * @param tokenId - The collectible identifier.
    * @param collectibleMetadata - Collectible optional metadata.
-   * @param detection - Whether the collectible is manually added or auto-detected for address and chainId.
+   * @param detection - An object containing the users currently selected address and the chainId used to ensure detected collectibles are added to the correct account.
    * @returns Promise resolving to the current collectible list.
    */
   async addCollectible(

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -469,7 +469,7 @@ export class CollectiblesController extends BaseController<
    * @param address - Hex address of the collectible contract.
    * @param tokenId - The collectible identifier.
    * @param collectibleMetadata - Collectible optional information (name, image and description).
-   * @param detection - Wether the collectible is manually added or auto-detected for address and chainId.
+   * @param detection - An object containing the users currently selected address and the chainId used to ensure detected collectibles are added to the correct account.
    * @returns Promise resolving to the current collectible list.
    */
   private async addIndividualCollectible(

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -550,7 +550,7 @@ export class CollectiblesController extends BaseController<
    * Adds a collectible contract to the stored collectible contracts list.
    *
    * @param address - Hex address of the collectible contract.
-   * @param detection - Whether the collectible is manually added or auto-detected for address and chainId.
+   * @param detection - An object containing the users currently selected address and the chainId used to ensure detected collectibles are added to the correct account.
    * @returns Promise resolving to the current collectible contracts list.
    */
   private async addCollectibleContract(


### PR DESCRIPTION
**Description**
- REMOVED
  - [BREAKING] Both `collectibles` and `collectibleContracts` are removed from `CollectiblesController` state. 
- FIXED:

	- [BREAKING] Change auto detection from `boolean` to an object containing `address` and `chainId` that was used to autodetect.

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented

**Issue**

Related https://github.com/MetaMask/metamask-mobile/issues/3335

