### PR TITLE
Make getTokenStandardAndDetails function signature reflect that the second arg is optional

### DIFF
--- a/src/assets/AssetsContractController.ts
+++ b/src/assets/AssetsContractController.ts
@@ -166,7 +166,7 @@ export class AssetsContractController extends BaseController<
    */
   async getTokenStandardAndDetails(
     tokenAddress: string,
-    userAddress: string,
+    userAddress?: string,
     tokenId?: string,
   ): Promise<{
     standard: string;


### PR DESCRIPTION
- CHANGED:

  - Make `getTokenStandardAndDetails` function signature reflect that the second arg is optional. Consumers of this method can continue to pass the `userAddress` as a second option if they are wanting to query for the user balance of an ERC20 token.


