### PR TITLE
Add caller-specified error for ApprovalController.clear

### DIFF
--- a/src/approval/ApprovalController.test.ts
+++ b/src/approval/ApprovalController.test.ts
@@ -325,7 +325,7 @@ describe('approval controller', () => {
       approvalController.reject('2', new Error('foo'));
       expect(approvalController.getTotalApprovalCount()).toStrictEqual(2);
 
-      approvalController.clear();
+      approvalController.clear(new EthereumRpcError(1, 'clear'));
       expect(approvalController.getTotalApprovalCount()).toStrictEqual(0);
     });
   });
@@ -589,7 +589,9 @@ describe('approval controller', () => {
     });
 
     it('does nothing if state is already empty', () => {
-      expect(() => approvalController.clear()).not.toThrow();
+      expect(() =>
+        approvalController.clear(new EthereumRpcError(1, 'clear')),
+      ).not.toThrow();
     });
 
     it('deletes existing entries', async () => {
@@ -603,7 +605,7 @@ describe('approval controller', () => {
         .add({ id: 'foo3', origin: 'fizz.buzz', type: 'myType' })
         .catch((_error) => undefined);
 
-      approvalController.clear();
+      approvalController.clear(new EthereumRpcError(1, 'clear'));
 
       expect(approvalController.state[STORE_KEY]).toStrictEqual({});
       expect(rejectSpy.callCount).toStrictEqual(2);

--- a/src/approval/ApprovalController.test.ts
+++ b/src/approval/ApprovalController.test.ts
@@ -1,4 +1,4 @@
-import { errorCodes } from 'eth-rpc-errors';
+import { errorCodes, EthereumRpcError } from 'eth-rpc-errors';
 import sinon from 'sinon';
 import { ControllerMessenger } from '../ControllerMessenger';
 import {
@@ -607,6 +607,19 @@ describe('approval controller', () => {
 
       expect(approvalController.state[STORE_KEY]).toStrictEqual({});
       expect(rejectSpy.callCount).toStrictEqual(2);
+    });
+
+    it('rejects existing entries with a caller-specified error', async () => {
+      const rejectPromise = approvalController.add({
+        id: 'foo2',
+        origin: 'bar.baz',
+        type: 'myType',
+      });
+
+      approvalController.clear(new EthereumRpcError(1000, 'foo'));
+      await expect(rejectPromise).rejects.toThrow(
+        new EthereumRpcError(1000, 'foo'),
+      );
     });
   });
 

--- a/src/approval/ApprovalController.ts
+++ b/src/approval/ApprovalController.ts
@@ -74,7 +74,7 @@ export type GetApprovalsState = {
 
 export type ClearApprovalRequests = {
   type: `${typeof controllerName}:clearRequests`;
-  handler: () => void;
+  handler: (error: EthereumRpcError<unknown>) => void;
 };
 
 type AddApprovalOptions = {
@@ -406,11 +406,7 @@ export class ApprovalController extends BaseController<
    * @param rejectionError - The EthereumRpcError to reject the approval
    * requests with.
    */
-  clear(
-    rejectionError: EthereumRpcError<any> = ethErrors.rpc.resourceUnavailable(
-      'The request was rejected; please try again.',
-    ),
-  ): void {
+  clear(rejectionError: EthereumRpcError<unknown>): void {
     for (const id of this._approvals.keys()) {
       this.reject(id, rejectionError);
     }

--- a/src/approval/ApprovalController.ts
+++ b/src/approval/ApprovalController.ts
@@ -1,5 +1,5 @@
 import type { Patch } from 'immer';
-import { ethErrors } from 'eth-rpc-errors';
+import { EthereumRpcError, ethErrors } from 'eth-rpc-errors';
 import { nanoid } from 'nanoid';
 
 import { BaseController, Json } from '../BaseControllerV2';
@@ -402,12 +402,15 @@ export class ApprovalController extends BaseController<
 
   /**
    * Rejects and deletes all approval requests.
+   *
+   * @param rejectionError - The EthereumRpcError to reject the approval
+   * requests with.
    */
-  clear(): void {
-    const rejectionError = ethErrors.rpc.resourceUnavailable(
+  clear(
+    rejectionError: EthereumRpcError<any> = ethErrors.rpc.resourceUnavailable(
       'The request was rejected; please try again.',
-    );
-
+    ),
+  ): void {
     for (const id of this._approvals.keys()) {
       this.reject(id, rejectionError);
     }


### PR DESCRIPTION
`ApprovalController.clear` rejects all pending approvals and clears the state of the controller. This PR adds a "rejection error" parameter to the `clear` method and removes the default error. We decided that there is no reasonable default for this method, since `clear` may be called for a variety of different reasons.