### PR TITLE
Use stripHexPrefix from ethereumjs-util and ditch ethjs-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "ethereumjs-wallet": "^1.0.1",
     "ethers": "^5.4.1",
     "ethjs-unit": "^0.1.6",
-    "ethjs-util": "^0.1.6",
     "human-standard-collectible-abi": "^1.0.2",
     "human-standard-multi-collectible-abi": "^1.0.4",
     "human-standard-token-abi": "^2.0.0",

--- a/src/dependencies.d.ts
+++ b/src/dependencies.d.ts
@@ -16,8 +16,6 @@ declare module 'eth-query';
 
 declare module 'ethjs-provider-http';
 
-declare module 'ethjs-util';
-
 declare module 'ethjs-unit';
 
 declare module 'human-standard-collectible-abi';

--- a/src/keyring/KeyringController.ts
+++ b/src/keyring/KeyringController.ts
@@ -3,8 +3,8 @@ import {
   bufferToHex,
   isValidPrivate,
   toBuffer,
+  stripHexPrefix,
 } from 'ethereumjs-util';
-import { stripHexPrefix } from 'ethjs-util';
 import {
   normalize as normalizeAddress,
   signTypedData,

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,8 +5,8 @@ import {
   bufferToHex,
   BN,
   toChecksumAddress,
+  stripHexPrefix,
 } from 'ethereumjs-util';
-import { stripHexPrefix } from 'ethjs-util';
 import { fromWei, toWei } from 'ethjs-unit';
 import { ethErrors } from 'eth-rpc-errors';
 import ensNamehash from 'eth-ens-namehash';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3574,7 +3574,7 @@ ethjs-util@0.1.3:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
 
-ethjs-util@0.1.6, ethjs-util@^0.1.3, ethjs-util@^0.1.6:
+ethjs-util@0.1.6, ethjs-util@^0.1.3:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ethjs-util/-/ethjs-util-0.1.6.tgz#f308b62f185f9fe6237132fb2a9818866a5cd536"
   integrity sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**PR Title**

- Use `stripHexPrefix` from `ethereumjs-util` instead of `ethjs-util`

**Description**

_this imports a utility function from a different dependency so we can remove `ethjs-util`_
