### PR TITLE
Fix ipfs address generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "immer": "^9.0.6",
     "isomorphic-fetch": "^3.0.0",
     "jsonschema": "^1.2.4",
+    "multiformats": "^9.5.2",
     "nanoid": "^3.1.12",
     "punycode": "^2.1.1",
     "single-call-balance-checker-abi": "^1.0.0",

--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -6,7 +6,7 @@ import {
   NetworkController,
   NetworksChainId,
 } from '../network/NetworkController';
-import { getFormattedIpfsURL } from '../util';
+import { getFormattedIpfsUrl } from '../util';
 import { AssetsContractController } from './AssetsContractController';
 import { CollectiblesController } from './CollectiblesController';
 
@@ -34,9 +34,10 @@ const CLOUDFARE_PATH = 'https://cloudflare-ipfs.com/ipfs/';
 const DEPRESSIONIST_CID_V1 =
   'bafybeidf7aw7bmnmewwj4ayq3she2jfk5jrdpp24aaucf6fddzb3cfhrvm';
 
-const DEPRESSIONIST_CLOUDFLARE_IPFS_SUBDOMAIN_PATH = getFormattedIpfsURL(
+const DEPRESSIONIST_CLOUDFLARE_IPFS_SUBDOMAIN_PATH = getFormattedIpfsUrl(
   CLOUDFARE_PATH,
-  DEPRESSIONIST_CID_V1,
+  `ipfs://${DEPRESSIONIST_CID_V1}`,
+  true
 );
 
 describe('CollectiblesController', () => {

--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -6,6 +6,7 @@ import {
   NetworkController,
   NetworksChainId,
 } from '../network/NetworkController';
+import { getFormattedIpfsURL } from '../util';
 import { AssetsContractController } from './AssetsContractController';
 import { CollectiblesController } from './CollectiblesController';
 
@@ -29,8 +30,14 @@ const OPEN_SEA_HOST = 'https://api.opensea.io';
 const OPEN_SEA_PATH = '/api/v1';
 
 const CLOUDFARE_PATH = 'https://cloudflare-ipfs.com/ipfs/';
-const DEPRESSIONIST_IPFS_PATH =
-  '/QmVChNtStZfPyV8JfKpube3eigQh5rUXqYchPgLc91tWLJ';
+
+const DEPRESSIONIST_CID_V1 =
+  'bafybeidf7aw7bmnmewwj4ayq3she2jfk5jrdpp24aaucf6fddzb3cfhrvm';
+
+const DEPRESSIONIST_CLOUDFLARE_IPFS_SUBDOMAIN_PATH = getFormattedIpfsURL(
+  CLOUDFARE_PATH,
+  DEPRESSIONIST_CID_V1,
+);
 
 describe('CollectiblesController', () => {
   let collectiblesController: CollectiblesController;
@@ -167,7 +174,7 @@ describe('CollectiblesController', () => {
         asset_contract: { schema_name: 'ERC1155' },
       });
 
-    nock(CLOUDFARE_PATH).get(DEPRESSIONIST_IPFS_PATH).reply(200, {
+    nock(DEPRESSIONIST_CLOUDFLARE_IPFS_SUBDOMAIN_PATH).get('/').reply(200, {
       name: 'name',
       image: 'image',
       description: 'description',

--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -37,7 +37,7 @@ const DEPRESSIONIST_CID_V1 =
 const DEPRESSIONIST_CLOUDFLARE_IPFS_SUBDOMAIN_PATH = getFormattedIpfsUrl(
   CLOUDFARE_PATH,
   `ipfs://${DEPRESSIONIST_CID_V1}`,
-  true
+  true,
 );
 
 describe('CollectiblesController', () => {

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -10,7 +10,7 @@ import {
   handleFetch,
   toChecksumHexAddress,
   BNToHex,
-  getIpfsUrlContentIdentifier,
+  getIpfsUrlContentIdentifierAndPath,
   getFormattedIpfsURL,
 } from '../util';
 import {
@@ -267,8 +267,8 @@ export class CollectiblesController extends BaseController<
     const standard = result[1];
 
     if (tokenURI.startsWith('ipfs://')) {
-      const contentId = getIpfsUrlContentIdentifier(tokenURI);
-      tokenURI = getFormattedIpfsURL(ipfsGateway, contentId);
+      const { cid, path } = getIpfsUrlContentIdentifierAndPath(tokenURI);
+      tokenURI = getFormattedIpfsURL(ipfsGateway, cid, path);
     }
 
     try {

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -10,8 +10,7 @@ import {
   handleFetch,
   toChecksumHexAddress,
   BNToHex,
-  getIpfsUrlContentIdentifierAndPath,
-  getFormattedIpfsURL,
+  getFormattedIpfsUrl,
 } from '../util';
 import {
   MAINNET,
@@ -134,6 +133,7 @@ export interface CollectiblesConfig extends BaseConfig {
   chainId: string;
   ipfsGateway: string;
   openSeaEnabled: boolean;
+  useIPFSSubdomains: boolean;
 }
 
 /**
@@ -258,7 +258,7 @@ export class CollectiblesController extends BaseController<
     contractAddress: string,
     tokenId: string,
   ): Promise<CollectibleMetadata> {
-    const { ipfsGateway } = this.config;
+    const { ipfsGateway, useIPFSSubdomains } = this.config;
     const result = await this.getCollectibleURIAndStandard(
       contractAddress,
       tokenId,
@@ -267,8 +267,7 @@ export class CollectiblesController extends BaseController<
     const standard = result[1];
 
     if (tokenURI.startsWith('ipfs://')) {
-      const { cid, path } = getIpfsUrlContentIdentifierAndPath(tokenURI);
-      tokenURI = getFormattedIpfsURL(ipfsGateway, cid, path);
+      tokenURI = getFormattedIpfsUrl(ipfsGateway, tokenURI, useIPFSSubdomains);
     }
 
     try {
@@ -844,6 +843,7 @@ export class CollectiblesController extends BaseController<
       chainId: '',
       ipfsGateway: IPFS_DEFAULT_GATEWAY_URL,
       openSeaEnabled: false,
+      useIPFSSubdomains: true,
     };
 
     this.defaultState = {

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -11,6 +11,7 @@ import {
   toChecksumHexAddress,
   BNToHex,
   getIpfsUrlContentIdentifier,
+  getFormattedIpfsURL,
 } from '../util';
 import {
   MAINNET,
@@ -246,16 +247,6 @@ export class CollectiblesController extends BaseController<
     return collectibleMetadata;
   }
 
-  private getValidIpfsGatewayFormat() {
-    const { ipfsGateway } = this.config;
-    if (ipfsGateway.endsWith('/ipfs/')) {
-      return ipfsGateway;
-    } else if (ipfsGateway.endsWith('/')) {
-      return `${ipfsGateway}ipfs/`;
-    }
-    return `${ipfsGateway}/ipfs/`;
-  }
-
   /**
    * Request individual collectible information from contracts that follows Metadata Interface.
    *
@@ -267,6 +258,7 @@ export class CollectiblesController extends BaseController<
     contractAddress: string,
     tokenId: string,
   ): Promise<CollectibleMetadata> {
+    const { ipfsGateway } = this.config;
     const result = await this.getCollectibleURIAndStandard(
       contractAddress,
       tokenId,
@@ -276,7 +268,7 @@ export class CollectiblesController extends BaseController<
 
     if (tokenURI.startsWith('ipfs://')) {
       const contentId = getIpfsUrlContentIdentifier(tokenURI);
-      tokenURI = `${this.getValidIpfsGatewayFormat()}${contentId}`;
+      tokenURI = getFormattedIpfsURL(ipfsGateway, contentId);
     }
 
     try {

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -20,6 +20,8 @@ const IPFS_CID_V0 = 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n';
 const IPFS_CID_V1 =
   'bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku';
 
+const IFPS_GATEWAY = 'dweb.link'
+
 const MAX_FEE_PER_GAS = 'maxFeePerGas';
 const MAX_PRIORITY_FEE_PER_GAS = 'maxPriorityFeePerGas';
 const GAS_PRICE = 'gasPrice';
@@ -1068,6 +1070,20 @@ describe('util', () => {
       expect(() =>
         util.validateMinimumIncrease('0x7162a5ca', '0x5916a6d6'),
       ).not.toThrow(Error);
+    });
+  });
+
+  describe('getFormattedIpfsURL', () => {
+    it('should return ipfs url when passed ipfsGateway without protocol prefix', () => {
+      expect(util.getFormattedIpfsURL(IFPS_GATEWAY, IPFS_CID_V1)).toStrictEqual(
+        `https://${IPFS_CID_V1}.ipfs.${IFPS_GATEWAY}`,
+      );
+    });
+
+    it('should return ipfs url when passed ipfsGateway with protocol prefix', () => {
+      expect(util.getFormattedIpfsURL(`https://${IFPS_GATEWAY}`, IPFS_CID_V1)).toStrictEqual(
+        `https://${IPFS_CID_V1}.ipfs.${IFPS_GATEWAY}`,
+      );
     });
   });
 

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -14,8 +14,11 @@ const VALID = '4e1fF7229BDdAf0A73DF183a88d9c3a04cc975e0';
 const SOME_API = 'https://someapi.com';
 const SOME_FAILING_API = 'https://somefailingapi.com';
 
-const DEFAULT_IPFS_URL = 'ipfs://0001';
-const ALTERNATIVE_IPFS_URL = 'ipfs://ipfs/0001';
+const DEFAULT_IPFS_URL_FORMAT = 'ipfs://';
+const ALTERNATIVE_IPFS_URL_FORMAT = 'ipfs://ipfs/';
+const IPFS_CID_V0 = 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n';
+const IPFS_CID_V1 =
+  'bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku';
 
 const MAX_FEE_PER_GAS = 'maxFeePerGas';
 const MAX_PRIORITY_FEE_PER_GAS = 'maxPriorityFeePerGas';
@@ -1069,16 +1072,28 @@ describe('util', () => {
   });
 
   describe('getIpfsUrlContentIdentifier', () => {
-    it('should return content identifier from default ipfs url', () => {
-      expect(util.getIpfsUrlContentIdentifier(DEFAULT_IPFS_URL)).toStrictEqual(
-        '0001',
-      );
+    it('should return content identifier from default ipfs url format', () => {
+      expect(
+        util.getIpfsUrlContentIdentifier(
+          `${DEFAULT_IPFS_URL_FORMAT}${IPFS_CID_V0}`,
+        ),
+      ).toStrictEqual(IPFS_CID_V1);
     });
 
-    it('should return content identifier from alternative ipfs url', () => {
+    it('should return content identifier from alternative ipfs url format', () => {
       expect(
-        util.getIpfsUrlContentIdentifier(ALTERNATIVE_IPFS_URL),
-      ).toStrictEqual('0001');
+        util.getIpfsUrlContentIdentifier(
+          `${ALTERNATIVE_IPFS_URL_FORMAT}${IPFS_CID_V0}`,
+        ),
+      ).toStrictEqual(IPFS_CID_V1);
+    });
+
+    it('should return unchanged content identifier if already v1', () => {
+      expect(
+        util.getIpfsUrlContentIdentifier(
+          `${DEFAULT_IPFS_URL_FORMAT}${IPFS_CID_V1}`,
+        ),
+      ).toStrictEqual(IPFS_CID_V1);
     });
 
     it('should return url if its not a ipfs standard url', () => {

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1073,22 +1073,46 @@ describe('util', () => {
     });
   });
 
-  describe('getFormattedIpfsURL', () => {
+  // describe('getFormattedIpfsURL', () => {
+  //   it('should return a correctly formatted ipfs url when passed ipfsGateway without protocol prefix and no path', () => {
+  //     expect(util.getFormattedIpfsURL(IFPS_GATEWAY, IPFS_CID_V1)).toStrictEqual(
+  //       `https://${IPFS_CID_V1}.ipfs.${IFPS_GATEWAY}`,
+  //     );
+  //   });
+
+  //   it('should return a correctly formatted ipfs url when passed ipfsGateway with protocol prefix and no path', () => {
+  //     expect(
+  //       util.getFormattedIpfsURL(`https://${IFPS_GATEWAY}`, IPFS_CID_V1),
+  //     ).toStrictEqual(`https://${IPFS_CID_V1}.ipfs.${IFPS_GATEWAY}`);
+  //   });
+
+  //   it('should return correctly formatted url when passed a path', () => {
+  //     expect(
+  //       util.getFormattedIpfsURL(
+  //         `https://${IFPS_GATEWAY}`,
+  //         IPFS_CID_V1,
+  //         '/test',
+  //       ),
+  //     ).toStrictEqual(`https://${IPFS_CID_V1}.ipfs.${IFPS_GATEWAY}/test`);
+  //   });
+  // });
+
+  describe('getFormattedIpfsUrl', () => {
     it('should return a correctly formatted ipfs url when passed ipfsGateway without protocol prefix and no path', () => {
-      expect(util.getFormattedIpfsURL(IFPS_GATEWAY, IPFS_CID_V1)).toStrictEqual(
+      expect(util.getFormattedIpfsUrl(IFPS_GATEWAY, IPFS_CID_V1)).toStrictEqual(
         `https://${IPFS_CID_V1}.ipfs.${IFPS_GATEWAY}`,
       );
     });
 
     it('should return a correctly formatted ipfs url when passed ipfsGateway with protocol prefix and no path', () => {
       expect(
-        util.getFormattedIpfsURL(`https://${IFPS_GATEWAY}`, IPFS_CID_V1),
+        util.getFormattedIpfsUrl(`https://${IFPS_GATEWAY}`, IPFS_CID_V1),
       ).toStrictEqual(`https://${IPFS_CID_V1}.ipfs.${IFPS_GATEWAY}`);
     });
 
     it('should return correctly formatted url when passed a path', () => {
       expect(
-        util.getFormattedIpfsURL(
+        util.getFormattedIpfsUrl(
           `https://${IFPS_GATEWAY}`,
           IPFS_CID_V1,
           '/test',

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1127,7 +1127,7 @@ describe('util', () => {
         util.getIpfsUrlContentIdentifierAndPath(
           `${DEFAULT_IPFS_URL_FORMAT}${IPFS_CID_V1}/test/test/test`,
         ),
-      ).toStrictEqual({ cid: IPFS_CID_V1, path: 'test/test/test' });
+      ).toStrictEqual({ cid: IPFS_CID_V1, path: '/test/test/test' });
     });
 
     it('should throw error if passed a non ipfs url', () => {

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1157,11 +1157,23 @@ describe('util', () => {
     });
   });
 
+  describe('addUrlProtocolPrefix', () => {
+    it('should return a URL with https:// prepended if input URL does not already have it', () => {
+      expect(util.addUrlProtocolPrefix(IFPS_GATEWAY)).toStrictEqual(
+        `https://${IFPS_GATEWAY}`,
+      );
+    });
+
+    it('should return a URL as is if https:// is already prepended', () => {
+      expect(util.addUrlProtocolPrefix(SOME_API)).toStrictEqual(SOME_API);
+    });
+  });
+
   describe('getIpfsCIDv1AndPath', () => {
     it('should return content identifier from default ipfs url format', () => {
       expect(
         util.getIpfsCIDv1AndPath(`${DEFAULT_IPFS_URL_FORMAT}${IPFS_CID_V0}`),
-      ).toStrictEqual({ cid: IPFS_CID_V1, path: '' });
+      ).toStrictEqual({ cid: IPFS_CID_V1, path: undefined });
     });
 
     it('should return content identifier from alternative ipfs url format', () => {
@@ -1169,13 +1181,13 @@ describe('util', () => {
         util.getIpfsCIDv1AndPath(
           `${ALTERNATIVE_IPFS_URL_FORMAT}${IPFS_CID_V0}`,
         ),
-      ).toStrictEqual({ cid: IPFS_CID_V1, path: '' });
+      ).toStrictEqual({ cid: IPFS_CID_V1, path: undefined });
     });
 
     it('should return unchanged content identifier if already v1', () => {
       expect(
         util.getIpfsCIDv1AndPath(`${DEFAULT_IPFS_URL_FORMAT}${IPFS_CID_V1}`),
-      ).toStrictEqual({ cid: IPFS_CID_V1, path: '' });
+      ).toStrictEqual({ cid: IPFS_CID_V1, path: undefined });
     });
 
     it('should return a path when url contains one', () => {

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -20,7 +20,7 @@ const IPFS_CID_V0 = 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n';
 const IPFS_CID_V1 =
   'bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku';
 
-const IFPS_GATEWAY = 'dweb.link'
+const IFPS_GATEWAY = 'dweb.link';
 
 const MAX_FEE_PER_GAS = 'maxFeePerGas';
 const MAX_PRIORITY_FEE_PER_GAS = 'maxPriorityFeePerGas';
@@ -1074,47 +1074,65 @@ describe('util', () => {
   });
 
   describe('getFormattedIpfsURL', () => {
-    it('should return ipfs url when passed ipfsGateway without protocol prefix', () => {
+    it('should return a correctly formatted ipfs url when passed ipfsGateway without protocol prefix and no path', () => {
       expect(util.getFormattedIpfsURL(IFPS_GATEWAY, IPFS_CID_V1)).toStrictEqual(
         `https://${IPFS_CID_V1}.ipfs.${IFPS_GATEWAY}`,
       );
     });
 
-    it('should return ipfs url when passed ipfsGateway with protocol prefix', () => {
-      expect(util.getFormattedIpfsURL(`https://${IFPS_GATEWAY}`, IPFS_CID_V1)).toStrictEqual(
-        `https://${IPFS_CID_V1}.ipfs.${IFPS_GATEWAY}`,
-      );
+    it('should return a correctly formatted ipfs url when passed ipfsGateway with protocol prefix and no path', () => {
+      expect(
+        util.getFormattedIpfsURL(`https://${IFPS_GATEWAY}`, IPFS_CID_V1),
+      ).toStrictEqual(`https://${IPFS_CID_V1}.ipfs.${IFPS_GATEWAY}`);
+    });
+
+    it('should return correctly formatted url when passed a path', () => {
+      expect(
+        util.getFormattedIpfsURL(
+          `https://${IFPS_GATEWAY}`,
+          IPFS_CID_V1,
+          '/test',
+        ),
+      ).toStrictEqual(`https://${IPFS_CID_V1}.ipfs.${IFPS_GATEWAY}/test`);
     });
   });
 
-  describe('getIpfsUrlContentIdentifier', () => {
+  describe('getIpfsUrlContentIdentifierAndPath', () => {
     it('should return content identifier from default ipfs url format', () => {
       expect(
-        util.getIpfsUrlContentIdentifier(
+        util.getIpfsUrlContentIdentifierAndPath(
           `${DEFAULT_IPFS_URL_FORMAT}${IPFS_CID_V0}`,
         ),
-      ).toStrictEqual(IPFS_CID_V1);
+      ).toStrictEqual({ cid: IPFS_CID_V1, path: '' });
     });
 
     it('should return content identifier from alternative ipfs url format', () => {
       expect(
-        util.getIpfsUrlContentIdentifier(
+        util.getIpfsUrlContentIdentifierAndPath(
           `${ALTERNATIVE_IPFS_URL_FORMAT}${IPFS_CID_V0}`,
         ),
-      ).toStrictEqual(IPFS_CID_V1);
+      ).toStrictEqual({ cid: IPFS_CID_V1, path: '' });
     });
 
     it('should return unchanged content identifier if already v1', () => {
       expect(
-        util.getIpfsUrlContentIdentifier(
+        util.getIpfsUrlContentIdentifierAndPath(
           `${DEFAULT_IPFS_URL_FORMAT}${IPFS_CID_V1}`,
         ),
-      ).toStrictEqual(IPFS_CID_V1);
+      ).toStrictEqual({ cid: IPFS_CID_V1, path: '' });
     });
 
-    it('should return url if its not a ipfs standard url', () => {
-      expect(util.getIpfsUrlContentIdentifier(SOME_API)).toStrictEqual(
-        SOME_API,
+    it('should return a path when url contains one', () => {
+      expect(
+        util.getIpfsUrlContentIdentifierAndPath(
+          `${DEFAULT_IPFS_URL_FORMAT}${IPFS_CID_V1}/test/test/test`,
+        ),
+      ).toStrictEqual({ cid: IPFS_CID_V1, path: 'test/test/test' });
+    });
+
+    it('should throw error if passed a non ipfs url', () => {
+      expect(() => util.getIpfsUrlContentIdentifierAndPath(SOME_API)).toThrow(
+        'this method should not be used with non ipfs urls',
       );
     });
   });

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1075,14 +1075,22 @@ describe('util', () => {
 
   describe('getFormattedIpfsUrl', () => {
     it('should return a correctly formatted subdomained ipfs url when passed ipfsGateway without protocol prefix, no path and subdomainSupported argument set to true', () => {
-      expect(util.getFormattedIpfsUrl(IFPS_GATEWAY, `${DEFAULT_IPFS_URL_FORMAT}${IPFS_CID_V1}`, true)).toStrictEqual(
-        `https://${IPFS_CID_V1}.ipfs.${IFPS_GATEWAY}`,
-      );
+      expect(
+        util.getFormattedIpfsUrl(
+          IFPS_GATEWAY,
+          `${DEFAULT_IPFS_URL_FORMAT}${IPFS_CID_V1}`,
+          true,
+        ),
+      ).toStrictEqual(`https://${IPFS_CID_V1}.ipfs.${IFPS_GATEWAY}`);
     });
 
-     it('should return a correctly formatted subdomained ipfs url when passed ipfsGateway with protocol prefix, a cidv0 no path and subdomainSupported argument set to true', () => {
+    it('should return a correctly formatted subdomained ipfs url when passed ipfsGateway with protocol prefix, a cidv0 and no path and subdomainSupported argument set to true', () => {
       expect(
-        util.getFormattedIpfsUrl(`https://${IFPS_GATEWAY}`, `${DEFAULT_IPFS_URL_FORMAT}${IPFS_CID_V0}`, true),
+        util.getFormattedIpfsUrl(
+          `https://${IFPS_GATEWAY}`,
+          `${DEFAULT_IPFS_URL_FORMAT}${IPFS_CID_V0}`,
+          true,
+        ),
       ).toStrictEqual(`https://${IPFS_CID_V1}.ipfs.${IFPS_GATEWAY}`);
     });
 
@@ -1124,7 +1132,7 @@ describe('util', () => {
           `${DEFAULT_IPFS_URL_FORMAT}${IPFS_CID_V0}/test`,
         ),
       ).toStrictEqual(`${IPFS_CID_V0}/test`);
-    })
+    });
 
     it('should return content identifier string from default ipfs url format if no path preset', () => {
       expect(
@@ -1132,7 +1140,7 @@ describe('util', () => {
           `${DEFAULT_IPFS_URL_FORMAT}${IPFS_CID_V0}`,
         ),
       ).toStrictEqual(IPFS_CID_V0);
-    })
+    });
 
     it('should return content identifier string from alternate ipfs url format', () => {
       expect(
@@ -1140,21 +1148,19 @@ describe('util', () => {
           `${ALTERNATIVE_IPFS_URL_FORMAT}${IPFS_CID_V0}`,
         ),
       ).toStrictEqual(IPFS_CID_V0);
-    })
+    });
 
     it('should throw error if passed a non ipfs url', () => {
       expect(() => util.removeIpfsProtocolPrefix(SOME_API)).toThrow(
         'this method should not be used with non ipfs urls',
       );
     });
-  })
+  });
 
   describe('getIpfsCIDv1AndPath', () => {
     it('should return content identifier from default ipfs url format', () => {
       expect(
-        util.getIpfsCIDv1AndPath(
-          `${DEFAULT_IPFS_URL_FORMAT}${IPFS_CID_V0}`,
-        ),
+        util.getIpfsCIDv1AndPath(`${DEFAULT_IPFS_URL_FORMAT}${IPFS_CID_V0}`),
       ).toStrictEqual({ cid: IPFS_CID_V1, path: '' });
     });
 
@@ -1168,9 +1174,7 @@ describe('util', () => {
 
     it('should return unchanged content identifier if already v1', () => {
       expect(
-        util.getIpfsCIDv1AndPath(
-          `${DEFAULT_IPFS_URL_FORMAT}${IPFS_CID_V1}`,
-        ),
+        util.getIpfsCIDv1AndPath(`${DEFAULT_IPFS_URL_FORMAT}${IPFS_CID_V1}`),
       ).toStrictEqual({ cid: IPFS_CID_V1, path: '' });
     });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -770,21 +770,20 @@ export function validateMinimumIncrease(proposed: string, min: string) {
 }
 
 /**
- * removes ipfs protocol prefix from ipfs-url
+ * Removes ipfs protocol prefix from ipfs-url.
  *
  * @param ipfsUrl - ipfs url
  * @returns Ipfs content identifier and (possibly) path in a string
- * @throws Will throw if the url passed is not ipfs.
+ * @throws will throw if the url passed is not ipfs.
  */
 export function removeIpfsProtocolPrefix(ipfsUrl: string) {
   if (ipfsUrl.startsWith('ipfs://ipfs/')) {
     return ipfsUrl.replace('ipfs://ipfs/', '');
   } else if (ipfsUrl.startsWith('ipfs://')) {
     return ipfsUrl.replace('ipfs://', '');
-  } else {
-    // this method should not be used with non-ipfs urls (i.e. startsWith('ipfs://') === true)
-    throw new Error('this method should not be used with non ipfs urls');
   }
+  // this method should not be used with non-ipfs urls (i.e. startsWith('ipfs://') === true)
+  throw new Error('this method should not be used with non ipfs urls');
 }
 
 /**
@@ -839,14 +838,13 @@ export function getFormattedIpfsUrl(
   subdomainSupported: boolean,
 ): string {
   if (subdomainSupported) {
-    const gatewayHost = new URL(addUrlProtocolPrefix(ipfsGateway))?.host;
+    const gatewayHost = new URL(addUrlProtocolPrefix(ipfsGateway)).host;
     const { cid, path } = getIpfsCIDv1AndPath(ipfsUrl);
-    return `https://${cid}.ipfs.${gatewayHost}${path ?? ''}`;
-  } else {
-    const cidAndPath = removeIpfsProtocolPrefix(ipfsUrl);
-    const gateway = ipfsGateway.endsWith('/ipfs/')
-      ? ipfsGateway
-      : `${ipfsGateway}/ipfs/`;
-    return `${gateway}${cidAndPath}`;
+    return `https://${cid}.ipfs.${gatewayHost}${path}`;
   }
+  const cidAndPath = removeIpfsProtocolPrefix(ipfsUrl);
+  const gateway = ipfsGateway.endsWith('/ipfs/')
+    ? ipfsGateway
+    : `${ipfsGateway}/ipfs/`;
+  return `${gateway}${cidAndPath}`;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -790,10 +790,9 @@ export function getIpfsUrlContentIdentifierAndPath(
 
   // check if there is a path
   // (CID is everything preceding first forward slash, path is everything after)
-  const splitURL = ipfsUrl.split('/');
-  const cid = splitURL[0];
-  splitURL.shift();
-  const path = splitURL.join('/');
+  const index = ipfsUrl.indexOf('/');
+  const cid = index !== -1 ? ipfsUrl.substring(0, index) : ipfsUrl;
+  const path = index !== -1 ? ipfsUrl.substring(index) : '';
 
   // we want to ensure that the CID is v1 (https://docs.ipfs.io/concepts/content-addressing/#identifier-formats)
   return {

--- a/src/util.ts
+++ b/src/util.ts
@@ -805,7 +805,7 @@ export function getIpfsCIDv1AndPath(
   const path = index !== -1 ? url.substring(index) : undefined;
 
   // We want to ensure that the CID is v1 (https://docs.ipfs.io/concepts/content-addressing/#identifier-formats)
-  // for security and use with IPFS subdomains
+  // because most cid v0s appear to be incompatible with IPFS subdomains
   return {
     cid: CID.parse(cid).toV1().toString(),
     path,

--- a/src/util.ts
+++ b/src/util.ts
@@ -769,6 +769,13 @@ export function validateMinimumIncrease(proposed: string, min: string) {
   throw new Error(errorMsg);
 }
 
+/**
+ * removes ipfs protocol prefix from ipfs-url
+ *
+ * @param ipfsUrl - ipfs url
+ * @returns Ipfs content identifier and (possibly) path in a string
+ * @throws Will throw if the url passed is not ipfs.
+ */
 export function removeIpfsProtocolPrefix(ipfsUrl: string) {
   if (ipfsUrl.startsWith('ipfs://ipfs/')) {
     return ipfsUrl.replace('ipfs://ipfs/', '');
@@ -781,7 +788,7 @@ export function removeIpfsProtocolPrefix(ipfsUrl: string) {
 }
 
 /**
- * Extracts content identifier from ipfs url.
+ * Extracts content identifier and path from ipfs url.
  *
  * @param ipfsUrl - ipfs url
  * @returns Ipfs content identifier as string and path as string.
@@ -817,23 +824,6 @@ export function addUrlProtocolPrefix(urlString: string): string {
   }
   return urlString;
 }
-
-/**
- * Formats url correctly for use retrieving assets hosted on IPFS.
- *
- * @param ipfsGateway - the user preferred ipfsGateway.
- * @param contentIdentifier - the asset's cid.
- * @param path - optional sub path
- * @returns string.
- */
-// export function getFormattedIpfsURL(
-//   ipfsGateway: string,
-//   contentIdentifier: string,
-//   path?: string,
-// ) {
-//   const gatewayHost = new URL(addUrlProtocolPrefix(ipfsGateway));
-//   return `https://${contentIdentifier}.ipfs.${gatewayHost.host}${path ?? ''}`;
-// }
 
 /**
  * Formats url correctly for use retrieving assets hosted on IPFS.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5730,6 +5730,11 @@ ms@2.1.2, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+multiformats@^9.5.2:
+  version "9.5.2"
+  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-9.5.2.tgz#14256e49bac8b6a5ecb558c4d3c347bb94873d65"
+  integrity sha512-nLQ9s7YOVtZdeNOVvCkNyFiZdS3wyq0gvCIvdm7Zy1zw3zBoColJKjMkIPXNdTqT7ruuq+G7HrezIN0cXiAZ0w==
+
 nan@2.13.2:
   version "2.13.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"


### PR DESCRIPTION
- CHANGED:

  -**BREAKING** Change IPFS URL generation to use subdomains and [cidV1s over cidV0s](https://docs.ipfs.io/concepts/content-addressing/#identifier-formats), in order to enhance [origin based security](https://docs.ipfs.io/concepts/ipfs-gateway/#subdomain) in our use of IPFS assets
   - Consumers using IPFS Gateway which do not support subdomain formats will need to set the new config value 'useIPFSSubdomains' on CollectiblesController to false in order to have continued IPFS resolution support. 

