### PR TITLE
Fix collectibles collection images

### DIFF
--- a/src/assets/CollectibleDetectionController.ts
+++ b/src/assets/CollectibleDetectionController.ts
@@ -75,7 +75,7 @@ export interface ApiCollectibleContract {
   external_link: string | null;
   collection: {
     name: string | null;
-    image_url: string | null;
+    image_url?: string | null;
   };
 }
 


### PR DESCRIPTION
**Description**

- FIXED:

  - Avoid overwriting `collection` property from `getCollectibleInformation`, this was causing `collection.image_url` to be `null`.


**Checklist**

- [X] Tests are included if applicable
- [X] Any added code is fully documented
