### PR TITLE
Add finish to EIP-1559 v2 gas estimate code 

### DIFF
--- a/src/gas/fetchBlockFeeHistory.test.ts
+++ b/src/gas/fetchBlockFeeHistory.test.ts
@@ -308,4 +308,65 @@ describe('fetchBlockFeeHistory', () => {
       expect(feeHistory).toStrictEqual([]);
     });
   });
+
+  describe('given includeNextBlock = true', () => {
+    const latestBlockNumber = 3;
+    const numberOfRequestedBlocks = 3;
+
+    it('includes an extra block with an estimated baseFeePerGas', async () => {
+      when(mockedQuery)
+        .calledWith(ethQuery, 'eth_feeHistory', [
+          toHex(numberOfRequestedBlocks),
+          toHex(latestBlockNumber),
+          [],
+        ])
+        .mockResolvedValue({
+          oldestBlock: toHex(1),
+          // Note that this array contains 6 items when we requested 5. Per
+          // <https://github.com/ethereum/go-ethereum/blob/57a3fab8a75eeb9c2f4fab770b73b51b9fe672c5/eth/gasprice/feehistory.go#L191-L192>,
+          // baseFeePerGas will always include an extra item which is the calculated base fee for the
+          // next (future) block.
+          baseFeePerGas: [
+            toHex(10_000_000_000),
+            toHex(20_000_000_000),
+            toHex(30_000_000_000),
+            toHex(40_000_000_000),
+          ],
+          gasUsedRatio: [0.1, 0.2, 0.3],
+        });
+
+      const feeHistory = await fetchBlockFeeHistory({
+        ethQuery,
+        numberOfBlocks: numberOfRequestedBlocks,
+        includeNextBlock: true,
+      });
+
+      expect(feeHistory).toStrictEqual([
+        {
+          number: new BN(1),
+          baseFeePerGas: new BN(10_000_000_000),
+          gasUsedRatio: 0.1,
+          priorityFeesByPercentile: {},
+        },
+        {
+          number: new BN(2),
+          baseFeePerGas: new BN(20_000_000_000),
+          gasUsedRatio: 0.2,
+          priorityFeesByPercentile: {},
+        },
+        {
+          number: new BN(3),
+          baseFeePerGas: new BN(30_000_000_000),
+          gasUsedRatio: 0.3,
+          priorityFeesByPercentile: {},
+        },
+        {
+          number: new BN(4),
+          baseFeePerGas: new BN(40_000_000_000),
+          gasUsedRatio: null,
+          priorityFeesByPercentile: null,
+        },
+      ]);
+    });
+  });
 });

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory.test.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory.test.ts
@@ -93,7 +93,7 @@ describe('fetchGasEstimatesViaEthFeeHistory', () => {
           },
         },
       ],
-      tinyRangeWithPending: [
+      tinyRangeWithNextBlock: [
         {
           number: new BN(5),
           baseFeePerGas: new BN(1),
@@ -112,6 +112,23 @@ describe('fetchGasEstimatesViaEthFeeHistory', () => {
             10: new BN('0'),
             95: new BN('0'),
           },
+        },
+      ],
+      latestWithNextBlock: [
+        {
+          number: new BN(6),
+          baseFeePerGas: new BN(1),
+          gasUsedRatio: 1,
+          priorityFeesByPercentile: {
+            10: new BN('0'),
+            95: new BN('0'),
+          },
+        },
+        {
+          number: new BN(7),
+          baseFeePerGas: new BN(1),
+          gasUsedRatio: null,
+          priorityFeesByPercentile: null,
         },
       ],
     };
@@ -143,28 +160,8 @@ describe('fetchGasEstimatesViaEthFeeHistory', () => {
     const networkCongestion = 0.5;
 
     mockedFetchLatestBlock.mockResolvedValue(latestBlock);
-    mockedBlockFeeHistoryDatasetFetcherConstructor.prototype.forLongRange.mockResolvedValue(
-      blocksByDataset.longRange,
-    );
-
-    mockedBlockFeeHistoryDatasetFetcherConstructor.prototype.forMediumRange.mockResolvedValue(
-      blocksByDataset.mediumRange,
-    );
-
-    mockedBlockFeeHistoryDatasetFetcherConstructor.prototype.forSmallRange.mockResolvedValue(
-      blocksByDataset.smallRange,
-    );
-
-    mockedBlockFeeHistoryDatasetFetcherConstructor.prototype.forTinyRange.mockResolvedValue(
-      blocksByDataset.tinyRange,
-    );
-
-    mockedBlockFeeHistoryDatasetFetcherConstructor.prototype.forTinyRangeWithPending.mockResolvedValue(
-      blocksByDataset.tinyRangeWithPending,
-    );
-
-    mockedBlockFeeHistoryDatasetFetcherConstructor.prototype.forLatest.mockResolvedValue(
-      blocksByDataset.latest,
+    mockedBlockFeeHistoryDatasetFetcherConstructor.prototype.forAll.mockResolvedValue(
+      blocksByDataset,
     );
 
     when(mockedCalculateGasFeeEstimatesForPriorityLevels)
@@ -176,7 +173,7 @@ describe('fetchGasEstimatesViaEthFeeHistory', () => {
       .mockReturnValue(historicalBaseFeeRange);
 
     when(mockedCalculateBaseFeeTrend)
-      .calledWith(blocksByDataset.tinyRangeWithPending)
+      .calledWith(blocksByDataset.latestWithNextBlock)
       .mockReturnValue(baseFeeTrend);
 
     when(mockedCalculatePriorityFeeRange)

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory/calculateGasFeeEstimatesForPriorityLevels.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory/calculateGasFeeEstimatesForPriorityLevels.ts
@@ -1,7 +1,7 @@
 import { BN } from 'ethereumjs-util';
 import { fromWei } from 'ethjs-unit';
 import { Eip1559GasFee, GasFeeEstimates } from '../GasFeeController';
-import { FeeHistoryBlock } from '../fetchBlockFeeHistory';
+import { ExistingFeeHistoryBlock } from '../fetchBlockFeeHistory';
 import { GWEI } from '../../constants';
 import medianOf from './medianOf';
 
@@ -54,7 +54,7 @@ const SETTINGS_BY_PRIORITY_LEVEL = {
  */
 function calculateEstimatesForPriorityLevel(
   priorityLevel: PriorityLevel,
-  blocks: FeeHistoryBlock<Percentile>[],
+  blocks: ExistingFeeHistoryBlock<Percentile>[],
 ): Eip1559GasFee {
   const settings = SETTINGS_BY_PRIORITY_LEVEL[priorityLevel];
 
@@ -95,7 +95,7 @@ function calculateEstimatesForPriorityLevel(
  * @returns The estimates.
  */
 export default function calculateGasFeeEstimatesForPriorityLevels(
-  blocks: FeeHistoryBlock<Percentile>[],
+  blocks: ExistingFeeHistoryBlock<Percentile>[],
 ): Pick<GasFeeEstimates, PriorityLevel> {
   return PRIORITY_LEVELS.reduce((obj, priorityLevel) => {
     const gasEstimatesForPriorityLevel = calculateEstimatesForPriorityLevel(

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory/calculatePriorityFeeRange.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory/calculatePriorityFeeRange.ts
@@ -1,7 +1,7 @@
 import { BN } from 'ethereumjs-util';
 import { fromWei } from 'ethjs-unit';
 import { GWEI } from '../../constants';
-import { FeeHistoryBlock } from '../fetchBlockFeeHistory';
+import { ExistingFeeHistoryBlock } from '../fetchBlockFeeHistory';
 import { FeeRange } from './types';
 
 /**
@@ -14,7 +14,7 @@ import { FeeRange } from './types';
  * @returns The range.
  */
 export default function calculatePriorityFeeRange(
-  blocks: FeeHistoryBlock<10 | 95>[],
+  blocks: ExistingFeeHistoryBlock<10 | 95>[],
 ): FeeRange {
   const sortedLowPriorityFees = blocks
     .map((block) => block.priorityFeesByPercentile[10])

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory/calculatePriorityFeeTrend.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory/calculatePriorityFeeTrend.ts
@@ -1,5 +1,5 @@
 import { BN } from 'ethereumjs-util';
-import { FeeHistoryBlock } from '../fetchBlockFeeHistory';
+import { ExistingFeeHistoryBlock } from '../fetchBlockFeeHistory';
 
 /**
  * Given a collection of blocks, returns an indicator of whether the base fee is moving up, down, or
@@ -9,7 +9,7 @@ import { FeeHistoryBlock } from '../fetchBlockFeeHistory';
  * @returns The indicator ("up", "down", or "level").
  */
 export default function calculatePriorityFeeTrend(
-  blocks: FeeHistoryBlock<50>[],
+  blocks: ExistingFeeHistoryBlock<50>[],
 ) {
   const priorityFees = blocks
     .map((block) => block.priorityFeesByPercentile[50])

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory/fetchLatestBlock.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory/fetchLatestBlock.ts
@@ -1,16 +1,26 @@
-import { query } from '../../util';
+import { query, fromHex } from '../../util';
 import { EthBlock, EthQuery } from './types';
 
 /**
  * Returns information about the latest completed block.
  *
  * @param ethQuery - An EthQuery instance
+ * @param includeFullTransactionData - Whether or not to include all data for transactions as
+ * opposed to merely hashes. False by default.
  * @returns The block.
  */
 export default async function fetchLatestBlock(
   ethQuery: EthQuery,
+  includeFullTransactionData = false,
 ): Promise<EthBlock> {
   const blockNumber = await query(ethQuery, 'blockNumber');
-  const block = await query(ethQuery, 'getBlockByNumber', blockNumber);
-  return block;
+  const block = await query(ethQuery, 'getBlockByNumber', [
+    blockNumber,
+    includeFullTransactionData,
+  ]);
+  return {
+    ...block,
+    number: fromHex(block.number),
+    baseFeePerGas: fromHex(block.baseFeePerGas),
+  };
 }


### PR DESCRIPTION
After integration-testing both the fallback and non-fallback code
responsible for pulling gas fee estimates, there were a few fixes
needed:

* `ethQuery.latestBlock()` was not being called correctly.
* For some datapoints, we need to pull the estimated base fee for the
  next block. This adds an `includeNextBlock` option to
  `fetchBlockFeeHistory` so that this is possible. It also splits the
  `FeeHistoryBlock` type into two types, because the next block won't
  have information about gas used ratios or priority fees (because there
  is no transaction data associated with the next block, as it doesn't
  exist).
* One of the allowed values for the `endBlock` argument to
  `fetchBlockFeeHistory` was "pending". This breaks
  `fetchBlockFeeHistory`, so this has been removed.
* Some of the datapoints were based on the wrong data, so this has been
  corrected as well.