### PR TITLE
Pull in remaining EIP-1559 v2 datapoints

### DIFF
--- a/src/gas/GasFeeController.test.ts
+++ b/src/gas/GasFeeController.test.ts
@@ -76,6 +76,17 @@ function buildMockGasFeeStateFeeMarket({
         suggestedMaxFeePerGas: (30 * modifier).toString(),
       },
       estimatedBaseFee: (100 * modifier).toString(),
+      historicalBaseFeeRange: [
+        (100 * modifier).toString(),
+        (200 * modifier).toString(),
+      ],
+      baseFeeTrend: 'up',
+      latestPriorityFeeRange: [modifier.toString(), (2 * modifier).toString()],
+      historicalPriorityFeeRange: [
+        (2 * modifier).toString(),
+        (4 * modifier).toString(),
+      ],
+      priorityFeeTrend: 'down',
       networkCongestion: 0.1 * modifier,
     },
     estimatedGasFeeTimeBounds: {

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -127,6 +127,11 @@ export type GasFeeEstimates = {
   medium: Eip1559GasFee;
   high: Eip1559GasFee;
   estimatedBaseFee: string;
+  historicalBaseFeeRange: [string, string];
+  baseFeeTrend: 'up' | 'down' | 'level';
+  latestPriorityFeeRange: [string, string];
+  historicalPriorityFeeRange: [string, string];
+  priorityFeeTrend: 'up' | 'down' | 'level';
   networkCongestion: number;
 };
 

--- a/src/gas/determineGasFeeCalculations.test.ts
+++ b/src/gas/determineGasFeeCalculations.test.ts
@@ -40,24 +40,29 @@ const mockedFetchGasEstimatesViaEthFeeHistory = mocked(
 function buildMockDataForFetchGasEstimates(): GasFeeEstimates {
   return {
     low: {
-      minWaitTimeEstimate: 10000,
-      maxWaitTimeEstimate: 20000,
+      minWaitTimeEstimate: 10_000,
+      maxWaitTimeEstimate: 20_000,
       suggestedMaxPriorityFeePerGas: '1',
       suggestedMaxFeePerGas: '10',
     },
     medium: {
-      minWaitTimeEstimate: 30000,
-      maxWaitTimeEstimate: 40000,
+      minWaitTimeEstimate: 30_000,
+      maxWaitTimeEstimate: 40_000,
       suggestedMaxPriorityFeePerGas: '1.5',
       suggestedMaxFeePerGas: '20',
     },
     high: {
-      minWaitTimeEstimate: 50000,
-      maxWaitTimeEstimate: 60000,
+      minWaitTimeEstimate: 50_000,
+      maxWaitTimeEstimate: 60_000,
       suggestedMaxPriorityFeePerGas: '2',
       suggestedMaxFeePerGas: '30',
     },
     estimatedBaseFee: '100',
+    historicalBaseFeeRange: ['100', '200'],
+    baseFeeTrend: 'up',
+    latestPriorityFeeRange: ['1', '2'],
+    historicalPriorityFeeRange: ['2', '4'],
+    priorityFeeTrend: 'down',
     networkCongestion: 0.5,
   };
 }

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory.ts
@@ -5,6 +5,10 @@ import { GasFeeEstimates } from './GasFeeController';
 import { EthQuery } from './fetchGasEstimatesViaEthFeeHistory/types';
 import BlockFeeHistoryDatasetFetcher from './fetchGasEstimatesViaEthFeeHistory/BlockFeeHistoryDatasetFetcher';
 import calculateGasFeeEstimatesForPriorityLevels from './fetchGasEstimatesViaEthFeeHistory/calculateGasFeeEstimatesForPriorityLevels';
+import calculateBaseFeeRange from './fetchGasEstimatesViaEthFeeHistory/calculateBaseFeeRange';
+import calculateBaseFeeTrend from './fetchGasEstimatesViaEthFeeHistory/calculateBaseFeeTrend';
+import calculatePriorityFeeRange from './fetchGasEstimatesViaEthFeeHistory/calculatePriorityFeeRange';
+import calculatePriorityFeeTrend from './fetchGasEstimatesViaEthFeeHistory/calculatePriorityFeeTrend';
 import calculateNetworkCongestion from './fetchGasEstimatesViaEthFeeHistory/calculateNetworkCongestion';
 import fetchLatestBlock from './fetchGasEstimatesViaEthFeeHistory/fetchLatestBlock';
 
@@ -26,14 +30,29 @@ async function fetchBlockFeeHistoryDatasets(
     endBlockNumber,
   });
 
-  const [longRange, smallRange] = await Promise.all([
+  const [
+    longRange,
+    mediumRange,
+    smallRange,
+    tinyRange,
+    tinyRangeWithPending,
+    latest,
+  ] = await Promise.all([
     fetcher.forLongRange(),
+    fetcher.forMediumRange(),
     fetcher.forSmallRange(),
+    fetcher.forTinyRange(),
+    fetcher.forTinyRangeWithPending(),
+    fetcher.forLatest(),
   ]);
 
   return {
     longRange,
+    mediumRange,
     smallRange,
+    tinyRange,
+    tinyRangeWithPending,
+    latest,
   };
 }
 
@@ -65,6 +84,19 @@ export default async function fetchGasEstimatesViaEthFeeHistory(
     blocksByDataset.smallRange,
   );
   const estimatedBaseFee = fromWei(latestBlock.baseFeePerGas, GWEI);
+  const historicalBaseFeeRange = calculateBaseFeeRange(
+    blocksByDataset.mediumRange,
+  );
+  const baseFeeTrend = calculateBaseFeeTrend(
+    blocksByDataset.tinyRangeWithPending,
+  );
+  const latestPriorityFeeRange = calculatePriorityFeeRange(
+    blocksByDataset.latest,
+  );
+  const historicalPriorityFeeRange = calculatePriorityFeeRange(
+    blocksByDataset.mediumRange,
+  );
+  const priorityFeeTrend = calculatePriorityFeeTrend(blocksByDataset.tinyRange);
   const networkCongestion = calculateNetworkCongestion(
     blocksByDataset.longRange,
   );
@@ -72,6 +104,11 @@ export default async function fetchGasEstimatesViaEthFeeHistory(
   return {
     ...levelSpecificEstimates,
     estimatedBaseFee,
+    historicalBaseFeeRange,
+    baseFeeTrend,
+    latestPriorityFeeRange,
+    historicalPriorityFeeRange,
+    priorityFeeTrend,
     networkCongestion,
   };
 }

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory/BlockFeeHistoryDatasetFetcher.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory/BlockFeeHistoryDatasetFetcher.ts
@@ -22,12 +22,39 @@ export default class BlockFeeHistoryDatasetFetcher {
     return this.fetch({ numberOfBlocks: 20_000 });
   }
 
+  forMediumRange() {
+    return this.fetch({ numberOfBlocks: 200, percentiles: [10, 95] });
+  }
+
   forSmallRange() {
     return this.fetch({ numberOfBlocks: 5, percentiles: [10, 20, 30] });
   }
 
+  forTinyRange() {
+    return this.fetch({
+      numberOfBlocks: 2,
+      percentiles: [50],
+    });
+  }
+
+  forTinyRangeWithPending() {
+    return this.fetch({
+      numberOfBlocks: 2,
+      endBlock: 'pending',
+      percentiles: [50],
+    });
+  }
+
+  forLatest() {
+    return this.fetch({
+      numberOfBlocks: 1,
+      percentiles: [10, 95],
+    });
+  }
+
   private fetch<T extends number = never>(args: {
     numberOfBlocks: number;
+    endBlock?: BN | 'pending';
     percentiles?: T[];
   }): Promise<FeeHistoryBlock<T>[]> {
     return fetchBlockFeeHistory({

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory/calculateBaseFeeRange.test.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory/calculateBaseFeeRange.test.ts
@@ -1,0 +1,29 @@
+import { BN } from 'ethereumjs-util';
+import calculateBaseFeeRange from './calculateBaseFeeRange';
+
+describe('calculateBaseFeeRange', () => {
+  it('returns the min and max of base fees across the given blocks', () => {
+    const baseFeeRange = calculateBaseFeeRange([
+      {
+        number: new BN(1),
+        baseFeePerGas: new BN(300_000_000_000),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {},
+      },
+      {
+        number: new BN(2),
+        baseFeePerGas: new BN(100_000_000_000),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {},
+      },
+      {
+        number: new BN(3),
+        baseFeePerGas: new BN(200_000_000_000),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {},
+      },
+    ]);
+
+    expect(baseFeeRange).toStrictEqual(['100', '300']);
+  });
+});

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory/calculateBaseFeeRange.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory/calculateBaseFeeRange.ts
@@ -1,0 +1,23 @@
+import { fromWei } from 'ethjs-unit';
+import { GWEI } from '../../constants';
+import { FeeHistoryBlock } from '../fetchBlockFeeHistory';
+import { FeeRange } from './types';
+
+/**
+ * Calculates reasonable minimum and maximum values for base fees over the last 200 blocks.
+ *
+ * @param blocks - A set of blocks obtained via {@link BlockFeeHistoryDatasetFetcher}.
+ * @returns The ranges.
+ */
+export default function calculateBaseFeeRange<Percentile extends number>(
+  blocks: FeeHistoryBlock<Percentile>[],
+): FeeRange {
+  const sortedBaseFeesPerGas = blocks
+    .map((block) => block.baseFeePerGas)
+    .sort((a, b) => a.cmp(b));
+
+  return [
+    fromWei(sortedBaseFeesPerGas[0], GWEI),
+    fromWei(sortedBaseFeesPerGas[sortedBaseFeesPerGas.length - 1], GWEI),
+  ];
+}

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory/calculateBaseFeeTrend.test.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory/calculateBaseFeeTrend.test.ts
@@ -1,0 +1,79 @@
+import { BN } from 'ethereumjs-util';
+import calculateBaseFeeTrend from './calculateBaseFeeTrend';
+
+describe('calculateBaseFeeTrend', () => {
+  it('returns "up" if the base fee of the last block is greater than the first', () => {
+    const baseFeeTrend = calculateBaseFeeTrend([
+      {
+        number: new BN(1),
+        baseFeePerGas: new BN(100_000_000_000),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {},
+      },
+      {
+        number: new BN(1),
+        baseFeePerGas: new BN(95_000_000_000),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {},
+      },
+      {
+        number: new BN(1),
+        baseFeePerGas: new BN(110_000_000_000),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {},
+      },
+    ]);
+
+    expect(baseFeeTrend).toStrictEqual('up');
+  });
+
+  it('returns "down" if the base fee of the last block is less than the first', () => {
+    const baseFeeTrend = calculateBaseFeeTrend([
+      {
+        number: new BN(1),
+        baseFeePerGas: new BN(100_000_000_000),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {},
+      },
+      {
+        number: new BN(1),
+        baseFeePerGas: new BN(110_000_000_000),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {},
+      },
+      {
+        number: new BN(1),
+        baseFeePerGas: new BN(95_000_000_000),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {},
+      },
+    ]);
+
+    expect(baseFeeTrend).toStrictEqual('down');
+  });
+
+  it('returns "level" if the base fee of the last block is the same as the first', () => {
+    const baseFeeTrend = calculateBaseFeeTrend([
+      {
+        number: new BN(1),
+        baseFeePerGas: new BN(100_000_000_000),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {},
+      },
+      {
+        number: new BN(1),
+        baseFeePerGas: new BN(110_000_000_000),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {},
+      },
+      {
+        number: new BN(1),
+        baseFeePerGas: new BN(100_000_000_000),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {},
+      },
+    ]);
+
+    expect(baseFeeTrend).toStrictEqual('level');
+  });
+});

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory/calculateBaseFeeTrend.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory/calculateBaseFeeTrend.ts
@@ -1,0 +1,23 @@
+import { FeeHistoryBlock } from '../fetchBlockFeeHistory';
+
+/**
+ * Given a collection of blocks, returns an indicator of whether the base fee is moving up, down, or
+ * holding steady, based on comparing the last base fee in the collection to the first.
+ *
+ * @param blocks - A set of blocks obtained via {@link BlockFeeHistoryDatasetFetcher}.
+ * @returns The indicator ("up", "down", or "level").
+ */
+export default function calculateBaseFeeTrend<Percentile extends number>(
+  blocks: FeeHistoryBlock<Percentile>[],
+) {
+  const baseFeesPerGas = blocks.map((block) => block.baseFeePerGas);
+  const first = baseFeesPerGas[0];
+  const last = baseFeesPerGas[baseFeesPerGas.length - 1];
+
+  if (last.gt(first)) {
+    return 'up';
+  } else if (first.gt(last)) {
+    return 'down';
+  }
+  return 'level';
+}

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory/calculatePriorityFeeRange.test.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory/calculatePriorityFeeRange.test.ts
@@ -1,0 +1,40 @@
+import { BN } from 'ethereumjs-util';
+import calculatePriorityFeeRange from './calculatePriorityFeeRange';
+
+describe('calculatePriorityFeeRange', () => {
+  it('returns the min and max of priority fees across the given blocks (omitting 0)', () => {
+    const blocks = [
+      {
+        number: new BN(1),
+        baseFeePerGas: new BN(1),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {
+          10: new BN(0),
+          95: new BN(1_000_000_000),
+        },
+      },
+      {
+        number: new BN(2),
+        baseFeePerGas: new BN(1),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {
+          10: new BN(500_000_000),
+          95: new BN(1_600_000_000),
+        },
+      },
+      {
+        number: new BN(3),
+        baseFeePerGas: new BN(1),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {
+          10: new BN(500_000_000),
+          95: new BN(2_000_000_000),
+        },
+      },
+    ];
+
+    const priorityFeeRange = calculatePriorityFeeRange(blocks);
+
+    expect(priorityFeeRange).toStrictEqual(['0.5', '2']);
+  });
+});

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory/calculatePriorityFeeRange.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory/calculatePriorityFeeRange.ts
@@ -1,0 +1,32 @@
+import { BN } from 'ethereumjs-util';
+import { fromWei } from 'ethjs-unit';
+import { GWEI } from '../../constants';
+import { FeeHistoryBlock } from '../fetchBlockFeeHistory';
+import { FeeRange } from './types';
+
+/**
+ * Calculates reasonable minimum and maximum values for priority fees over the last 200 blocks.
+ * Although some priority fees may be 0, these are discarded as they are not useful for suggestion
+ * purposes.
+ *
+ * @param blocks - A set of blocks populated with data for priority fee percentiles 10 and 95,
+ * obtained via {@link BlockFeeHistoryDatasetFetcher}.
+ * @returns The range.
+ */
+export default function calculatePriorityFeeRange(
+  blocks: FeeHistoryBlock<10 | 95>[],
+): FeeRange {
+  const sortedLowPriorityFees = blocks
+    .map((block) => block.priorityFeesByPercentile[10])
+    .filter((priorityFee) => !priorityFee.eq(new BN(0)))
+    .sort((a, b) => a.cmp(b));
+
+  const sortedHighPriorityFees = blocks
+    .map((block) => block.priorityFeesByPercentile[95])
+    .sort((a, b) => a.cmp(b));
+
+  return [
+    fromWei(sortedLowPriorityFees[0], GWEI),
+    fromWei(sortedHighPriorityFees[sortedHighPriorityFees.length - 1], GWEI),
+  ];
+}

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory/calculatePriorityFeeTrend.test.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory/calculatePriorityFeeTrend.test.ts
@@ -1,0 +1,97 @@
+import { BN } from 'ethereumjs-util';
+import calculatePriorityFeeTrend from './calculatePriorityFeeTrend';
+
+describe('calculatePriorityFeeTrend', () => {
+  it('returns "up" if the last priority fee at the 50th percentile among the blocks is greater than the first', () => {
+    const priorityFeeTrend = calculatePriorityFeeTrend([
+      {
+        number: new BN(1),
+        baseFeePerGas: new BN(1),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {
+          50: new BN(1_000_000_000),
+        },
+      },
+      {
+        number: new BN(1),
+        baseFeePerGas: new BN(1),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {
+          50: new BN(900_000_000),
+        },
+      },
+      {
+        number: new BN(1),
+        baseFeePerGas: new BN(1),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {
+          50: new BN(1_100_000_000),
+        },
+      },
+    ]);
+
+    expect(priorityFeeTrend).toStrictEqual('up');
+  });
+
+  it('returns "down" if the last priority fee at the 50th percentile among the blocks is less than the first', () => {
+    const priorityFeeTrend = calculatePriorityFeeTrend([
+      {
+        number: new BN(1),
+        baseFeePerGas: new BN(1),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {
+          50: new BN(1_000_000_000),
+        },
+      },
+      {
+        number: new BN(1),
+        baseFeePerGas: new BN(1),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {
+          50: new BN(1_100_000_000),
+        },
+      },
+      {
+        number: new BN(1),
+        baseFeePerGas: new BN(1),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {
+          50: new BN(900_000_000),
+        },
+      },
+    ]);
+
+    expect(priorityFeeTrend).toStrictEqual('down');
+  });
+
+  it('returns "level" if the last priority fee at the 50th percentile among the blocks is the same as the first', () => {
+    const priorityFeeTrend = calculatePriorityFeeTrend([
+      {
+        number: new BN(1),
+        baseFeePerGas: new BN(1),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {
+          50: new BN(1_000_000_000),
+        },
+      },
+      {
+        number: new BN(1),
+        baseFeePerGas: new BN(1),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {
+          50: new BN(1_100_000_000),
+        },
+      },
+      {
+        number: new BN(1),
+        baseFeePerGas: new BN(1),
+        gasUsedRatio: 1,
+        priorityFeesByPercentile: {
+          50: new BN(1_000_000_000),
+        },
+      },
+    ]);
+
+    expect(priorityFeeTrend).toStrictEqual('level');
+  });
+});

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory/calculatePriorityFeeTrend.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory/calculatePriorityFeeTrend.ts
@@ -1,0 +1,26 @@
+import { BN } from 'ethereumjs-util';
+import { FeeHistoryBlock } from '../fetchBlockFeeHistory';
+
+/**
+ * Given a collection of blocks, returns an indicator of whether the base fee is moving up, down, or
+ * holding steady, based on comparing the last base fee in the collection to the first.
+ *
+ * @param blocks - A set of blocks obtained via {@link BlockFeeHistoryDatasetFetcher}.
+ * @returns The indicator ("up", "down", or "level").
+ */
+export default function calculatePriorityFeeTrend(
+  blocks: FeeHistoryBlock<50>[],
+) {
+  const priorityFees = blocks
+    .map((block) => block.priorityFeesByPercentile[50])
+    .filter((priorityFee) => !priorityFee.eq(new BN(0)));
+  const first = priorityFees[0];
+  const last = priorityFees[priorityFees.length - 1];
+
+  if (last.gt(first)) {
+    return 'up';
+  } else if (first.gt(last)) {
+    return 'down';
+  }
+  return 'level';
+}

--- a/src/gas/gas-util.ts
+++ b/src/gas/gas-util.ts
@@ -66,6 +66,11 @@ export async function fetchGasEstimates(
       ),
     },
     estimatedBaseFee: normalizeGWEIDecimalNumbers(estimates.estimatedBaseFee),
+    historicalBaseFeeRange: estimates.historicalBaseFeeRange,
+    baseFeeTrend: estimates.baseFeeTrend,
+    latestPriorityFeeRange: estimates.latestPriorityFeeRange,
+    historicalPriorityFeeRange: estimates.historicalPriorityFeeRange,
+    priorityFeeTrend: estimates.priorityFeeTrend,
     networkCongestion: estimates.networkCongestion,
   };
 }


### PR DESCRIPTION
Several new properties are now available from the `/suggestedGasFees`
endpoint in the MetaSwap API. This commit updates GasFeeController to
store these properties in state when polling for gas fee estimates and
implements fallback code for the underlying datapoints. This way we can
use these values to display different UI elements to users when they are
sending transactions.

The properties are:

* `historicalBaseFeeRange` — minimum and maximum values for the base
  fees over the past 200 blocks
* `baseFeeTrend` — an indicator for which direction the base fee is
  moving based on the current pending block vs. the latest block
* `latestPriorityFeeRange` — minimum and maximum values for the priority
  fees in the latest block
* `historicalPriorityFeeRange` — minimum and maximum values for priority
  fees over the past 200 blocks
* `priorityFeeTrend` — an indicator for which direction priority fees
  are moving based on the current pending block vs. the latest block