### PR TITLE
Add method to check and update collectible ownership state

### DIFF
--- a/src/assets/CollectibleDetectionController.test.ts
+++ b/src/assets/CollectibleDetectionController.test.ts
@@ -304,6 +304,7 @@ describe('CollectibleDetectionController', () => {
         tokenId: '2574',
         standard: 'ERC721',
         favorite: false,
+        isCurrentlyOwned: true,
       },
     ]);
   });
@@ -343,6 +344,7 @@ describe('CollectibleDetectionController', () => {
         standard: 'ERC721',
         tokenId: '2573',
         favorite: false,
+        isCurrentlyOwned: true,
       },
       {
         address: '0xebE4e5E773AFD2bAc25De0cFafa084CFb3cBf1eD',
@@ -352,6 +354,7 @@ describe('CollectibleDetectionController', () => {
         tokenId: '2574',
         standard: 'ERC721',
         favorite: false,
+        isCurrentlyOwned: true,
       },
     ]);
   });
@@ -453,6 +456,7 @@ describe('CollectibleDetectionController', () => {
       tokenId: '2574',
       standard: 'ERC721',
       favorite: false,
+      isCurrentlyOwned: true,
     };
     const collectibleGG2574 = {
       address: '0xCE7ec4B2DfB30eB6c0BB5656D33aAd6BFb4001Fc',
@@ -462,6 +466,7 @@ describe('CollectibleDetectionController', () => {
       tokenId: '2574',
       standard: 'ERC721',
       favorite: false,
+      isCurrentlyOwned: true,
     };
     const collectibleII2577 = {
       address: '0x0B0fa4fF58D28A88d63235bd0756EDca69e49e6d',
@@ -471,6 +476,7 @@ describe('CollectibleDetectionController', () => {
       tokenId: '2577',
       standard: 'ERC721',
       favorite: false,
+      isCurrentlyOwned: true,
     };
     const collectibleContractHH = {
       address: '0xebE4e5E773AFD2bAc25De0cFafa084CFb3cBf1eD',

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -46,10 +46,12 @@ import { compareCollectiblesMetadata } from './assetsUtil';
  * @property animationOriginal - URI of the original animation associated with this collectible
  * @property externalLink - External link containing additional information
  * @property creator - The collectible owner information object
+ * @property isCurrentlyOwned - Boolean indicating whether the address/chainId combination where it's currently stored currently owns this collectible
  */
 export interface Collectible extends CollectibleMetadata {
   tokenId: string;
   address: string;
+  isCurrentlyOwned?: boolean;
 }
 
 /**
@@ -587,8 +589,9 @@ export class CollectiblesController extends BaseController<
       const newEntry: Collectible = {
         address,
         tokenId,
-        ...collectibleMetadata,
         favorite: existingEntry?.favorite || false,
+        isCurrentlyOwned: true,
+        ...collectibleMetadata,
       };
 
       const newCollectibles = [...collectibles, newEntry];
@@ -1034,6 +1037,50 @@ export class CollectiblesController extends BaseController<
    */
   clearIgnoredCollectibles() {
     this.update({ ignoredCollectibles: [] });
+  }
+
+  /**
+   * Checks whether Collectibles associated with current selectedAddress/chainId combination are still owned by the user
+   * And updates the isCurrentlyOwned value on each accordingly.
+   */
+  async checkAndUpdateCollectiblesOwnershipStatus() {
+    const { allCollectibles } = this.state;
+    const { chainId, selectedAddress } = this.config;
+    const collectibles = allCollectibles[selectedAddress]?.[chainId] || [];
+    const updatedCollectibles = await Promise.all(
+      collectibles.map(async (collectible) => {
+        const { address, tokenId } = collectible;
+        let isOwned = collectible.isCurrentlyOwned;
+        try {
+          isOwned = await this.isCollectibleOwner(
+            selectedAddress,
+            address,
+            tokenId,
+          );
+        } catch (error) {
+          if (!error.message.includes('Unable to verify ownership')) {
+            throw error;
+          }
+        }
+        collectible.isCurrentlyOwned = isOwned;
+
+        return collectible;
+      }),
+    );
+
+    const addressCollectibles = allCollectibles[selectedAddress];
+    const newAddressCollectibles = {
+      ...addressCollectibles,
+      ...{ [chainId]: updatedCollectibles },
+    };
+    const newAllCollectiblesState = {
+      ...allCollectibles,
+      ...{ [selectedAddress]: newAddressCollectibles },
+    };
+
+    this.update({
+      allCollectibles: newAllCollectiblesState,
+    });
   }
 
   /**

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -1068,19 +1068,10 @@ export class CollectiblesController extends BaseController<
       }),
     );
 
-    const addressCollectibles = allCollectibles[selectedAddress];
-    const newAddressCollectibles = {
-      ...addressCollectibles,
-      ...{ [chainId]: updatedCollectibles },
-    };
-    const newAllCollectiblesState = {
-      ...allCollectibles,
-      ...{ [selectedAddress]: newAddressCollectibles },
-    };
-
-    this.update({
-      allCollectibles: newAllCollectiblesState,
-    });
+    this.updateNestedCollectibleState(
+      updatedCollectibles,
+      ALL_COLLECTIBLES_STATE_KEY,
+    );
   }
 
   /**


### PR DESCRIPTION
- ADDED:

  - Adds `isCurrentlyOwned` field to the Collectible Type and a method to check whether each of the collectibles in state collection associated with currently active address/chainId combination are still owned by this address and update this new `isCurrentlyOwned` value accordingly.

