### PR TITLE
Adjust max line length to 100

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ trim_trailing_whitespace = true
 [*.md]
 indent_size = 4
 trim_trailing_whitespace = false
+
+[*.ts]
+max_line_length = 100


### PR DESCRIPTION
Inline code documentation seems to have historically been written using
a max line length of 100. This configures editors which support
EditorConfig to use this line length for all TypeScript files.