### PR TITLE
PhishFort phishing blacklist

### DIFF
--- a/src/third-party/PhishingController.test.ts
+++ b/src/third-party/PhishingController.test.ts
@@ -111,17 +111,17 @@ describe('PhishingController', () => {
   it('should return positive result for unsafe unicode domain from the PhishFort blacklist', async () => {
     const controller = new PhishingController();
     await controller.updatePhishingLists();
-    expect(controller.test('pancakeswop.net')).toBe(true);
+    expect(controller.test('e4d600ab9141b7a9859511c77e63b9b3.com')).toBe(true);
   });
 
   it('should return negative result for unsafe unicode domain if the PhishFort blacklist returns 304', async () => {
     nock('https://cdn.jsdelivr.net', { allowUnmocked: true })
-      .get('/gh/phishfort/phishfort-lists@master/blacklists/domains.json')
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
       .reply(304)
       .persist();
     const controller = new PhishingController();
     await controller.updatePhishingLists();
-    expect(controller.test('pancakeswop.net')).toBe(false);
+    expect(controller.test('e4d600ab9141b7a9859511c77e63b9b3.com')).toBe(false);
   });
 
   it('should bypass a given domain', () => {

--- a/src/third-party/PhishingController.test.ts
+++ b/src/third-party/PhishingController.test.ts
@@ -108,6 +108,22 @@ describe('PhishingController', () => {
     expect(controller.test('xn--myetherallet-4k5fwn.com')).toBe(true);
   });
 
+  it('should return positive result for unsafe unicode domain from the PhishFort blacklist', async () => {
+    const controller = new PhishingController();
+    await controller.updatePhishingLists();
+    expect(controller.test('pancakeswop.net')).toBe(true);
+  });
+
+  it('should return negative result for unsafe unicode domain if the PhishFort blacklist returns 304', async () => {
+    nock('https://cdn.jsdelivr.net', { allowUnmocked: true })
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/domains.json')
+      .reply(304)
+      .persist();
+    const controller = new PhishingController();
+    await controller.updatePhishingLists();
+    expect(controller.test('pancakeswop.net')).toBe(false);
+  });
+
   it('should bypass a given domain', () => {
     const controller = new PhishingController();
     const unsafeDomain = 'electrum.mx';
@@ -158,7 +174,7 @@ describe('PhishingController', () => {
   });
 
   it('should not update phishing lists if fetch returns 304', async () => {
-    nock('https://cdn.jsdelivr.net')
+    nock('https://cdn.jsdelivr.net', { allowUnmocked: true })
       .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
       .reply(304)
       .persist();
@@ -171,7 +187,7 @@ describe('PhishingController', () => {
   });
 
   it('should not update phishing lists if fetch returns error', async () => {
-    nock('https://cdn.jsdelivr.net')
+    nock('https://cdn.jsdelivr.net', { allowUnmocked: true })
       .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
       .reply(500)
       .persist();

--- a/src/third-party/PhishingController.ts
+++ b/src/third-party/PhishingController.ts
@@ -54,10 +54,8 @@ export class PhishingController extends BaseController<
 > {
   private configUrlMetaMask =
     'https://cdn.jsdelivr.net/gh/MetaMask/eth-phishing-detect@master/src/config.json';
-  private configPhishFort = {
-    whitelistUrl: `https://cdn.jsdelivr.net/gh/phishfort/phishfort-lists@master/whitelists/domains.json`,
-    blacklistUrl: `https://cdn.jsdelivr.net/gh/phishfort/phishfort-lists@master/blacklists/domains.json`,
-  };
+
+  private configUrlPhishFortBlacklist = `https://cdn.jsdelivr.net/gh/phishfort/phishfort-lists@master/blacklists/domains.json`;
 
   private detector: any;
 
@@ -139,16 +137,17 @@ export class PhishingController extends BaseController<
       return;
     }
 
-    const [ phishingOpts, pfWhitelist, pfBlacklist] = await Promise.all([
-      this.queryConfig<EthPhishingResponse>(this.configUrlMetaMask),
-      this.queryConfig<string[]>(this.configPhishFort.whitelistUrl),
-      this.queryConfig<string[]>(this.configPhishFort.blacklistUrl)
-    ]).catch(error => { throw error; });
+    const phishingOpts = await this.queryConfig<EthPhishingResponse>(
+      this.configUrlMetaMask,
+    );
+    const pfBlacklist = await this.queryConfig<string[]>(
+      this.configUrlPhishFortBlacklist,
+    );
 
     if (phishingOpts) {
-
-      if (pfWhitelist) phishingOpts.whitelist.push(...pfWhitelist);
-      if (pfBlacklist) phishingOpts.blacklist.push(...pfBlacklist);
+      if (pfBlacklist) {
+        phishingOpts.blacklist.push(...pfBlacklist);
+      }
 
       this.detector = new PhishingDetector(phishingOpts);
       this.update({

--- a/src/third-party/PhishingController.ts
+++ b/src/third-party/PhishingController.ts
@@ -139,7 +139,7 @@ export class PhishingController extends BaseController<
       return;
     }
 
-    const [ phishingOpts, pfWhilelist, pfBlacklist] = await Promise.all([
+    const [ phishingOpts, pfWhitelist, pfBlacklist] = await Promise.all([
       this.queryConfig<EthPhishingResponse>(this.configUrlMetaMask),
       this.queryConfig<string[]>(this.configPhishFort.whitelistUrl),
       this.queryConfig<string[]>(this.configPhishFort.blacklistUrl)
@@ -147,7 +147,7 @@ export class PhishingController extends BaseController<
 
     if (phishingOpts) {
 
-      if (pfWhilelist) phishingOpts.whitelist.push(...pfWhilelist);
+      if (pfWhitelist) phishingOpts.whitelist.push(...pfWhitelist);
       if (pfBlacklist) phishingOpts.blacklist.push(...pfBlacklist);
 
       this.detector = new PhishingDetector(phishingOpts);

--- a/src/third-party/PhishingController.ts
+++ b/src/third-party/PhishingController.ts
@@ -55,7 +55,8 @@ export class PhishingController extends BaseController<
   private configUrlMetaMask =
     'https://cdn.jsdelivr.net/gh/MetaMask/eth-phishing-detect@master/src/config.json';
 
-  private configUrlPhishFortBlacklist = `https://cdn.jsdelivr.net/gh/phishfort/phishfort-lists@master/blacklists/domains.json`;
+  private configUrlPhishFortHotlist =
+    `https://cdn.jsdelivr.net/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json`;
 
   private detector: any;
 
@@ -141,7 +142,7 @@ export class PhishingController extends BaseController<
       this.configUrlMetaMask,
     );
     const pfBlacklist = await this.queryConfig<string[]>(
-      this.configUrlPhishFortBlacklist,
+      this.configUrlPhishFortHotlist,
     );
 
     if (phishingOpts) {


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**PhishFort phishing blacklist**

Included PhishFort blacklist to the default blacklist used to perform phishing detection.

**Description**

- ADDED:

  - Fetch of public PhishFort blacklist via cdnjs / GitHub.
  - Inclusion of entries in the PhishFort blacklist into the one used by default (published as part of MetaMask/eth-phishing-detect)
  - Some tests to check for successful detection of entries from the PhishFort blacklist.

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented
