### PR TITLE
Enhance checkAndUpdateSingleCollectibleOwnershipStatus to use use passed accountParams for selectedAddress and chainId

### DIFF
--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -25,6 +25,7 @@ const MAINNET_PROVIDER = new HttpProvider(
   'https://mainnet.infura.io/v3/ad3a368836ff4596becc3be8e2f137ac',
 );
 const OWNER_ADDRESS = '0x5a3CA5cD63807Ce5e4d7841AB32Ce6B6d9BbBa2D';
+const SECOND_OWNER_ADDRESS = '0x500017171kasdfbou081';
 
 const OPEN_SEA_HOST = 'https://api.opensea.io';
 const OPEN_SEA_PATH = '/api/v1';
@@ -1300,6 +1301,70 @@ describe('CollectiblesController', () => {
         ).toBe(true);
 
         expect(updatedCollectible.isCurrentlyOwned).toBe(false);
+      });
+
+      it('should check whether the passed collectible is still owned by the the selectedAddress/chainId combination passed in the accountParams argument and update its isCurrentlyOwned property in state, when the currently configured selectedAddress/chainId are different from those passed', async () => {
+        const firstNetworkType = 'rinkeby';
+        const secondNetworkType = 'ropsten';
+
+        preferences.update({ selectedAddress: OWNER_ADDRESS });
+        network.update({
+          provider: {
+            type: firstNetworkType,
+            chainId: NetworksChainId[firstNetworkType],
+          },
+        });
+
+        const { selectedAddress, chainId } = collectiblesController.config;
+        const collectible = {
+          address: '0x02',
+          tokenId: '1',
+          name: 'name',
+          image: 'image',
+          description: 'description',
+          standard: 'standard',
+          favorite: false,
+        };
+
+        await collectiblesController.addCollectible(
+          collectible.address,
+          collectible.tokenId,
+          collectible,
+        );
+
+        expect(
+          collectiblesController.state.allCollectibles[selectedAddress][
+            chainId
+          ][0].isCurrentlyOwned,
+        ).toBe(true);
+
+        sandbox.restore();
+        sandbox
+          .stub(collectiblesController, 'isCollectibleOwner' as any)
+          .returns(false);
+
+        preferences.update({ selectedAddress: SECOND_OWNER_ADDRESS });
+        network.update({
+          provider: {
+            type: secondNetworkType,
+            chainId: NetworksChainId[secondNetworkType],
+          },
+        });
+
+        await collectiblesController.checkAndUpdateSingleCollectibleOwnershipStatus(
+          collectible,
+          false,
+          {
+            userAddress: OWNER_ADDRESS,
+            chainId: NetworksChainId[firstNetworkType],
+          },
+        );
+
+        expect(
+          collectiblesController.state.allCollectibles[OWNER_ADDRESS][
+            NetworksChainId[firstNetworkType]
+          ][0].isCurrentlyOwned,
+        ).toBe(false);
       });
     });
   });


### PR DESCRIPTION
- ADDED:

  - Adds an optional parameter `accountParams` (an object containing a `userAddress` and `chainId`) to method `checkAndUpdateSingleCollectibleOwnershipStatus`, which when uses the passed `userAddress` and `chainId` to find the collectible that should be updated.

