### PR TITLE
Add NotificationControllerV2

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,4 +37,14 @@ export * from './assets/TokenDetectionController';
 export * from './assets/CollectibleDetectionController';
 export * from './permissions';
 export * from './subject-metadata';
+export {
+  NotificationController as NotificationControllerV2,
+  NotificationArgs,
+  NotificationMessenger,
+  NotificationType,
+  ShowNotification,
+  NotificationState as NotificationStateV2,
+  NotificationStateChange,
+  GetNotificationState,
+} from './notification/NotificationControllerV2';
 export { util };

--- a/src/notification/NotificationControllerV2.test.ts
+++ b/src/notification/NotificationControllerV2.test.ts
@@ -32,8 +32,11 @@ describe('NotificationControllerV2', () => {
   jest.useFakeTimers();
   it('uses platform to show a notification', () => {
     const messenger = getRestrictedMessenger();
-    const platform = { _showNotifiction: jest.fn() };
-    const controller = new NotificationController({ platform, messenger });
+    const showNativeNotification = jest.fn();
+    const controller = new NotificationController({
+      showNativeNotification,
+      messenger,
+    });
     const origin = 'snap_test';
     const message = 'foo';
     const result = controller.show(origin, {
@@ -41,14 +44,14 @@ describe('NotificationControllerV2', () => {
       message,
     });
     expect(result).toBe(true);
-    expect(platform._showNotifiction).toHaveBeenCalledWith(origin, message);
+    expect(showNativeNotification).toHaveBeenCalledWith(origin, message);
   });
 
   it('returns false if rate-limited', () => {
     const messenger = getRestrictedMessenger();
-    const platform = { _showNotifiction: jest.fn() };
+    const showNativeNotification = jest.fn();
     const controller = new NotificationController({
-      platform,
+      showNativeNotification,
       messenger,
       rateLimitCount: 1,
     });
@@ -64,15 +67,15 @@ describe('NotificationControllerV2', () => {
     });
     expect(result).toBe(true);
     expect(result2).toBe(false);
-    expect(platform._showNotifiction).toHaveBeenCalledTimes(1);
-    expect(platform._showNotifiction).toHaveBeenCalledWith(origin, message);
+    expect(showNativeNotification).toHaveBeenCalledTimes(1);
+    expect(showNativeNotification).toHaveBeenCalledWith(origin, message);
   });
 
   it('rate limit is reset after timeout', () => {
     const messenger = getRestrictedMessenger();
-    const platform = { _showNotifiction: jest.fn() };
+    const showNativeNotification = jest.fn();
     const controller = new NotificationController({
-      platform,
+      showNativeNotification,
       messenger,
       rateLimitCount: 1,
     });
@@ -89,7 +92,7 @@ describe('NotificationControllerV2', () => {
       message,
     });
     expect(result2).toBe(true);
-    expect(platform._showNotifiction).toHaveBeenCalledTimes(2);
-    expect(platform._showNotifiction).toHaveBeenCalledWith(origin, message);
+    expect(showNativeNotification).toHaveBeenCalledTimes(2);
+    expect(showNativeNotification).toHaveBeenCalledWith(origin, message);
   });
 });

--- a/src/notification/NotificationControllerV2.test.ts
+++ b/src/notification/NotificationControllerV2.test.ts
@@ -30,7 +30,9 @@ function getRestrictedMessenger() {
   return messenger;
 }
 
-const SNAP_NAME = 'Test Snap Name'
+const SNAP_NAME = 'Test Snap Name';
+const origin = 'snap_test';
+const message = 'foo';
 
 const subjectMetadata = {
   snap_test: { origin: 'snap_test', name: SNAP_NAME },
@@ -51,13 +53,12 @@ describe('NotificationControllerV2', () => {
       showNativeNotification,
       messenger,
     });
-    const origin = 'snap_test';
-    const message = 'foo';
-    const result = controller.show(origin, {
-      type: NotificationType.Native,
-      message,
-    });
-    expect(result).toBe(true);
+    expect(
+      controller.show(origin, {
+        type: NotificationType.Native,
+        message,
+      }),
+    ).toBe(true);
     expect(showNativeNotification).toHaveBeenCalledWith(SNAP_NAME, message);
     expect(callActionSpy).toHaveBeenCalledTimes(1);
     expect(callActionSpy).toHaveBeenCalledWith(
@@ -78,13 +79,12 @@ describe('NotificationControllerV2', () => {
       showNativeNotification,
       messenger,
     });
-    const origin = 'snap_test';
-    const message = 'foo';
-    const result = controller.show(origin, {
-      type: NotificationType.Native,
-      message,
-    });
-    expect(result).toBe(true);
+    expect(
+      controller.show(origin, {
+        type: NotificationType.Native,
+        message,
+      }),
+    ).toBe(true);
     expect(showNativeNotification).toHaveBeenCalledWith(origin, message);
     expect(callActionSpy).toHaveBeenCalledTimes(1);
     expect(callActionSpy).toHaveBeenCalledWith(
@@ -105,18 +105,20 @@ describe('NotificationControllerV2', () => {
       messenger,
       rateLimitCount: 1,
     });
-    const origin = 'snap_test';
-    const message = 'foo';
-    const result = controller.show(origin, {
-      type: NotificationType.Native,
-      message,
-    });
-    const result2 = controller.show(origin, {
-      type: NotificationType.Native,
-      message,
-    });
-    expect(result).toBe(true);
-    expect(result2).toBe(false);
+
+    expect(
+      controller.show(origin, {
+        type: NotificationType.Native,
+        message,
+      }),
+    ).toBe(true);
+
+    expect(
+      controller.show(origin, {
+        type: NotificationType.Native,
+        message,
+      }),
+    ).toBe(false);
     expect(showNativeNotification).toHaveBeenCalledTimes(1);
     expect(showNativeNotification).toHaveBeenCalledWith(SNAP_NAME, message);
     expect(callActionSpy).toHaveBeenCalledTimes(1);
@@ -138,19 +140,19 @@ describe('NotificationControllerV2', () => {
       messenger,
       rateLimitCount: 1,
     });
-    const origin = 'snap_test';
-    const message = 'foo';
-    const result = controller.show(origin, {
-      type: NotificationType.Native,
-      message,
-    });
-    expect(result).toBe(true);
+    expect(
+      controller.show(origin, {
+        type: NotificationType.Native,
+        message,
+      }),
+    ).toBe(true);
     jest.runAllTimers();
-    const result2 = controller.show(origin, {
-      type: NotificationType.Native,
-      message,
-    });
-    expect(result2).toBe(true);
+    expect(
+      controller.show(origin, {
+        type: NotificationType.Native,
+        message,
+      }),
+    ).toBe(true);
     expect(showNativeNotification).toHaveBeenCalledTimes(2);
     expect(showNativeNotification).toHaveBeenCalledWith(SNAP_NAME, message);
     expect(callActionSpy).toHaveBeenCalledTimes(2);

--- a/src/notification/NotificationControllerV2.test.ts
+++ b/src/notification/NotificationControllerV2.test.ts
@@ -1,0 +1,73 @@
+import { ControllerMessenger } from '../ControllerMessenger';
+import {
+  GetNotificationState,
+  NotificationController,
+  NotificationStateChange,
+} from './NotificationControllerV2';
+
+const name = 'NotificationControllerV2';
+function getRestrictedMessenger() {
+  const controllerMessenger = new ControllerMessenger<
+    GetNotificationState,
+    NotificationStateChange
+  >();
+  const messenger = controllerMessenger.getRestricted<
+    typeof name,
+    never,
+    never
+  >({
+    name,
+  });
+  return messenger;
+}
+
+describe('NotificationControllerV2', () => {
+  jest.useFakeTimers();
+  it('uses platform to show a notification', () => {
+    const messenger = getRestrictedMessenger();
+    const platform = { _showNotifiction: jest.fn() };
+    const controller = new NotificationController({ platform, messenger });
+    const origin = 'snap_test';
+    const message = 'foo';
+    const result = controller.show(origin, { type: 'native', message });
+    expect(result).toBe(true);
+    expect(platform._showNotifiction).toHaveBeenCalledWith(origin, message);
+  });
+
+  it('returns false if rate-limited', () => {
+    const messenger = getRestrictedMessenger();
+    const platform = { _showNotifiction: jest.fn() };
+    const controller = new NotificationController({
+      platform,
+      messenger,
+      rateLimitCount: 1,
+    });
+    const origin = 'snap_test';
+    const message = 'foo';
+    const result = controller.show(origin, { type: 'native', message });
+    const result2 = controller.show(origin, { type: 'native', message });
+    expect(result).toBe(true);
+    expect(result2).toBe(false);
+    expect(platform._showNotifiction).toHaveBeenCalledTimes(1);
+    expect(platform._showNotifiction).toHaveBeenCalledWith(origin, message);
+  });
+
+  it('rate limit is reset after timeout', () => {
+    const messenger = getRestrictedMessenger();
+    const platform = { _showNotifiction: jest.fn() };
+    const controller = new NotificationController({
+      platform,
+      messenger,
+      rateLimitCount: 1,
+    });
+    const origin = 'snap_test';
+    const message = 'foo';
+    const result = controller.show(origin, { type: 'native', message });
+    expect(result).toBe(true);
+    jest.runAllTimers();
+    const result2 = controller.show(origin, { type: 'native', message });
+    expect(result2).toBe(true);
+    expect(platform._showNotifiction).toHaveBeenCalledTimes(2);
+    expect(platform._showNotifiction).toHaveBeenCalledWith(origin, message);
+  });
+});

--- a/src/notification/NotificationControllerV2.test.ts
+++ b/src/notification/NotificationControllerV2.test.ts
@@ -25,7 +25,10 @@ function getRestrictedMessenger() {
   >({
     name,
     // @ts-expect-error Missing types for now
-    allowedActions: ['SubjectMetadataController:getState'],
+    allowedActions: [
+      'SubjectMetadataController:getState',
+      'NotificationControllerV2:show',
+    ],
   });
   return messenger;
 }
@@ -40,6 +43,27 @@ const subjectMetadata = {
 
 describe('NotificationControllerV2', () => {
   jest.useFakeTimers();
+
+  it('action: NotificationControllerV2:show', async () => {
+    const messenger = getRestrictedMessenger();
+
+    const showNativeNotification = jest.fn();
+    const controller = new NotificationController({
+      showNativeNotification,
+      messenger,
+    });
+    const showSpy = jest
+      .spyOn(controller, 'show')
+      .mockImplementationOnce(() => true);
+    expect(
+      await messenger.call('NotificationControllerV2:show', origin, {
+        type: NotificationType.Native,
+        message,
+      }),
+    ).toBe(true);
+    expect(showSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('uses showNativeNotification to show a notification', () => {
     const messenger = getRestrictedMessenger();
     const callActionSpy = jest

--- a/src/notification/NotificationControllerV2.test.ts
+++ b/src/notification/NotificationControllerV2.test.ts
@@ -6,6 +6,12 @@ import {
 } from './NotificationControllerV2';
 
 const name = 'NotificationControllerV2';
+
+/**
+ * Constructs a restricted controller messenger.
+ *
+ * @returns A restricted controller messenger.
+ */
 function getRestrictedMessenger() {
   const controllerMessenger = new ControllerMessenger<
     GetNotificationState,

--- a/src/notification/NotificationControllerV2.test.ts
+++ b/src/notification/NotificationControllerV2.test.ts
@@ -3,6 +3,7 @@ import {
   GetNotificationState,
   NotificationController,
   NotificationStateChange,
+  NotificationType,
 } from './NotificationControllerV2';
 
 const name = 'NotificationControllerV2';
@@ -35,7 +36,10 @@ describe('NotificationControllerV2', () => {
     const controller = new NotificationController({ platform, messenger });
     const origin = 'snap_test';
     const message = 'foo';
-    const result = controller.show(origin, { type: 'native', message });
+    const result = controller.show(origin, {
+      type: NotificationType.Native,
+      message,
+    });
     expect(result).toBe(true);
     expect(platform._showNotifiction).toHaveBeenCalledWith(origin, message);
   });
@@ -50,8 +54,14 @@ describe('NotificationControllerV2', () => {
     });
     const origin = 'snap_test';
     const message = 'foo';
-    const result = controller.show(origin, { type: 'native', message });
-    const result2 = controller.show(origin, { type: 'native', message });
+    const result = controller.show(origin, {
+      type: NotificationType.Native,
+      message,
+    });
+    const result2 = controller.show(origin, {
+      type: NotificationType.Native,
+      message,
+    });
     expect(result).toBe(true);
     expect(result2).toBe(false);
     expect(platform._showNotifiction).toHaveBeenCalledTimes(1);
@@ -68,10 +78,16 @@ describe('NotificationControllerV2', () => {
     });
     const origin = 'snap_test';
     const message = 'foo';
-    const result = controller.show(origin, { type: 'native', message });
+    const result = controller.show(origin, {
+      type: NotificationType.Native,
+      message,
+    });
     expect(result).toBe(true);
     jest.runAllTimers();
-    const result2 = controller.show(origin, { type: 'native', message });
+    const result2 = controller.show(origin, {
+      type: NotificationType.Native,
+      message,
+    });
     expect(result2).toBe(true);
     expect(platform._showNotifiction).toHaveBeenCalledTimes(2);
     expect(platform._showNotifiction).toHaveBeenCalledWith(origin, message);

--- a/src/notification/NotificationControllerV2.ts
+++ b/src/notification/NotificationControllerV2.ts
@@ -1,0 +1,163 @@
+/* eslint-disable prettier/prettier */
+import type { Patch } from 'immer';
+
+import { BaseController } from '../BaseControllerV2';
+
+import type { RestrictedControllerMessenger } from '../ControllerMessenger';
+
+/**
+ * @type NotificationState
+ * @property requests - Object containing number of requests in a given interval and a timeout id
+ */
+export type NotificationState = {
+  requests: Record<string, NotificationRequests>;
+};
+
+interface NotificationRequests {
+  count: number;
+  timeoutId?: NodeJS.Timeout;
+}
+
+export enum NotificationType {
+  native = 'native',
+}
+
+export interface NotificationArgs {
+  /**
+   * @todo
+   */
+  type: NotificationType;
+
+  /**
+   * @todo
+   */
+  message: string;
+}
+
+const name = 'NotificationControllerV2';
+
+export type NotificationStateChange = {
+  type: `${typeof name}:stateChange`;
+  payload: [NotificationState, Patch[]];
+};
+
+export type GetNotificationState = {
+  type: `${typeof name}:getState`;
+  handler: () => NotificationState;
+};
+
+type NotificationMessenger = RestrictedControllerMessenger<
+  typeof name,
+  GetNotificationState,
+  NotificationStateChange,
+  never,
+  never
+>;
+
+const metadata = {
+  requests: { persist: false, anonymous: false },
+};
+
+const defaultState = {
+  requests: {},
+};
+
+/**
+ * Controller that handles showing notifications to the user and rate limiting origins
+ */
+export class NotificationController extends BaseController<
+  typeof name,
+  NotificationState,
+  NotificationMessenger
+> {
+  private platform;
+
+  private rateLimitTimeout;
+
+  private rateLimitCount;
+
+  /**
+   * Creates a NotificationController instance.
+   *
+   * @param options - Constructor options.
+   * @param options.messenger - A reference to the messaging system.
+   * @param options.state - Initial state to set on this controller.
+   * @param options.platform - The ExtensionPlatform defined in the extension
+   * @param options.rateLimitTimeout The time window in which the rate limit is applied
+   * @param options.rateLimitCount The amount of notifications an origin can show in the rate limit time window
+   */
+  constructor({
+    rateLimitTimeout = 5000,
+    rateLimitCount = 3,
+    messenger,
+    state,
+    platform,
+  }: {
+    rateLimitTimeout?: number;
+    rateLimitCount?: number;
+    messenger: NotificationMessenger;
+    state?: Partial<NotificationState>;
+    platform: any; // ExtensionPlatform from extension
+  }) {
+    super({
+      name,
+      metadata,
+      messenger,
+      state: { ...defaultState, ...state },
+    });
+    this.platform = platform;
+    this.rateLimitTimeout = rateLimitTimeout;
+    this.rateLimitCount = rateLimitCount;
+  }
+
+  /**
+   * Shows a notification if origin is not rate-limited
+   *
+   * @param origin The origin trying to send a notification
+   * @param args Notification arguments, containing the notification message etc.
+   * @returns False if rate-limited, true if not
+   */
+  show(origin: string, args: NotificationArgs) {
+    if (this._isRateLimited(origin)) {
+      return false;
+    }
+    this._recordRequest(origin);
+
+    switch (args.type) {
+      case NotificationType.native:
+        this.platform._showNotifiction(origin, args.message);
+        break;
+      default:
+        throw new Error('Invalid notification type');
+    }
+
+    return true;
+  }
+
+  _isRateLimited(origin: string) {
+    return this.state.requests[origin]?.count >= this.rateLimitCount;
+  }
+
+  _recordRequest(origin: string) {
+    this.update((state) => {
+      if (!(origin in state.requests)) {
+        state.requests[origin] = {
+          count: 1,
+          timeoutId: setTimeout(
+            () => this._resetRequestCount(origin),
+            this.rateLimitTimeout,
+          ),
+        };
+      } else {
+        state.requests[origin].count += 1;
+      }
+    });
+  }
+
+  _resetRequestCount(origin: string) {
+    this.update((state) => {
+      state.requests[origin].count = 0;
+      state.requests[origin].timeoutId = undefined;
+    });
+  }
+}

--- a/src/notification/NotificationControllerV2.ts
+++ b/src/notification/NotificationControllerV2.ts
@@ -50,7 +50,7 @@ export type ControllerActions = GetNotificationState | ShowNotification;
 
 type AllowedActions = GetSubjectMetadataState;
 
-type NotificationMessenger = RestrictedControllerMessenger<
+export type NotificationMessenger = RestrictedControllerMessenger<
   typeof name,
   ControllerActions | AllowedActions,
   NotificationStateChange,

--- a/src/notification/NotificationControllerV2.ts
+++ b/src/notification/NotificationControllerV2.ts
@@ -13,7 +13,7 @@ export type NotificationState = {
 };
 
 export enum NotificationType {
-  native = 'native',
+  Native = 'native',
 }
 
 export interface NotificationArgs {
@@ -118,7 +118,7 @@ export class NotificationController extends BaseController<
     this._recordRequest(origin);
 
     switch (args.type) {
-      case NotificationType.native:
+      case NotificationType.Native:
         this.platform._showNotifiction(origin, args.message);
         break;
       default:

--- a/src/notification/NotificationControllerV2.ts
+++ b/src/notification/NotificationControllerV2.ts
@@ -40,11 +40,14 @@ export type GetNotificationState = {
   handler: () => NotificationState;
 };
 
+// @ts-expect-error @todo Import when other PR is merged
+type AllowedActions = GetSubjectMetadataState;
+
 type NotificationMessenger = RestrictedControllerMessenger<
   typeof name,
   GetNotificationState,
   NotificationStateChange,
-  never,
+  AllowedActions['type'],
   never
 >;
 
@@ -122,11 +125,12 @@ export class NotificationController extends BaseController<
     this._recordRequest(origin);
 
     // @todo Missing types
-    const subjectMetadata = this.messagingSystem.call(
+    const subjectMetadataState = this.messagingSystem.call(
       'SubjectMetadataController:getState',
     );
 
-    const originMetadata = subjectMetadata[origin];
+    // @ts-expect-error @todo Import when other PR is merged
+    const originMetadata = subjectMetadataState.subjectMetadata[origin];
 
     switch (args.type) {
       case NotificationType.Native:

--- a/src/notification/NotificationControllerV2.ts
+++ b/src/notification/NotificationControllerV2.ts
@@ -19,12 +19,12 @@ export enum NotificationType {
 
 export interface NotificationArgs {
   /**
-   * @todo
+   * Enum type to determine notification type. Currently only supports 'native'.
    */
   type: NotificationType;
 
   /**
-   * @todo
+   * A message to show on the notification.
    */
   message: string;
 }
@@ -91,6 +91,7 @@ export class NotificationController extends BaseController<
    * @param options.rateLimitCount - The amount of notifications an origin can show in the rate limit time window
    */
   constructor({
+    // @todo Pick some sane defaults for this
     rateLimitTimeout = 5000,
     rateLimitCount = 3,
     messenger,
@@ -156,10 +157,21 @@ export class NotificationController extends BaseController<
     return true;
   }
 
+  /**
+   * Checks whether a given origin is rate limited.
+   *
+   * @param origin - The origin trying to send a notification
+   * @returns True if rate-limited
+   */
   _isRateLimited(origin: string) {
     return this.state.requests[origin] >= this.rateLimitCount;
   }
 
+  /**
+   * Records that an origin has made a request to show a notification. For rate limiting purposes.
+   *
+   * @param origin - The origin trying to send a notification
+   */
   _recordRequest(origin: string) {
     this.update((state) => {
       state.requests[origin] = (state.requests[origin] ?? 0) + 1;
@@ -167,6 +179,11 @@ export class NotificationController extends BaseController<
     });
   }
 
+  /**
+   * Resets the request for a given origin. For rate limiting purposes.
+   *
+   * @param origin - The origin in question
+   */
   _resetRequestCount(origin: string) {
     this.update((state) => {
       state.requests[origin] = 0;

--- a/src/notification/NotificationControllerV2.ts
+++ b/src/notification/NotificationControllerV2.ts
@@ -3,6 +3,7 @@ import type { Patch } from 'immer';
 import { BaseController } from '../BaseControllerV2';
 
 import type { RestrictedControllerMessenger } from '../ControllerMessenger';
+import type { GetSubjectMetadataState } from '../subject-metadata';
 
 /**
  * @type NotificationState
@@ -47,12 +48,11 @@ export type ShowNotification = {
 
 export type ControllerActions = GetNotificationState | ShowNotification;
 
-// @ts-expect-error @todo Import when other PR is merged
 type AllowedActions = GetSubjectMetadataState;
 
 type NotificationMessenger = RestrictedControllerMessenger<
   typeof name,
-  ControllerActions,
+  ControllerActions | AllowedActions,
   NotificationStateChange,
   AllowedActions['type'],
   never
@@ -118,7 +118,7 @@ export class NotificationController extends BaseController<
     this.rateLimitCount = rateLimitCount;
 
     this.messagingSystem.registerActionHandler(
-      `${name}:show`,
+      `${name}:show` as const,
       (origin: string, args: NotificationArgs) => this.show(origin, args),
     );
   }
@@ -136,12 +136,10 @@ export class NotificationController extends BaseController<
     }
     this._recordRequest(origin);
 
-    // @todo Missing types
     const subjectMetadataState = this.messagingSystem.call(
       'SubjectMetadataController:getState',
     );
 
-    // @ts-expect-error @todo Import when other PR is merged
     const originMetadata = subjectMetadataState.subjectMetadata[origin];
 
     switch (args.type) {

--- a/src/notification/NotificationControllerV2.ts
+++ b/src/notification/NotificationControllerV2.ts
@@ -40,12 +40,19 @@ export type GetNotificationState = {
   handler: () => NotificationState;
 };
 
+export type ShowNotification = {
+  type: `${typeof name}:show`;
+  handler: NotificationController['show'];
+};
+
+export type ControllerActions = GetNotificationState | ShowNotification;
+
 // @ts-expect-error @todo Import when other PR is merged
 type AllowedActions = GetSubjectMetadataState;
 
 type NotificationMessenger = RestrictedControllerMessenger<
   typeof name,
-  GetNotificationState,
+  ControllerActions,
   NotificationStateChange,
   AllowedActions['type'],
   never
@@ -109,6 +116,11 @@ export class NotificationController extends BaseController<
     this.showNativeNotification = showNativeNotification;
     this.rateLimitTimeout = rateLimitTimeout;
     this.rateLimitCount = rateLimitCount;
+
+    this.messagingSystem.registerActionHandler(
+      `${name}:show`,
+      (origin: string, args: NotificationArgs) => this.show(origin, args),
+    );
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Added `NotificationControllerV2 `. A new controller for handling _actual_ notifications. The previous version should not be deprecated, but should instead be renamed when this is taken in to use (as it handles another use case).

- ADDED:
  - Added `NotificationControllerV2
    - Initial implementation only supports native extensions
    - Supports rate-limiting by origin

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented

<!--
**Issue**

Resolves #???
-->
