### PR TITLE
add openSeaEnabled preference

### DIFF
--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -166,6 +166,7 @@ describe('ComposableController', () => {
           selectedAddress: '',
           useStaticTokenList: false,
           useCollectibleDetection: false,
+          openSeaEnabled: false,
         },
       });
     });
@@ -236,6 +237,7 @@ describe('ComposableController', () => {
         selectedAddress: '',
         useStaticTokenList: false,
         useCollectibleDetection: false,
+        openSeaEnabled: false,
         suggestedAssets: [],
         tokens: [],
       });

--- a/src/assets/CollectibleDetectionController.test.ts
+++ b/src/assets/CollectibleDetectionController.test.ts
@@ -53,6 +53,7 @@ describe('CollectibleDetectionController', () => {
       getCollectiblesState: () => collectiblesController.state,
     });
 
+    preferences.setOpenSeaEnabled(true);
     preferences.setUseCollectibleDetection(true);
 
     nock(OPEN_SEA_HOST)
@@ -368,6 +369,16 @@ describe('CollectibleDetectionController', () => {
 
   it('should not detect and add collectibles if preferences controller useCollectibleDetection is set to false', async () => {
     preferences.setUseCollectibleDetection(false);
+    collectibleDetection.configure({
+      networkType: MAINNET,
+      selectedAddress: '0x9',
+    });
+    collectibleDetection.detectCollectibles();
+    expect(collectiblesController.state.collectibles).toStrictEqual([]);
+  });
+
+  it('should not detect and add collectibles if preferences controller openSeaEnabled is set to false', async () => {
+    preferences.setOpenSeaEnabled(false);
     collectibleDetection.configure({
       networkType: MAINNET,
       selectedAddress: '0x9',

--- a/src/assets/CollectibleDetectionController.ts
+++ b/src/assets/CollectibleDetectionController.ts
@@ -233,6 +233,9 @@ export class CollectibleDetectionController extends BaseController<
         this.configure({ selectedAddress, disabled: !useCollectibleDetection });
         this.detectCollectibles();
       }
+      if (!useCollectibleDetection) {
+        this.stop();
+      }
     });
 
     onNetworkStateChange(({ provider }) => {

--- a/src/assets/CollectibleDetectionController.ts
+++ b/src/assets/CollectibleDetectionController.ts
@@ -233,6 +233,7 @@ export class CollectibleDetectionController extends BaseController<
         this.configure({ selectedAddress, disabled: !useCollectibleDetection });
         this.detectCollectibles();
       }
+
       if (!useCollectibleDetection) {
         this.stop();
       }

--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -60,7 +60,10 @@ describe('CollectiblesController', () => {
       ),
     });
 
-    preferences.update({ selectedAddress: OWNER_ADDRESS });
+    preferences.update({
+      selectedAddress: OWNER_ADDRESS,
+      openSeaEnabled: true,
+    });
 
     sandbox
       .stub(collectiblesController, 'isCollectibleOwner' as any)

--- a/src/user/PreferencesController.test.ts
+++ b/src/user/PreferencesController.test.ts
@@ -12,6 +12,7 @@ describe('PreferencesController', () => {
       selectedAddress: '',
       useStaticTokenList: false,
       useCollectibleDetection: false,
+      openSeaEnabled: false,
     });
   });
 
@@ -220,6 +221,7 @@ describe('PreferencesController', () => {
 
   it('should set useCollectibleDetection', () => {
     const controller = new PreferencesController();
+    controller.setOpenSeaEnabled(true);
     controller.setUseCollectibleDetection(true);
     expect(controller.state.useCollectibleDetection).toStrictEqual(true);
   });

--- a/src/user/PreferencesController.ts
+++ b/src/user/PreferencesController.ts
@@ -47,6 +47,7 @@ export interface PreferencesState extends BaseState {
   selectedAddress: string;
   useStaticTokenList: boolean;
   useCollectibleDetection: boolean;
+  openSeaEnabled: boolean;
 }
 
 /**
@@ -78,6 +79,7 @@ export class PreferencesController extends BaseController<
       selectedAddress: '',
       useStaticTokenList: false,
       useCollectibleDetection: false,
+      openSeaEnabled: false,
     };
     this.initialize();
   }
@@ -302,6 +304,15 @@ export class PreferencesController extends BaseController<
    */
   setUseCollectibleDetection(useCollectibleDetection: boolean) {
     this.update({ useCollectibleDetection });
+  }
+
+  /**
+   * Toggle the opensea enabled setting.
+   *
+   * @param useCollectibleDetection - Boolean indicating user preference on using OpenSea's API.
+   */
+  setOpenSeaEnabled(openSeaEnabled: boolean) {
+    this.update({ openSeaEnabled });
   }
 }
 

--- a/src/user/PreferencesController.ts
+++ b/src/user/PreferencesController.ts
@@ -309,7 +309,7 @@ export class PreferencesController extends BaseController<
   /**
    * Toggle the opensea enabled setting.
    *
-   * @param useCollectibleDetection - Boolean indicating user preference on using OpenSea's API.
+   * @param openSeaEnabled - Boolean indicating user preference on using OpenSea's API.
    */
   setOpenSeaEnabled(openSeaEnabled: boolean) {
     this.update({ openSeaEnabled });

--- a/src/user/PreferencesController.ts
+++ b/src/user/PreferencesController.ts
@@ -313,6 +313,9 @@ export class PreferencesController extends BaseController<
    */
   setOpenSeaEnabled(openSeaEnabled: boolean) {
     this.update({ openSeaEnabled });
+    if (!openSeaEnabled) {
+      this.update({ useCollectibleDetection: false });
+    }
   }
 }
 

--- a/src/user/PreferencesController.ts
+++ b/src/user/PreferencesController.ts
@@ -303,6 +303,11 @@ export class PreferencesController extends BaseController<
    * @param useCollectibleDetection - Boolean indicating user preference on collectible detection.
    */
   setUseCollectibleDetection(useCollectibleDetection: boolean) {
+    if (useCollectibleDetection && !this.state.openSeaEnabled) {
+      throw new Error(
+        'useCollectibleDetection cannot be enabled if openSeaEnabled is false',
+      );
+    }
     this.update({ useCollectibleDetection });
   }
 


### PR DESCRIPTION
- BREAKING:
  - openSeaEnabled preference is introduced and defaulted to false on the preferencesController. This value is used to determine whether the collectiblesController makes use of OpenSea's API for fetching collectible data.
     - Consumers who use the collectibleDetectionController and collectibleController who wish to continue use of OpenSea's API will either need to configure openSeaEnabled to true after instantiating the controller now or expose a toggle for users to change the openSeaEnabled state in the preferences controller.

- FIXED:
  - fixes issue introduced in https://github.com/MetaMask/controllers/pull/638 where polling collectibleDetection polling was not properly stopped when useCollectibleDetection preference is set to false.

