### PR TITLE
Modify requirements for adding opensea detected contract

### DIFF
--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -563,7 +563,7 @@ export class CollectiblesController extends BaseController<
       // If being auto-detected opensea information is expected
       // Otherwise at least name and symbol from contract is needed
       if (
-        (detection && !image_url) ||
+        (detection && !name) ||
         Object.keys(contractInformation).length === 0
       ) {
         return collectibleContracts;


### PR DESCRIPTION
In cases where a collectible contract that has been detected from OpenSea API does not have an image_url (collection logo), we should not short-circuit the auto-detection of the NFTs associated with that contract. It seems the original reasoning for this was that we assumed that the image_url (collection logo) was a good proxy for whether the contract had useable data. While testing development of NFTs on the extension I came across several instances where this was not a good proxy and valid NFT assets were not detected as a result. 

Context: If a contract is not added to CollectibleContracts state [we do not add the collectible to state](https://github.com/MetaMask/controllers/blob/3497fa8cad2a206d914bbac5d8914045467a39f5/src/assets/CollectiblesController.ts#L924)

- CHANGED:
  - Modify requirements for adding OpenSea detected contract to CollectiblesContract state

