### PR TITLE
remove chainid normalization

### DIFF
--- a/src/assets/CollectibleDetectionController.ts
+++ b/src/assets/CollectibleDetectionController.ts
@@ -1,4 +1,3 @@
-import { isHexString } from 'ethereumjs-util';
 import { BaseController, BaseConfig, BaseState } from '../BaseController';
 import type { NetworkState, NetworkType } from '../network/NetworkController';
 import type { PreferencesState } from '../user/PreferencesController';
@@ -305,14 +304,7 @@ export class CollectibleDetectionController extends BaseController<
     if (!this.isMainnet() || this.disabled) {
       return;
     }
-    const { selectedAddress } = this.config;
-
-    let { chainId } = this.config;
-    if (typeof chainId === 'string' && isHexString(chainId)) {
-      chainId = `${parseInt(chainId, 16)}` as const;
-    } else if (typeof chainId === 'number') {
-      chainId = `${chainId}` as const;
-    }
+    const { selectedAddress, chainId } = this.config;
 
     /* istanbul ignore else */
     if (!selectedAddress) {

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import { BN, stripHexPrefix, isHexString } from 'ethereumjs-util';
+import { BN, stripHexPrefix } from 'ethereumjs-util';
 import { Mutex } from 'async-mutex';
 
 import { BaseController, BaseConfig, BaseState } from '../BaseController';
@@ -493,13 +493,6 @@ export class CollectiblesController extends BaseController<
         selectedAddress = this.config.selectedAddress;
       }
 
-      // ensure that chainid matches dec format for both detection and manual flows
-      if (typeof chainId === 'string' && isHexString(chainId)) {
-        chainId = `${parseInt(chainId, 16)}` as const;
-      } else if (typeof chainId === 'number') {
-        chainId = `${chainId}` as const;
-      }
-
       const collectibles = allCollectibles[selectedAddress]?.[chainId] || [];
 
       const existingEntry: Collectible | undefined = collectibles.find(
@@ -577,13 +570,6 @@ export class CollectiblesController extends BaseController<
       } else {
         chainId = this.config.chainId;
         selectedAddress = this.config.selectedAddress;
-      }
-
-      // ensure that chainid matches dec format for both detection and manual flows
-      if (typeof chainId === 'string' && isHexString(chainId)) {
-        chainId = `${parseInt(chainId, 16)}` as const;
-      } else if (typeof chainId === 'number') {
-        chainId = `${chainId}` as const;
       }
 
       const collectibleContracts =


### PR DESCRIPTION
- REMOVED:

  - Removes the chainId format normalization introduced in https://github.com/MetaMask/controllers/pull/644 and adapted for in https://github.com/MetaMask/controllers/pull/648
  - This normalization was not needed and caused issues when consumers had chainId formats other than decimal.



