### PR TITLE
**BREAKING**: Fetch and return token image as part of `getDetails` calls on ERC721Standard and ERC1155Standard

### DIFF
--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -91,7 +91,10 @@ describe('ComposableController', () => {
     it('should compose controller state', () => {
       const preferencesController = new PreferencesController();
       const networkController = new NetworkController();
-      const assetContractController = new AssetsContractController();
+      const assetContractController = new AssetsContractController({
+        onPreferencesStateChange: (listener) =>
+          preferencesController.subscribe(listener),
+      });
       const collectiblesController = new CollectiblesController({
         onPreferencesStateChange: (listener) =>
           preferencesController.subscribe(listener),
@@ -172,7 +175,10 @@ describe('ComposableController', () => {
     it('should compose flat controller state', () => {
       const preferencesController = new PreferencesController();
       const networkController = new NetworkController();
-      const assetContractController = new AssetsContractController();
+      const assetContractController = new AssetsContractController({
+        onPreferencesStateChange: (listener) =>
+          preferencesController.subscribe(listener),
+      });
       const collectiblesController = new CollectiblesController({
         onPreferencesStateChange: (listener) =>
           preferencesController.subscribe(listener),

--- a/src/assets/AssetsContractController.test.ts
+++ b/src/assets/AssetsContractController.test.ts
@@ -1,4 +1,6 @@
 import HttpProvider from 'ethjs-provider-http';
+import { IPFS_DEFAULT_GATEWAY_URL } from '../constants';
+import { PreferencesController } from '../user/PreferencesController';
 import { AssetsContractController } from './AssetsContractController';
 
 const MAINNET_PROVIDER = new HttpProvider(
@@ -16,12 +18,30 @@ const TEST_ACCOUNT_PUBLIC_ADDRESS =
   '0x5a3CA5cD63807Ce5e4d7841AB32Ce6B6d9BbBa2D';
 describe('AssetsContractController', () => {
   let assetsContract: AssetsContractController;
+  let preferences: PreferencesController;
   beforeEach(() => {
-    assetsContract = new AssetsContractController();
+    preferences = new PreferencesController();
+    assetsContract = new AssetsContractController({
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
+    });
   });
 
   it('should set default config', () => {
     expect(assetsContract.config).toStrictEqual({
+      ipfsGateway: IPFS_DEFAULT_GATEWAY_URL,
+      provider: undefined,
+    });
+  });
+
+  it('should update the ipfsGateWay config value when this value is changed in the preferences controller', () => {
+    expect(assetsContract.config).toStrictEqual({
+      ipfsGateway: IPFS_DEFAULT_GATEWAY_URL,
+      provider: undefined,
+    });
+
+    preferences.setIpfsGateway('newIPFSGateWay');
+    expect(assetsContract.config).toStrictEqual({
+      ipfsGateway: 'newIPFSGateWay',
       provider: undefined,
     });
   });

--- a/src/assets/CollectibleDetectionController.test.ts
+++ b/src/assets/CollectibleDetectionController.test.ts
@@ -23,7 +23,10 @@ describe('CollectibleDetectionController', () => {
   beforeEach(async () => {
     preferences = new PreferencesController();
     network = new NetworkController();
-    assetsContract = new AssetsContractController();
+    assetsContract = new AssetsContractController({
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
+    });
+
     collectiblesController = new CollectiblesController({
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) => network.subscribe(listener),

--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -51,7 +51,10 @@ describe('CollectiblesController', () => {
   beforeEach(() => {
     preferences = new PreferencesController();
     network = new NetworkController();
-    assetsContract = new AssetsContractController();
+    assetsContract = new AssetsContractController({
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
+    });
+
     collectiblesController = new CollectiblesController({
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) => network.subscribe(listener),

--- a/src/assets/Standards/CollectibleStandards/ERC1155/ERC1155Standard.ts
+++ b/src/assets/Standards/CollectibleStandards/ERC1155/ERC1155Standard.ts
@@ -5,6 +5,10 @@ import {
   ERC1155_METADATA_URI_INTERFACE_ID,
   ERC1155_TOKEN_RECEIVER_INTERFACE_ID,
 } from '../../../../constants';
+import {
+  getFormattedIpfsUrl,
+  timeoutFetch,
+} from '../../../../util';
 import { Web3 } from '../../standards-types';
 
 export class ERC1155Standard {
@@ -173,20 +177,38 @@ export class ERC1155Standard {
    * Query if a contract implements an interface.
    *
    * @param address - Asset contract address.
+   * @param ipfsGateway - The user's preferred IPFS gateway.
    * @param tokenId - tokenId of a given token in the contract.
    * @returns Promise resolving an object containing the standard, tokenURI, symbol and name of the given contract/tokenId pair.
    */
   getDetails = async (
     address: string,
+    ipfsGateway: string,
     tokenId?: string,
   ): Promise<{
     standard: string;
     tokenURI: string | undefined;
+    image: string | undefined;
   }> => {
     const isERC1155 = await this.contractSupportsBase1155Interface(address);
-    let tokenURI;
+    let tokenURI, image;
+
     if (tokenId) {
       tokenURI = await this.getTokenURI(address, tokenId);
+      if (tokenURI.startsWith('ipfs://')) {
+        tokenURI = getFormattedIpfsUrl(ipfsGateway, tokenURI, true);
+      }
+
+      try {
+        const response = await timeoutFetch(tokenURI);
+        const object = await response.json();
+        image = object?.image;
+        if (image?.startsWith('ipfs://')) {
+          image = getFormattedIpfsUrl(ipfsGateway, image, true);
+        }
+      } catch {
+        // ignore
+      }
     }
 
     // TODO consider querying to the metadata to get name.
@@ -194,6 +216,7 @@ export class ERC1155Standard {
       return {
         standard: ERC1155,
         tokenURI,
+        image,
       };
     }
 

--- a/src/assets/Standards/CollectibleStandards/ERC1155/ERC1155Standard.ts
+++ b/src/assets/Standards/CollectibleStandards/ERC1155/ERC1155Standard.ts
@@ -5,10 +5,7 @@ import {
   ERC1155_METADATA_URI_INTERFACE_ID,
   ERC1155_TOKEN_RECEIVER_INTERFACE_ID,
 } from '../../../../constants';
-import {
-  getFormattedIpfsUrl,
-  timeoutFetch,
-} from '../../../../util';
+import { getFormattedIpfsUrl, timeoutFetch } from '../../../../util';
 import { Web3 } from '../../standards-types';
 
 export class ERC1155Standard {

--- a/src/assets/Standards/CollectibleStandards/ERC721/ERC721Standard.test.ts
+++ b/src/assets/Standards/CollectibleStandards/ERC721/ERC721Standard.test.ts
@@ -1,6 +1,7 @@
 import Web3 from 'web3';
 import HttpProvider from 'ethjs-provider-http';
 import nock from 'nock';
+import { IPFS_DEFAULT_GATEWAY_URL } from '../../../../constants';
 import { ERC721Standard } from './ERC721Standard';
 
 const MAINNET_PROVIDER = new HttpProvider(
@@ -157,11 +158,14 @@ describe('ERC721Standard', () => {
       symbol: 'GODS',
       tokenURI: undefined,
     };
-    const details = await erc721Standard.getDetails(ERC721_GODSADDRESS);
+    const details = await erc721Standard.getDetails(
+      ERC721_GODSADDRESS,
+      IPFS_DEFAULT_GATEWAY_URL,
+    );
     expect(details).toMatchObject(expectedResult);
   });
 
-  it('should get correct details including tokenURI for a given contract (that supports the ERC721 metadata interface) with a tokenID provided', async () => {
+  it('should get correct details including tokenURI and image for a given contract (that supports the ERC721 metadata interface) with a tokenID provided when the tokenURI content is not hosted on IPFS', async () => {
     nock('https://mainnet.infura.io:443', { encodedQueryParams: true })
       .post('/v3/341eacb578dd44a1a049cbc5f6fd4035', {
         jsonrpc: '2.0',
@@ -276,25 +280,58 @@ describe('ERC721Standard', () => {
           '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002468747470733a2f2f6170692e676f6473756e636861696e65642e636f6d2f636172642f3400000000000000000000000000000000000000000000000000000000',
       });
 
+    nock('https://api.godsunchained.com', { encodedQueryParams: true })
+      .get('/card/4')
+      .reply(200, () => {
+        return {
+          image: 'https://card.godsunchained.com/?id=1329&q=4',
+        };
+      });
+
     const expectedResult = {
       name: 'Gods Unchained',
       standard: 'ERC721',
       symbol: 'GODS',
       tokenURI: 'https://api.godsunchained.com/card/4',
+      image: 'https://card.godsunchained.com/?id=1329&q=4',
     };
-    const details = await erc721Standard.getDetails(ERC721_GODSADDRESS, '4');
+
+    const details = await erc721Standard.getDetails(
+      ERC721_GODSADDRESS,
+      IPFS_DEFAULT_GATEWAY_URL,
+      '4',
+    );
     expect(details).toMatchObject(expectedResult);
   });
 
-  it('should return an object with all fields undefined except standard for a given contract (that does not support the ERC721 metadata interface) with or without a tokenID provided', async () => {
+  it('should get correct details including tokenURI and image for a given contract (that supports the ERC721 metadata interface) with a tokenID provided when the tokenURI content is hosted on IPFS', async () => {
     nock('https://mainnet.infura.io:443', { encodedQueryParams: true })
+      .post('/v3/341eacb578dd44a1a049cbc5f6fd4035', {
+        jsonrpc: '2.0',
+        id: 14,
+        method: 'eth_call',
+        params: [
+          {
+            to: '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D',
+            data:
+              '0x01ffc9a75b5e139f00000000000000000000000000000000000000000000000000000000',
+          },
+          'latest',
+        ],
+      })
+      .reply(200, {
+        jsonrpc: '2.0',
+        id: 14,
+        result:
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+      })
       .post('/v3/341eacb578dd44a1a049cbc5f6fd4035', {
         jsonrpc: '2.0',
         id: 13,
         method: 'eth_call',
         params: [
           {
-            to: '0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85',
+            to: '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D',
             data:
               '0x01ffc9a780ac58cd00000000000000000000000000000000000000000000000000000000',
           },
@@ -309,7 +346,134 @@ describe('ERC721Standard', () => {
       })
       .post('/v3/341eacb578dd44a1a049cbc5f6fd4035', {
         jsonrpc: '2.0',
-        id: 14,
+        id: 15,
+        method: 'eth_call',
+        params: [
+          {
+            to: '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D',
+            data: '0x95d89b41',
+          },
+          'latest',
+        ],
+      })
+      .reply(200, {
+        jsonrpc: '2.0',
+        id: 15,
+        result:
+          '0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000044241594300000000000000000000000000000000000000000000000000000000',
+      })
+      .post('/v3/341eacb578dd44a1a049cbc5f6fd4035', {
+        jsonrpc: '2.0',
+        id: 16,
+        method: 'eth_call',
+        params: [
+          {
+            to: '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D',
+            data: '0x06fdde03',
+          },
+          'latest',
+        ],
+      })
+      .reply(200, {
+        jsonrpc: '2.0',
+        id: 16,
+        result:
+          '0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000011426f7265644170655961636874436c7562000000000000000000000000000000',
+      })
+      .post('/v3/341eacb578dd44a1a049cbc5f6fd4035', {
+        jsonrpc: '2.0',
+        id: 17,
+        method: 'eth_call',
+        params: [
+          {
+            to: '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D',
+            data:
+              '0x01ffc9a75b5e139f00000000000000000000000000000000000000000000000000000000',
+          },
+          'latest',
+        ],
+      })
+      .reply(200, {
+        jsonrpc: '2.0',
+        id: 17,
+        result:
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+      });
+
+    nock('https://mainnet.infura.io:443', { encodedQueryParams: true })
+      .post('/v3/341eacb578dd44a1a049cbc5f6fd4035', {
+        jsonrpc: '2.0',
+        id: 18,
+        method: 'eth_call',
+        params: [
+          {
+            to: '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D',
+            data:
+              '0xc87b56dd0000000000000000000000000000000000000000000000000000000000000003',
+          },
+          'latest',
+        ],
+      })
+      .reply(200, {
+        jsonrpc: '2.0',
+        id: 18,
+        result:
+          '0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000037697066733a2f2f516d65536a53696e4870506e6d586d73704d6a776958794e367a533445397a63636172694752336a7863615774712f33000000000000000000',
+      });
+
+    nock(
+      'https://bafybeihpjhkeuiq3k6nqa3fkgeigeri7iebtrsuyuey5y6vy36n345xmbi.ipfs.cloudflare-ipfs.com',
+    )
+      .get('/3')
+      .reply(200, () => {
+        return {
+          image:
+            'https://bafybeie5ycnlx5ukzhlecakrbjeqnkpanuolobatuqooaeguptulganq6u.ipfs.cloudflare-ipfs.com',
+        };
+      });
+
+    const expectedResult = {
+      name: 'BoredApeYachtClub',
+      standard: 'ERC721',
+      symbol: 'BAYC',
+      tokenURI:
+        'https://bafybeihpjhkeuiq3k6nqa3fkgeigeri7iebtrsuyuey5y6vy36n345xmbi.ipfs.cloudflare-ipfs.com/3',
+      image:
+        'https://bafybeie5ycnlx5ukzhlecakrbjeqnkpanuolobatuqooaeguptulganq6u.ipfs.cloudflare-ipfs.com',
+    };
+
+    const details = await erc721Standard.getDetails(
+      '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D',
+      IPFS_DEFAULT_GATEWAY_URL,
+      '3',
+    );
+    expect(details).toMatchObject(expectedResult);
+  });
+
+  it('should return an object with all fields undefined except standard for a given contract (that does not support the ERC721 metadata interface) with or without a tokenID provided', async () => {
+    nock('https://mainnet.infura.io:443', { encodedQueryParams: true })
+      .post('/v3/341eacb578dd44a1a049cbc5f6fd4035', {
+        jsonrpc: '2.0',
+        id: 19,
+        method: 'eth_call',
+        params: [
+          {
+            to: '0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85',
+            data:
+              '0x01ffc9a780ac58cd00000000000000000000000000000000000000000000000000000000',
+          },
+          'latest',
+        ],
+      })
+      .reply(200, {
+        jsonrpc: '2.0',
+        id: 19,
+        result:
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+      })
+      .post('/v3/341eacb578dd44a1a049cbc5f6fd4035', {
+        jsonrpc: '2.0',
+        id: 20,
         method: 'eth_call',
         params: [
           {
@@ -322,7 +486,7 @@ describe('ERC721Standard', () => {
       })
       .reply(200, {
         jsonrpc: '2.0',
-        id: 14,
+        id: 20,
         result:
           '0x0000000000000000000000000000000000000000000000000000000000000000',
       });
@@ -333,7 +497,11 @@ describe('ERC721Standard', () => {
       symbol: undefined,
       tokenURI: undefined,
     };
-    const details = await erc721Standard.getDetails(ERC721_ENSADDRESS, '4');
+    const details = await erc721Standard.getDetails(
+      ERC721_ENSADDRESS,
+      IPFS_DEFAULT_GATEWAY_URL,
+      '4',
+    );
     expect(details).toMatchObject(expectedResult);
   });
 
@@ -341,7 +509,7 @@ describe('ERC721Standard', () => {
     nock('https://mainnet.infura.io:443', { encodedQueryParams: true })
       .post('/v3/341eacb578dd44a1a049cbc5f6fd4035', {
         jsonrpc: '2.0',
-        id: 15,
+        id: 21,
         method: 'eth_call',
         params: [
           {
@@ -354,13 +522,13 @@ describe('ERC721Standard', () => {
       })
       .reply(200, {
         jsonrpc: '2.0',
-        id: 15,
+        id: 21,
         result:
           '0x0000000000000000000000000000000000000000000000000000000000000000',
       })
       .post('/v3/341eacb578dd44a1a049cbc5f6fd4035', {
         jsonrpc: '2.0',
-        id: 16,
+        id: 22,
         method: 'eth_call',
         params: [
           {
@@ -373,7 +541,7 @@ describe('ERC721Standard', () => {
       })
       .reply(200, {
         jsonrpc: '2.0',
-        id: 16,
+        id: 22,
         result:
           '0x0000000000000000000000000000000000000000000000000000000000000000',
       });

--- a/src/assets/Standards/CollectibleStandards/ERC721/ERC721Standard.ts
+++ b/src/assets/Standards/CollectibleStandards/ERC721/ERC721Standard.ts
@@ -1,9 +1,6 @@
 import { abiERC721 } from '@metamask/metamask-eth-abis';
 import { Web3 } from '../../standards-types';
-import {
-  getFormattedIpfsUrl,
-  timeoutFetch,
-} from '../../../../util';
+import { getFormattedIpfsUrl, timeoutFetch } from '../../../../util';
 import {
   ERC721_INTERFACE_ID,
   ERC721_METADATA_INTERFACE_ID,

--- a/src/assets/Standards/CollectibleStandards/ERC721/ERC721Standard.ts
+++ b/src/assets/Standards/CollectibleStandards/ERC721/ERC721Standard.ts
@@ -1,6 +1,10 @@
 import { abiERC721 } from '@metamask/metamask-eth-abis';
 import { Web3 } from '../../standards-types';
 import {
+  getFormattedIpfsUrl,
+  timeoutFetch,
+} from '../../../../util';
+import {
   ERC721_INTERFACE_ID,
   ERC721_METADATA_INTERFACE_ID,
   ERC721_ENUMERABLE_INTERFACE_ID,
@@ -205,23 +209,26 @@ export class ERC721Standard {
    * Query if a contract implements an interface.
    *
    * @param address - Asset contract address.
+   * @param ipfsGateway - The user's preferred IPFS gateway.
    * @param tokenId - tokenId of a given token in the contract.
    * @returns Promise resolving an object containing the standard, tokenURI, symbol and name of the given contract/tokenId pair.
    */
   getDetails = async (
     address: string,
+    ipfsGateway: string,
     tokenId?: string,
   ): Promise<{
     standard: string;
     tokenURI: string | undefined;
     symbol: string | undefined;
     name: string | undefined;
+    image: string | undefined;
   }> => {
     const [isERC721, supportsMetadata] = await Promise.all([
       this.contractSupportsBase721Interface(address),
       this.contractSupportsMetadataInterface(address),
     ]);
-    let tokenURI, symbol, name;
+    let tokenURI, symbol, name, image;
     if (supportsMetadata) {
       [symbol, name] = await Promise.all([
         this.getAssetSymbol(address),
@@ -230,6 +237,20 @@ export class ERC721Standard {
 
       if (tokenId) {
         tokenURI = await this.getTokenURI(address, tokenId);
+        if (tokenURI.startsWith('ipfs://')) {
+          tokenURI = getFormattedIpfsUrl(ipfsGateway, tokenURI, true);
+        }
+
+        try {
+          const response = await timeoutFetch(tokenURI);
+          const object = await response.json();
+          image = object?.image;
+          if (image?.startsWith('ipfs://')) {
+            image = getFormattedIpfsUrl(ipfsGateway, image, true);
+          }
+        } catch {
+          // ignore
+        }
       }
     }
 
@@ -239,6 +260,7 @@ export class ERC721Standard {
         tokenURI,
         symbol,
         name,
+        image,
       };
     }
 

--- a/src/assets/TokenBalancesController.test.ts
+++ b/src/assets/TokenBalancesController.test.ts
@@ -181,9 +181,11 @@ describe('TokenBalancesController', () => {
   });
 
   it('should subscribe to new sibling assets controllers', async () => {
-    const assetsContract = new AssetsContractController();
-    const network = new NetworkController();
     const preferences = new PreferencesController();
+    const assetsContract = new AssetsContractController({
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
+    });
+    const network = new NetworkController();
     const tokensController = new TokensController({
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) => network.subscribe(listener),

--- a/src/assets/TokenDetectionController.test.ts
+++ b/src/assets/TokenDetectionController.test.ts
@@ -120,7 +120,10 @@ describe('TokenDetectionController', () => {
   beforeEach(async () => {
     preferences = new PreferencesController();
     network = new NetworkController();
-    assetsContract = new AssetsContractController();
+    assetsContract = new AssetsContractController({
+      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
+    });
+
     tokensController = new TokensController({
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) => network.subscribe(listener),


### PR DESCRIPTION
- ADDED:

  - **BREAKING** Adds functionality to fetch and return token images as part of `getDetails` calls on ERC721Standard and ERC1155Standard
     - This change is breaking because it requires that the AssetsContractController (on which the ERC721Standard and ERC1155Standard are instantiated) be passed a listener for `onPreferencesStateChange` from the `PreferencesController` so that it can use the user's preferred IPFSGateway to fetch any images hosted on IPFS. Consumers will have to pass `onPreferencesStateChange` in an options object (first arg) to the AssetsContractController constructor when initializing.

Resolves #689 
