### PR TITLE
Improve eth_feeHistory performance

### DIFF
--- a/src/gas/fetchGasEstimatesViaEthFeeHistory.test.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory.test.ts
@@ -10,6 +10,7 @@ import calculatePriorityFeeTrend from './fetchGasEstimatesViaEthFeeHistory/calcu
 import calculateNetworkCongestion from './fetchGasEstimatesViaEthFeeHistory/calculateNetworkCongestion';
 import fetchLatestBlock from './fetchGasEstimatesViaEthFeeHistory/fetchLatestBlock';
 import fetchGasEstimatesViaEthFeeHistory from './fetchGasEstimatesViaEthFeeHistory';
+import { ExistingFeeHistoryBlock } from './fetchBlockFeeHistory';
 
 jest.mock('./fetchGasEstimatesViaEthFeeHistory/BlockFeeHistoryDatasetFetcher');
 jest.mock(
@@ -54,13 +55,28 @@ describe('fetchGasEstimatesViaEthFeeHistory', () => {
     const blocksByDataset = {
       mediumRange: [
         {
-          number: new BN(2),
+          number: new BN(6),
           baseFeePerGas: new BN(1),
           gasUsedRatio: 1,
           priorityFeesByPercentile: {
             10: new BN('0'),
             95: new BN('0'),
           },
+        },
+        {
+          number: new BN(6),
+          baseFeePerGas: new BN(1),
+          gasUsedRatio: 1,
+          priorityFeesByPercentile: {
+            10: new BN('0'),
+            95: new BN('0'),
+          },
+        },
+        {
+          number: new BN(7),
+          baseFeePerGas: new BN(1),
+          gasUsedRatio: null,
+          priorityFeesByPercentile: null,
         },
       ],
       smallRange: [
@@ -106,23 +122,6 @@ describe('fetchGasEstimatesViaEthFeeHistory', () => {
           },
         },
       ],
-      latestWithNextBlock: [
-        {
-          number: new BN(6),
-          baseFeePerGas: new BN(1),
-          gasUsedRatio: 1,
-          priorityFeesByPercentile: {
-            10: new BN('0'),
-            95: new BN('0'),
-          },
-        },
-        {
-          number: new BN(7),
-          baseFeePerGas: new BN(1),
-          gasUsedRatio: null,
-          priorityFeesByPercentile: null,
-        },
-      ],
     };
     const levelSpecificEstimates = {
       low: {
@@ -165,13 +164,17 @@ describe('fetchGasEstimatesViaEthFeeHistory', () => {
       .mockReturnValue(historicalBaseFeeRange);
 
     when(mockedCalculateBaseFeeTrend)
-      .calledWith(blocksByDataset.latestWithNextBlock)
+      .calledWith(blocksByDataset.mediumRange.slice(-2))
       .mockReturnValue(baseFeeTrend);
 
     when(mockedCalculatePriorityFeeRange)
       .calledWith(blocksByDataset.latest)
       .mockReturnValue(latestPriorityFeeRange)
-      .calledWith(blocksByDataset.mediumRange)
+      .calledWith(
+        blocksByDataset.mediumRange.slice(0, -1) as ExistingFeeHistoryBlock<
+          10 | 95
+        >[],
+      )
       .mockReturnValue(historicalPriorityFeeRange);
 
     when(mockedCalculatePriorityFeeTrend)

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory.ts
@@ -10,6 +10,7 @@ import calculatePriorityFeeRange from './fetchGasEstimatesViaEthFeeHistory/calcu
 import calculatePriorityFeeTrend from './fetchGasEstimatesViaEthFeeHistory/calculatePriorityFeeTrend';
 import calculateNetworkCongestion from './fetchGasEstimatesViaEthFeeHistory/calculateNetworkCongestion';
 import fetchLatestBlock from './fetchGasEstimatesViaEthFeeHistory/fetchLatestBlock';
+import { ExistingFeeHistoryBlock } from './fetchBlockFeeHistory';
 
 /**
  * Generates gas fee estimates based on gas fees that have been used in the recent past so that
@@ -43,14 +44,15 @@ export default async function fetchGasEstimatesViaEthFeeHistory(
   const historicalBaseFeeRange = calculateBaseFeeRange(
     blocksByDataset.mediumRange,
   );
-  const baseFeeTrend = calculateBaseFeeTrend(
-    blocksByDataset.latestWithNextBlock,
-  );
+  const lastTwoBlocks = blocksByDataset.mediumRange.slice(-2);
+  const baseFeeTrend = calculateBaseFeeTrend(lastTwoBlocks);
   const latestPriorityFeeRange = calculatePriorityFeeRange(
     blocksByDataset.latest,
   );
   const historicalPriorityFeeRange = calculatePriorityFeeRange(
-    blocksByDataset.mediumRange,
+    blocksByDataset.mediumRange.slice(0, -1) as ExistingFeeHistoryBlock<
+      10 | 95
+    >[],
   );
   const priorityFeeTrend = calculatePriorityFeeTrend(blocksByDataset.tinyRange);
   const networkCongestion = calculateNetworkCongestion([]);

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory/BlockFeeHistoryDatasetFetcher.test.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory/BlockFeeHistoryDatasetFetcher.test.ts
@@ -38,6 +38,7 @@ describe('BlockFeeHistoryDatasetFetcher', () => {
           endBlock: fakeEndBlockNumber,
           numberOfBlocks: 200,
           percentiles: [10, 95],
+          includeNextBlock: true
         })
         .mockResolvedValue(fakeBlocks);
 
@@ -87,27 +88,6 @@ describe('BlockFeeHistoryDatasetFetcher', () => {
       });
 
       expect(await fetcher.forTinyRange()).toStrictEqual(fakeBlocks);
-    });
-  });
-
-  describe('forLatestWithNextBlock', () => {
-    it('returns 1 block along with the 10th and 90th reward percentiles (including the next block)', async () => {
-      when(mockedFetchBlockFeeHistory)
-        .calledWith({
-          ethQuery: fakeEthQuery,
-          endBlock: fakeEndBlockNumber,
-          numberOfBlocks: 1,
-          includeNextBlock: true,
-          percentiles: [10, 95],
-        })
-        .mockResolvedValue(fakeBlocks);
-
-      const fetcher = new BlockFeeHistoryDatasetFetcher({
-        ethQuery: fakeEthQuery,
-        endBlockNumber: fakeEndBlockNumber,
-      });
-
-      expect(await fetcher.forLatestWithNextBlock()).toStrictEqual(fakeBlocks);
     });
   });
 });

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory/BlockFeeHistoryDatasetFetcher.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory/BlockFeeHistoryDatasetFetcher.ts
@@ -23,20 +23,14 @@ export default class BlockFeeHistoryDatasetFetcher {
   }
 
   async forAll() {
-    const [
-      mediumRange,
-      smallRange,
-      tinyRange,
-      latestWithNextBlock,
-    ] = await Promise.all([
+    const [mediumRange, smallRange, tinyRange] = await Promise.all([
       this.forMediumRange(),
       this.forSmallRange(),
       this.forTinyRange(),
-      this.forLatestWithNextBlock(),
     ]);
 
-    const latest = latestWithNextBlock.slice(0, -1) as ExistingFeeHistoryBlock<
-      ExtractPercentileFrom<typeof latestWithNextBlock>
+    const latest = mediumRange.slice(-2, -1) as ExistingFeeHistoryBlock<
+      ExtractPercentileFrom<typeof mediumRange>
     >[];
 
     return {
@@ -44,12 +38,11 @@ export default class BlockFeeHistoryDatasetFetcher {
       smallRange,
       tinyRange,
       latest,
-      latestWithNextBlock,
     };
   }
 
   forMediumRange() {
-    return this.fetchExcludingNextBlock({
+    return this.fetchIncludingNextBlock({
       numberOfBlocks: 200,
       percentiles: [10, 95],
     });
@@ -66,13 +59,6 @@ export default class BlockFeeHistoryDatasetFetcher {
     return this.fetchExcludingNextBlock({
       numberOfBlocks: 2,
       percentiles: [50],
-    });
-  }
-
-  forLatestWithNextBlock() {
-    return this.fetchIncludingNextBlock({
-      numberOfBlocks: 1,
-      percentiles: [10, 95],
     });
   }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

Merge two calls into one improving performance when using fallback `eth_feeHistory` logic.

- CHANGED:
  - Merge two calls into one improving performance when using fallback `eth_feeHistory` logic.

**Checklist**

- [ ] Tests are included if applicable
- [ ] Any added code is fully documented

**Issue**

Resolves #???
