### PR TITLE
[GasController] Check for undefined basefeePerGas

### DIFF
--- a/src/gas/fetchBlockFeeHistory.test.ts
+++ b/src/gas/fetchBlockFeeHistory.test.ts
@@ -111,6 +111,26 @@ describe('fetchBlockFeeHistory', () => {
 
       expect(feeHistory).toStrictEqual([]);
     });
+
+    it('should be able to handle an response with undefined baseFeePerGas from eth_feeHistory', async () => {
+      when(mockedQuery)
+        .calledWith(ethQuery, 'eth_feeHistory', [
+          toHex(numberOfRequestedBlocks),
+          toHex(latestBlockNumber),
+          [],
+        ])
+        .mockResolvedValue({
+          oldestBlock: toHex(0),
+          gasUsedRatio: null,
+        });
+
+      const feeHistory = await fetchBlockFeeHistory({
+        ethQuery,
+        numberOfBlocks: numberOfRequestedBlocks,
+      });
+
+      expect(feeHistory).toStrictEqual([]);
+    });
   });
 
   describe('given a numberOfBlocks that exceeds the max limit that the EVM returns', () => {

--- a/src/gas/fetchBlockFeeHistory.ts
+++ b/src/gas/fetchBlockFeeHistory.ts
@@ -22,6 +22,8 @@ type RequestChunkSpecifier = {
  * @property oldestBlock - The id of the oldest block (in hex format) in the range of blocks
  * requested.
  * @property baseFeePerGas - Base fee per gas for each block in the range of blocks requested.
+ * For go-ethereum based chains baseFeePerGas will not returned in case of empty results
+ * <github.com/ethereum/go-ethereum/blob/v1.10.16/internal/ethapi/api.go#L87>
  * @property gasUsedRatio - A number between 0 and 1 that represents the gas used vs. gas limit for
  * each block in the range of blocks requested.
  * @property reward - The priority fee at the percentiles requested for each block in the range of
@@ -30,7 +32,7 @@ type RequestChunkSpecifier = {
 
 export type EthFeeHistoryResponse = {
   oldestBlock: string;
-  baseFeePerGas: string[];
+  baseFeePerGas?: string[];
   gasUsedRatio: number[];
   reward?: string[][];
 };
@@ -288,6 +290,7 @@ async function makeRequestForChunk<Percentile extends number>({
   const startBlockNumber = fromHex(response.oldestBlock);
 
   if (
+    response.baseFeePerGas !== undefined &&
     response.baseFeePerGas.length > 0 &&
     response.gasUsedRatio.length > 0 &&
     (response.reward === undefined || response.reward.length > 0)


### PR DESCRIPTION
**PR Title**
GasController: Don't fall back to eth_gasPrice if node returns empty fee history

**Description**
go-ethereum based chains never return empty baseFeePerGas because this is omitted in the serializer:
```
type feeHistoryResult struct {
	OldestBlock  *hexutil.Big     `json:"oldestBlock"`
	Reward       [][]*hexutil.Big `json:"reward,omitempty"`
	BaseFee      []*hexutil.Big   `json:"baseFeePerGas,omitempty"` <---
	GasUsedRatio []float64        `json:"gasUsedRatio"`
}
```
Current code checks for `baseFeePerGas.length > 0` without checking for the occurence of this element.
This leads to an exception and in later flow to fallback to eth_gasPrice mode

- FIXED:
no feeMarket mode available in case one of past requests return no results

**Checklist**

- [X] Tests are included if applicable
- [X] Any added code is fully documented

**Issue**