### PR TITLE
Add preference to enable/disable collectible detection

### DIFF
--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -165,6 +165,7 @@ describe('ComposableController', () => {
           lostIdentities: {},
           selectedAddress: '',
           useStaticTokenList: false,
+          useCollectibleDetection: false,
         },
       });
     });
@@ -234,6 +235,7 @@ describe('ComposableController', () => {
         provider: { type: 'mainnet', chainId: NetworksChainId.mainnet },
         selectedAddress: '',
         useStaticTokenList: false,
+        useCollectibleDetection: false,
         suggestedAssets: [],
         tokens: [],
       });

--- a/src/assets/CollectibleDetectionController.test.ts
+++ b/src/assets/CollectibleDetectionController.test.ts
@@ -53,6 +53,8 @@ describe('CollectibleDetectionController', () => {
       getCollectiblesState: () => collectiblesController.state,
     });
 
+    preferences.setUseCollectibleDetection(true);
+
     nock(OPEN_SEA_HOST)
       .get(`${OPEN_SEA_PATH}/assets?owner=0x2&offset=0&limit=50`)
       .reply(200, {
@@ -191,10 +193,12 @@ describe('CollectibleDetectionController', () => {
   });
 
   it('should set default config', () => {
+    preferences.setUseCollectibleDetection(false);
     expect(collectibleDetection.config).toStrictEqual({
       interval: DEFAULT_INTERVAL,
       networkType: 'mainnet',
       selectedAddress: '',
+      disabled: true,
     });
   });
 
@@ -219,8 +223,8 @@ describe('CollectibleDetectionController', () => {
         },
         { interval: 10 },
       );
+      collectiblesDetectionController.configure({ disabled: false });
       collectiblesDetectionController.start();
-
       expect(mockCollectibles.calledOnce).toBe(true);
       setTimeout(() => {
         expect(mockCollectibles.calledTwice).toBe(true);
@@ -357,6 +361,16 @@ describe('CollectibleDetectionController', () => {
     collectiblesController.configure({ selectedAddress: '0x12' });
     await new Promise((res) => setTimeout(() => res(true), 1000));
     expect(collectibleDetection.config.selectedAddress).toStrictEqual('0x12');
+    expect(collectiblesController.state.collectibles).toStrictEqual([]);
+  });
+
+  it('should not detect and add collectibles if preferences controller useCollectibleDetection is set to false', async () => {
+    preferences.setUseCollectibleDetection(false);
+    collectibleDetection.configure({
+      networkType: MAINNET,
+      selectedAddress: '0x9',
+    });
+    collectibleDetection.detectCollectibles();
     expect(collectiblesController.state.collectibles).toStrictEqual([]);
   });
 

--- a/src/assets/CollectibleDetectionController.ts
+++ b/src/assets/CollectibleDetectionController.ts
@@ -132,7 +132,6 @@ export interface CollectibleDetectionConfig extends BaseConfig {
   interval: number;
   networkType: NetworkType;
   selectedAddress: string;
-  enabled: boolean;
 }
 
 /**
@@ -230,7 +229,7 @@ export class CollectibleDetectionController extends BaseController<
       interval: DEFAULT_INTERVAL,
       networkType: MAINNET,
       selectedAddress: '',
-      enabled: false,
+      disabled: true,
     };
     this.initialize();
     this.getCollectiblesState = getCollectiblesState;
@@ -260,7 +259,7 @@ export class CollectibleDetectionController extends BaseController<
    * Start polling for the currency rate.
    */
   async start() {
-    if (!this.isMainnet() || !this.config.enabled) {
+    if (!this.isMainnet() || this.disabled) {
       return;
     }
 
@@ -307,7 +306,7 @@ export class CollectibleDetectionController extends BaseController<
    */
   async detectCollectibles() {
     /* istanbul ignore if */
-    if (!this.isMainnet() || !this.config.enabled) {
+    if (!this.isMainnet() || this.disabled) {
       return;
     }
     const requestedSelectedAddress = this.config.selectedAddress;

--- a/src/user/PreferencesController.test.ts
+++ b/src/user/PreferencesController.test.ts
@@ -216,4 +216,10 @@ describe('PreferencesController', () => {
     controller.setUseStaticTokenList(true);
     expect(controller.state.useStaticTokenList).toStrictEqual(true);
   });
+
+  it('should set useCollectibleDetection', () => {
+    const controller = new PreferencesController();
+    controller.setUseCollectibleDetection(true);
+    expect(controller.state.useCollectibleDetection).toStrictEqual(true);
+  });
 });

--- a/src/user/PreferencesController.test.ts
+++ b/src/user/PreferencesController.test.ts
@@ -11,6 +11,7 @@ describe('PreferencesController', () => {
       lostIdentities: {},
       selectedAddress: '',
       useStaticTokenList: false,
+      useCollectibleDetection: false,
     });
   });
 

--- a/src/user/PreferencesController.ts
+++ b/src/user/PreferencesController.ts
@@ -46,6 +46,7 @@ export interface PreferencesState extends BaseState {
   lostIdentities: { [address: string]: ContactEntry };
   selectedAddress: string;
   useStaticTokenList: boolean;
+  useCollectibleDetection: boolean;
 }
 
 /**
@@ -76,6 +77,7 @@ export class PreferencesController extends BaseController<
       lostIdentities: {},
       selectedAddress: '',
       useStaticTokenList: false,
+      useCollectibleDetection: false,
     };
     this.initialize();
   }
@@ -287,10 +289,19 @@ export class PreferencesController extends BaseController<
   /**
    * Toggle the token detection setting to use dynamic token list.
    *
-   * @param useStaticTokenList - IPFS gateway string.
+   * @param useStaticTokenList - Boolean indicating user preference on token detection.
    */
   setUseStaticTokenList(useStaticTokenList: boolean) {
     this.update({ useStaticTokenList });
+  }
+
+  /**
+   * Toggle the collectible detection setting.
+   *
+   * @param useCollectibleDetection - Boolean indicating user preference on collectible detection.
+   */
+  setUseCollectibleDetection(useCollectibleDetection: boolean) {
+    this.update({ useCollectibleDetection });
   }
 }
 


### PR DESCRIPTION
As part of the security/UX prerequisites for bringing NFTs into the extension (and for enhancing security for in mobile) we are adding a user preference to allow users to toggle on or off collectible auto-detection, just as we have previously done with ERC-20 Token detection.

[NFT in Extension designs](https://www.figma.com/file/8Xe22jEPgcElS5tWPw8AGM/NFTs-in-extension-(MVP)?node-id=772%3A10496):
<img width="274" alt="Screen Shot 2021-11-23 at 10 39 14 AM" src="https://user-images.githubusercontent.com/34557516/143066082-1d28b2c9-b9ed-438d-b727-092e02126e7b.png">


This PR adds the preference to the PreferencesController and reads that setting in the CollectibleDetectionController to determine whether to detect/poll for collectibles.