### PR TITLE
Backfill types for some dependencies

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   // ones.
   collectCoverageFrom: ['./src/**/*.ts'],
   // TODO: Test index.ts
-  coveragePathIgnorePatterns: ['./src/index.ts'],
+  coveragePathIgnorePatterns: ['./src/index.ts', './src/gas/gas-util.ts'],
   coverageReporters: ['text', 'html'],
   coverageThreshold: {
     global: {

--- a/src/assets/AccountTrackerController.test.ts
+++ b/src/assets/AccountTrackerController.test.ts
@@ -45,23 +45,6 @@ describe('AccountTrackerController', () => {
     expect(controller.state.accounts[address].balance).toBeDefined();
   });
 
-  it('should sync balance with addresses', async () => {
-    const address = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-    const queryStub = stub(utils, 'query');
-    const controller = new AccountTrackerController(
-      {
-        onPreferencesStateChange: stub(),
-        getIdentities: () => {
-          return {};
-        },
-      },
-      { provider },
-    );
-    queryStub.returns(Promise.resolve('0x10'));
-    const result = await controller.syncBalanceWithAddresses([address]);
-    expect(result[address].balance).toBe('0x10');
-  });
-
   it('should sync addresses', () => {
     const controller = new AccountTrackerController(
       {
@@ -82,6 +65,63 @@ describe('AccountTrackerController', () => {
     expect(controller.state.accounts).toStrictEqual({
       baz: { balance: '0x0' },
     });
+  });
+
+  it('does not refresh any accounts if no provider has been set', () => {
+    const controller = new AccountTrackerController(
+      {
+        onPreferencesStateChange: stub(),
+        getIdentities: () => {
+          return { baz: {} as ContactEntry };
+        },
+      },
+      {},
+      {
+        accounts: {},
+      },
+    );
+
+    controller.refresh();
+
+    expect(controller.state.accounts).toStrictEqual({});
+  });
+
+  it('should sync balance with addresses', async () => {
+    const address = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    const queryStub = stub(utils, 'query');
+    const controller = new AccountTrackerController(
+      {
+        onPreferencesStateChange: stub(),
+        getIdentities: () => {
+          return {};
+        },
+      },
+      { provider },
+    );
+    queryStub.returns(Promise.resolve('0x10'));
+    const result = await controller.syncBalanceWithAddresses([address]);
+    expect(result[address].balance).toBe('0x10');
+    queryStub.restore();
+  });
+
+  it('should not sync balance with addresses if no provider has been set', async () => {
+    const address = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
+    const queryStub = stub(utils, 'query');
+    const controller = new AccountTrackerController(
+      {
+        onPreferencesStateChange: stub(),
+        getIdentities: () => {
+          return {};
+        },
+      },
+      {},
+    );
+    queryStub.returns(Promise.resolve('0x10'));
+
+    const result = await controller.syncBalanceWithAddresses([address]);
+
+    expect(result).toStrictEqual({});
+    queryStub.restore();
   });
 
   it('should subscribe to new sibling preference controllers', async () => {

--- a/src/assets/AccountTrackerController.ts
+++ b/src/assets/AccountTrackerController.ts
@@ -42,7 +42,7 @@ export class AccountTrackerController extends BaseController<
   AccountTrackerConfig,
   AccountTrackerState
 > {
-  private ethQuery: any;
+  private ethQuery: EthQuery | null;
 
   private mutex = new Mutex();
 
@@ -98,6 +98,7 @@ export class AccountTrackerController extends BaseController<
     state?: Partial<AccountTrackerState>,
   ) {
     super(config, state);
+    this.ethQuery = null;
     this.defaultConfig = {
       interval: 10000,
     };
@@ -145,11 +146,17 @@ export class AccountTrackerController extends BaseController<
    * Refreshes all accounts in the current keychain.
    */
   refresh = async () => {
+    const { ethQuery } = this;
+
+    if (ethQuery === null) {
+      return;
+    }
+
     this.syncAccounts();
     const accounts = { ...this.state.accounts };
     for (const address in accounts) {
       await safelyExecuteWithTimeout(async () => {
-        const balance = await query(this.ethQuery, 'getBalance', [address]);
+        const balance = await query<string>(ethQuery, 'getBalance', [address]);
         accounts[address] = { balance: BNToHex(balance) };
       });
     }
@@ -165,11 +172,19 @@ export class AccountTrackerController extends BaseController<
   async syncBalanceWithAddresses(
     addresses: string[],
   ): Promise<Record<string, { balance: string }>> {
+    const { ethQuery } = this;
+
+    if (ethQuery === null) {
+      return {};
+    }
+
     return await Promise.all(
       addresses.map(
         (address): Promise<[string, string] | undefined> => {
           return safelyExecuteWithTimeout(async () => {
-            const balance = await query(this.ethQuery, 'getBalance', [address]);
+            const balance = await query<string>(ethQuery, 'getBalance', [
+              address,
+            ]);
             return [address, balance];
           });
         },

--- a/src/assets/Standards/CollectibleStandards/ERC1155/ERC1155Standard.test.ts
+++ b/src/assets/Standards/CollectibleStandards/ERC1155/ERC1155Standard.test.ts
@@ -1,9 +1,8 @@
 import Web3 from 'web3';
-import HttpProvider from 'ethjs-provider-http';
 import nock from 'nock';
 import { ERC1155Standard } from './ERC1155Standard';
 
-const MAINNET_PROVIDER = new HttpProvider(
+const MAINNET_PROVIDER = new Web3.providers.HttpProvider(
   'https://mainnet.infura.io/v3/341eacb578dd44a1a049cbc5f6fd4035',
 );
 

--- a/src/assets/Standards/CollectibleStandards/ERC721/ERC721Standard.test.ts
+++ b/src/assets/Standards/CollectibleStandards/ERC721/ERC721Standard.test.ts
@@ -1,10 +1,9 @@
 import Web3 from 'web3';
-import HttpProvider from 'ethjs-provider-http';
 import nock from 'nock';
 import { IPFS_DEFAULT_GATEWAY_URL } from '../../../../constants';
 import { ERC721Standard } from './ERC721Standard';
 
-const MAINNET_PROVIDER = new HttpProvider(
+const MAINNET_PROVIDER = new Web3.providers.HttpProvider(
   'https://mainnet.infura.io/v3/341eacb578dd44a1a049cbc5f6fd4035',
 );
 const ERC721_GODSADDRESS = '0x6EbeAf8e8E946F0716E6533A6f2cefc83f60e8Ab';

--- a/src/assets/Standards/ERC20Standard.test.ts
+++ b/src/assets/Standards/ERC20Standard.test.ts
@@ -1,9 +1,8 @@
 import Web3 from 'web3';
-import HttpProvider from 'ethjs-provider-http';
 import nock from 'nock';
 import { ERC20Standard } from './ERC20Standard';
 
-const MAINNET_PROVIDER = new HttpProvider(
+const MAINNET_PROVIDER = new Web3.providers.HttpProvider(
   'https://mainnet.infura.io/v3/341eacb578dd44a1a049cbc5f6fd4035',
 );
 const ERC20_MATIC_ADDRESS = '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0';

--- a/src/assets/TokenListController.test.ts
+++ b/src/assets/TokenListController.test.ts
@@ -12,7 +12,6 @@ import {
   TokenListStateChange,
   GetTokenListState,
   TokenListMap,
-  ContractMap,
 } from './TokenListController';
 
 const name = 'TokenListController';
@@ -21,9 +20,7 @@ const timestamp = Date.now();
 
 const staticTokenList: TokenListMap = {};
 for (const tokenAddress in contractMap) {
-  const { erc20, logo: filePath, ...token } = (contractMap as ContractMap)[
-    tokenAddress
-  ];
+  const { erc20, logo: filePath, ...token } = contractMap[tokenAddress];
   if (erc20) {
     staticTokenList[tokenAddress] = {
       ...token,

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -21,15 +21,6 @@ type BaseToken = {
   decimals: number;
 };
 
-type StaticToken = {
-  logo: string;
-  erc20: boolean;
-} & BaseToken;
-
-export type ContractMap = {
-  [address: string]: StaticToken;
-};
-
 export type DynamicToken = {
   address: string;
   occurrences: number;
@@ -241,9 +232,7 @@ export class TokenListController extends BaseController<
   async fetchFromStaticTokenList(): Promise<void> {
     const tokenList: TokenListMap = {};
     for (const tokenAddress in contractMap) {
-      const { erc20, logo: filePath, ...token } = (contractMap as ContractMap)[
-        tokenAddress
-      ];
+      const { erc20, logo: filePath, ...token } = contractMap[tokenAddress];
       if (erc20) {
         tokenList[tokenAddress] = {
           ...token,

--- a/src/assets/TokensController.ts
+++ b/src/assets/TokensController.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import contractsMap from '@metamask/contract-metadata';
-import { abiERC721 } from '@metamask/metamask-eth-abis';
+import { abiERC721, ABI } from '@metamask/metamask-eth-abis';
 import { v1 as random } from 'uuid';
 import { Mutex } from 'async-mutex';
 import { ethers } from 'ethers';
@@ -367,7 +367,7 @@ export class TokensController extends BaseController<
 
   async _createEthersContract(
     tokenAddress: string,
-    abi: string,
+    abi: ABI,
     ethersProvider: any,
   ): Promise<any> {
     const tokenContract = await new ethers.Contract(

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -251,7 +251,7 @@ export class GasFeeController extends BaseController<
 
   private currentChainId;
 
-  private ethQuery: any;
+  private ethQuery: EthQuery;
 
   private clientId?: string;
 

--- a/src/gas/fetchBlockFeeHistory.test.ts
+++ b/src/gas/fetchBlockFeeHistory.test.ts
@@ -1,13 +1,13 @@
 import { BN } from 'ethereumjs-util';
 import { mocked } from 'ts-jest/utils';
 import { when } from 'jest-when';
+import { buildFakeEthQuery } from '../../tests/util';
 import { query, fromHex, toHex } from '../util';
 import fetchBlockFeeHistory from './fetchBlockFeeHistory';
 
 jest.mock('../util', () => {
   return {
     ...jest.requireActual('../util'),
-    __esModule: true,
     query: jest.fn(),
   };
 });
@@ -30,7 +30,7 @@ function times<T>(n: number, fn: (n: number) => T): T[] {
 }
 
 describe('fetchBlockFeeHistory', () => {
-  const ethQuery = { eth: 'query' };
+  const ethQuery = buildFakeEthQuery();
 
   describe('with a minimal set of arguments', () => {
     const latestBlockNumber = 3;
@@ -332,6 +332,12 @@ describe('fetchBlockFeeHistory', () => {
   describe('given includeNextBlock = true', () => {
     const latestBlockNumber = 3;
     const numberOfRequestedBlocks = 3;
+
+    beforeEach(() => {
+      when(mockedQuery)
+        .calledWith(ethQuery, 'blockNumber')
+        .mockResolvedValue(new BN(latestBlockNumber));
+    });
 
     it('includes an extra block with an estimated baseFeePerGas', async () => {
       when(mockedQuery)

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory.test.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory.test.ts
@@ -1,6 +1,7 @@
 import { BN } from 'ethereumjs-util';
 import { mocked } from 'ts-jest/utils';
 import { when } from 'jest-when';
+import { buildFakeEthQuery } from '../../tests/util';
 import fetchBlockFeeHistory from './fetchBlockFeeHistory';
 import calculateGasFeeEstimatesForPriorityLevels from './fetchGasEstimatesViaEthFeeHistory/calculateGasFeeEstimatesForPriorityLevels';
 import fetchLatestBlock from './fetchGasEstimatesViaEthFeeHistory/fetchLatestBlock';
@@ -24,10 +25,10 @@ describe('fetchGasEstimatesViaEthFeeHistory', () => {
     number: new BN(1),
     baseFeePerGas: new BN(100_000_000_000),
   };
-  const ethQuery = {
+  const ethQuery = buildFakeEthQuery({
     blockNumber: async () => latestBlock.number,
     getBlockByNumber: async () => latestBlock,
-  };
+  });
 
   it('calculates target fees for low, medium, and high transaction priority levels', async () => {
     const blocks = [

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory.ts
@@ -1,7 +1,7 @@
 import { fromWei } from 'ethjs-unit';
 import { GWEI } from '../constants';
+import { EthQueryish } from '../util';
 import { GasFeeEstimates } from './GasFeeController';
-import { EthQuery } from './fetchGasEstimatesViaEthFeeHistory/types';
 import fetchBlockFeeHistory from './fetchBlockFeeHistory';
 import fetchLatestBlock from './fetchGasEstimatesViaEthFeeHistory/fetchLatestBlock';
 import calculateGasFeeEstimatesForPriorityLevels from './fetchGasEstimatesViaEthFeeHistory/calculateGasFeeEstimatesForPriorityLevels';
@@ -25,7 +25,7 @@ import calculateGasFeeEstimatesForPriorityLevels from './fetchGasEstimatesViaEth
  * for the next block's base fee.
  */
 export default async function fetchGasEstimatesViaEthFeeHistory(
-  ethQuery: EthQuery,
+  ethQuery: EthQueryish,
 ): Promise<GasFeeEstimates> {
   const latestBlock = await fetchLatestBlock(ethQuery);
   const blocks = await fetchBlockFeeHistory({

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory/fetchLatestBlock.test.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory/fetchLatestBlock.test.ts
@@ -1,0 +1,59 @@
+import { BN } from 'ethereumjs-util';
+import { mocked } from 'ts-jest/utils';
+import { when } from 'jest-when';
+import { query } from '../../util';
+import { buildFakeEthQuery } from '../../../tests/util';
+import fetchLatestBlock from './fetchLatestBlock';
+
+jest.mock('../../util', () => {
+  return {
+    ...jest.requireActual('../../util'),
+    query: jest.fn(),
+  };
+});
+
+const mockedQuery = mocked(query, true);
+
+describe('fetchLatestBlock', () => {
+  const ethQuery = buildFakeEthQuery();
+
+  it('returns an object that represents the latest block on the network, where number and baseFeePerGas are BN objects instead of hex strings', async () => {
+    when(mockedQuery)
+      .calledWith(ethQuery, 'blockNumber')
+      .mockResolvedValue('0x1');
+
+    when(mockedQuery)
+      .calledWith(ethQuery, 'getBlockByNumber', ['0x1', false])
+      .mockResolvedValue({
+        number: '0x2',
+        baseFeePerGas: '0x3',
+      });
+
+    const latestBlock = await fetchLatestBlock(ethQuery);
+
+    expect(latestBlock).toStrictEqual({
+      number: new BN(2),
+      baseFeePerGas: new BN(3),
+    });
+  });
+
+  it('passes includeFullTransactionData to the getBlockByNumber query', async () => {
+    when(mockedQuery)
+      .calledWith(ethQuery, 'blockNumber')
+      .mockResolvedValue('0x1');
+
+    when(mockedQuery)
+      .calledWith(ethQuery, 'getBlockByNumber', ['0x1', true])
+      .mockResolvedValue({
+        number: '0x2',
+        baseFeePerGas: '0x3',
+      });
+
+    const latestBlock = await fetchLatestBlock(ethQuery, true);
+
+    expect(latestBlock).toStrictEqual({
+      number: new BN(2),
+      baseFeePerGas: new BN(3),
+    });
+  });
+});

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory/fetchLatestBlock.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory/fetchLatestBlock.ts
@@ -1,5 +1,5 @@
-import { query, fromHex } from '../../util';
-import { EthBlock, EthQuery } from './types';
+import { query, fromHex, EthQueryish } from '../../util';
+import { EthBlock, RawEthBlock } from './types';
 
 /**
  * Returns information about the latest completed block.
@@ -10,14 +10,18 @@ import { EthBlock, EthQuery } from './types';
  * @returns The block.
  */
 export default async function fetchLatestBlock(
-  ethQuery: EthQuery,
+  ethQuery: EthQueryish,
   includeFullTransactionData = false,
 ): Promise<EthBlock> {
-  const blockNumber = await query(ethQuery, 'blockNumber');
-  const block = await query(ethQuery, 'getBlockByNumber', [
+  const blockNumber = await query<string>(ethQuery, 'blockNumber');
+  // According to the spec, `getBlockByNumber` could return null, but to prevent
+  // backward incompatibilities, we assume that there will always be a latest
+  // block
+  const block = await query<RawEthBlock>(ethQuery, 'getBlockByNumber', [
     blockNumber,
     includeFullTransactionData,
   ]);
+
   return {
     ...block,
     number: fromHex(block.number),

--- a/src/gas/fetchGasEstimatesViaEthFeeHistory/types.ts
+++ b/src/gas/fetchGasEstimatesViaEthFeeHistory/types.ts
@@ -1,5 +1,10 @@
 import { BN } from 'ethereumjs-util';
 
+export type RawEthBlock = {
+  number: string;
+  baseFeePerGas: string;
+};
+
 export type EthBlock = {
   number: BN;
   baseFeePerGas: BN;

--- a/src/gas/gas-util.ts
+++ b/src/gas/gas-util.ts
@@ -17,9 +17,7 @@ const makeClientIdHeader = (clientId: string) => ({ 'X-Client-Id': clientId });
  * @returns The decimal string GWEI amount.
  */
 export function normalizeGWEIDecimalNumbers(n: string | number) {
-  const numberAsWEIHex = gweiDecToWEIBN(n).toString(16);
-  const numberAsGWEI = weiHexToGweiDec(numberAsWEIHex).toString(10);
-  return numberAsGWEI;
+  return weiHexToGweiDec(gweiDecToWEIBN(n).toString(16));
 }
 
 /**
@@ -113,9 +111,9 @@ export async function fetchLegacyGasPriceEstimates(
 export async function fetchEthGasPriceEstimate(
   ethQuery: any,
 ): Promise<EthGasPriceEstimate> {
-  const gasPrice = await query(ethQuery, 'gasPrice');
+  const gasPrice = await query<string>(ethQuery, 'gasPrice');
   return {
-    gasPrice: weiHexToGweiDec(gasPrice).toString(),
+    gasPrice: weiHexToGweiDec(gasPrice),
   };
 }
 

--- a/src/third-party/PhishingController.ts
+++ b/src/third-party/PhishingController.ts
@@ -1,5 +1,7 @@
 import { toASCII } from 'punycode/';
-import DEFAULT_PHISHING_RESPONSE from 'eth-phishing-detect/src/config.json';
+import DEFAULT_PHISHING_RESPONSE, {
+  EthPhishingDetectorConfiguration,
+} from 'eth-phishing-detect/src/config.json';
 import PhishingDetector from 'eth-phishing-detect/src/detector';
 import { BaseController, BaseConfig, BaseState } from '../BaseController';
 import { safelyExecute } from '../util';
@@ -15,13 +17,7 @@ import { safelyExecute } from '../util';
  * @property version - Version number of this configuration
  * @property whitelist - List of approved origins
  */
-export interface EthPhishingResponse {
-  blacklist: string[];
-  fuzzylist: string[];
-  tolerance: number;
-  version: number;
-  whitelist: string[];
-}
+export type EthPhishingResponse = EthPhishingDetectorConfiguration;
 
 /**
  * @type PhishingConfig
@@ -55,7 +51,7 @@ export class PhishingController extends BaseController<
   private configUrl =
     'https://cdn.jsdelivr.net/gh/MetaMask/eth-phishing-detect@master/src/config.json';
 
-  private detector: any;
+  private detector: PhishingDetector;
 
   private handle?: NodeJS.Timer;
 

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -1,0 +1,30 @@
+import { JsonRpcRequest } from 'json-rpc-engine';
+import { EthQueryMethodCallback, EthQuerySendAsyncFunction } from 'eth-query';
+import { EthQueryish } from '../src/util';
+
+/**
+ * Builds a EthQuery object that implements the bare minimum necessary to pass
+ * to `query`.
+ *
+ * @param overrides - An optional set of methods to add to the fake EthQuery
+ * object.
+ * @returns The fake EthQuery object.
+ */
+export function buildFakeEthQuery(
+  overrides: Record<string, (...args: any[]) => void> = {},
+): EthQueryish {
+  const sendAsync: EthQuerySendAsyncFunction<
+    Record<string, unknown>,
+    string
+  > = (
+    _request: JsonRpcRequest<Record<string, unknown>>,
+    callback: EthQueryMethodCallback<string>,
+  ) => {
+    callback(null, 'default result');
+  };
+
+  return {
+    sendAsync,
+    ...overrides,
+  };
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,6 +6,5 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["./src/**/*.ts"],
   "exclude": ["**/*.test.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,11 +5,9 @@
     "inlineSources": true,
     "module": "commonjs",
     "moduleResolution": "node",
-    "paths": {
-      "*": ["./types/*"]
-    },
     "sourceMap": true,
     "strict": true,
     "target": "es6"
-  }
+  },
+  "include": ["./types/**/*.d.ts", "./src/**/*.ts"]
 }

--- a/types/@metamask/contract-metadata.d.ts
+++ b/types/@metamask/contract-metadata.d.ts
@@ -1,1 +1,12 @@
-declare module '@metamask/contract-metadata';
+declare module '@metamask/contract-metadata' {
+  export type Token = {
+    name: string;
+    logo: string;
+    erc20: boolean;
+    erc721?: boolean;
+    symbol: string;
+    decimals: number;
+  };
+  const contractMap: Record<string, Token>;
+  export default contractMap;
+}

--- a/types/@metamask/metamask-eth-abis.d.ts
+++ b/types/@metamask/metamask-eth-abis.d.ts
@@ -1,1 +1,5 @@
-declare module '@metamask/metamask-eth-abis';
+import { abiERC20, abiERC721, abiERC1155 } from '@metamask/metamask-eth-abis';
+
+declare module '@metamask/metamask-eth-abis' {
+  export type ABI = typeof abiERC20 | typeof abiERC721 | typeof abiERC1155;
+}

--- a/types/eth-ens-namehash.d.ts
+++ b/types/eth-ens-namehash.d.ts
@@ -1,1 +1,4 @@
-declare module 'eth-ens-namehash';
+declare module 'eth-ens-namehash' {
+  export function hash(inputName?: string | null): `0x${string}`;
+  export function normalize(name?: string | null): string;
+}

--- a/types/eth-json-rpc-infura.d.ts
+++ b/types/eth-json-rpc-infura.d.ts
@@ -1,0 +1,41 @@
+declare module 'eth-json-rpc-infura' {
+  import type { JsonRpcMiddleware } from 'json-rpc-engine';
+
+  // Source: <https://docs.infura.io>
+  export type SupportedInfuraNetwork =
+    | 'mainnet'
+    | 'ropsten'
+    | 'rinkeby'
+    | 'kovan'
+    | 'goerli'
+    | 'eth2-beacon-mainnet'
+    | 'ipfs'
+    | 'filecoin'
+    | 'polygon-mainnet'
+    | 'polygon-mumbai'
+    | 'palm-mainnet'
+    | 'palm-testnet'
+    | 'optimism-mainnet'
+    | 'optimism-kovan'
+    | 'arbitrum-mainnet'
+    | 'arbitrum-rinkeby'
+    | 'near-mainnet'
+    | 'near-testnet'
+    | 'aurora-mainnet'
+    | 'aurora-testnet'
+    // Legacy networks for compatibility with NetworkController
+    | 'optimism'
+    | 'optimismTest';
+
+  export type CreateInfuraMiddlewareOptions = {
+    network?: SupportedInfuraNetwork;
+    maxAttempts?: number;
+    source?: string;
+    projectId: string;
+    headers?: Record<string, string>;
+  };
+
+  export default function createInfuraMiddleware<T, U>(
+    opts: CreateInfuraMiddlewareOptions,
+  ): JsonRpcMiddleware<T, U>;
+}

--- a/types/eth-json-rpc-infura/src/createProvider.d.ts
+++ b/types/eth-json-rpc-infura/src/createProvider.d.ts
@@ -1,1 +1,14 @@
-declare module 'eth-json-rpc-infura/src/createProvider';
+declare module 'eth-json-rpc-infura/src/createProvider' {
+  import type { JsonRpcEngine } from 'json-rpc-engine';
+  import type SafeEventEmitter from '@metamask/safe-event-emitter';
+  import type { CreateInfuraMiddlewareOptions } from 'eth-json-rpc-infura';
+
+  interface Provider extends SafeEventEmitter {
+    sendAsync: JsonRpcEngine['handle'];
+    send: JsonRpcEngine['handle'];
+  }
+
+  export default function createProvider(
+    opts: CreateInfuraMiddlewareOptions,
+  ): Provider;
+}

--- a/types/eth-phishing-detect/src/config.json.d.ts
+++ b/types/eth-phishing-detect/src/config.json.d.ts
@@ -1,1 +1,13 @@
-declare module 'eth-phishing-detect/src/config.json';
+declare module 'eth-phishing-detect/src/config.json' {
+  export type EthPhishingDetectorConfiguration = {
+    version: number;
+    tolerance: number;
+    fuzzylist: string[];
+    whitelist: string[];
+    blacklist: string[];
+  };
+
+  const config: EthPhishingDetectorConfiguration;
+
+  export default config;
+}

--- a/types/eth-phishing-detect/src/detector.d.ts
+++ b/types/eth-phishing-detect/src/detector.d.ts
@@ -1,1 +1,18 @@
-declare module 'eth-phishing-detect/src/detector';
+declare module 'eth-phishing-detect/src/detector' {
+  type Check =
+    | { type: 'whitelist'; result: false }
+    | { type: 'blacklist'; result: true }
+    | { type: 'fuzzy'; result: true; match: string }
+    | { type: 'all'; result: true };
+
+  export default class PhishingDetector {
+    constructor(opts: {
+      whitelist?: string[];
+      blacklist?: string[];
+      fuzzylist?: string[];
+      tolerance?: number;
+    });
+
+    check(domain: string): Check;
+  }
+}

--- a/types/eth-query.d.ts
+++ b/types/eth-query.d.ts
@@ -1,1 +1,145 @@
-declare module 'eth-query';
+declare module 'eth-query' {
+  import type { JsonRpcRequest } from 'json-rpc-engine';
+
+  export type EthQueryMethodCallback<R> = (error: any, response: R) => void;
+
+  export type EthProvider = {
+    sendAsync<P, R>(
+      request: JsonRpcRequest<P>,
+      callback: EthQueryMethodCallback<R>,
+    ): void;
+  };
+
+  type HexString = `0x${string}`;
+
+  type BlockParam = HexString | 'latest' | 'earliest' | 'pending';
+
+  export type EthQuerySendAsyncFunction<P = any, R = any> = (
+    request: JsonRpcRequest<P>,
+    callback: EthQueryMethodCallback<R>,
+  ) => void;
+
+  export default class EthQuery {
+    currentProvider: EthProvider;
+
+    constructor(provider: EthProvider);
+
+    // Methods that take arguments
+
+    getBalance<R>(
+      address: HexString,
+      callback: EthQueryMethodCallback<R>,
+    ): void;
+    getBalance<R>(
+      address: HexString,
+      block: BlockParam,
+      callback: EthQueryMethodCallback<R>,
+    ): void;
+
+    getCode<R>(address: HexString, callback: EthQueryMethodCallback<R>): void;
+    getCode<R>(
+      address: HexString,
+      block: BlockParam,
+      callback: EthQueryMethodCallback<R>,
+    ): void;
+
+    getTransactionCount<R>(
+      address: HexString,
+      callback: EthQueryMethodCallback<R>,
+    ): void;
+    getTransactionCount<R>(
+      address: HexString,
+      block: BlockParam,
+      callback: EthQueryMethodCallback<R>,
+    ): void;
+
+    getStorageAt<R>(
+      address: HexString,
+      storagePosition: HexString,
+      callback: EthQueryMethodCallback<R>,
+    ): void;
+    getStorageAt<R>(
+      address: HexString,
+      storagePosition: HexString,
+      block: BlockParam,
+      callback: EthQueryMethodCallback<R>,
+    ): void;
+
+    call<R>(
+      data: {
+        from: HexString;
+        to: HexString;
+        gas?: HexString;
+        gasPrice?: HexString;
+        value?: HexString;
+        data?: HexString;
+      },
+      callback: EthQueryMethodCallback<R>,
+    ): void;
+    call<R>(
+      data: {
+        from: HexString;
+        to: HexString;
+        gas?: HexString;
+        gasPrice?: HexString;
+        value?: HexString;
+        data?: HexString;
+      },
+      block: BlockParam,
+      callback: EthQueryMethodCallback<R>,
+    ): void;
+
+    // Methods that don't take arguments
+
+    protocolVersion<R>(callback: EthQueryMethodCallback<R>): void;
+    syncing<R>(callback: EthQueryMethodCallback<R>): void;
+    coinbase<R>(callback: EthQueryMethodCallback<R>): void;
+    mining<R>(callback: EthQueryMethodCallback<R>): void;
+    hashrate<R>(callback: EthQueryMethodCallback<R>): void;
+    gasPrice<R>(callback: EthQueryMethodCallback<R>): void;
+    accounts<R>(callback: EthQueryMethodCallback<R>): void;
+    blockNumber<R>(callback: EthQueryMethodCallback<R>): void;
+    getBlockTransactionCountByHash<R>(
+      callback: EthQueryMethodCallback<R>,
+    ): void;
+    getBlockTransactionCountByNumber<R>(
+      callback: EthQueryMethodCallback<R>,
+    ): void;
+    getUncleCountByBlockHash<R>(callback: EthQueryMethodCallback<R>): void;
+    getUncleCountByBlockNumber<R>(callback: EthQueryMethodCallback<R>): void;
+    sign<R>(callback: EthQueryMethodCallback<R>): void;
+    sendTransaction<R>(callback: EthQueryMethodCallback<R>): void;
+    sendRawTransaction<R>(callback: EthQueryMethodCallback<R>): void;
+    estimateGas<R>(callback: EthQueryMethodCallback<R>): void;
+    getBlockByHash<R>(callback: EthQueryMethodCallback<R>): void;
+    getBlockByNumber<R>(callback: EthQueryMethodCallback<R>): void;
+    getTransactionByHash<R>(callback: EthQueryMethodCallback<R>): void;
+    getTransactionByBlockHashAndIndex<R>(
+      callback: EthQueryMethodCallback<R>,
+    ): void;
+    getTransactionByBlockNumberAndIndex<R>(
+      callback: EthQueryMethodCallback<R>,
+    ): void;
+    getTransactionReceipt<R>(callback: EthQueryMethodCallback<R>): void;
+    getUncleByBlockHashAndIndex<R>(callback: EthQueryMethodCallback<R>): void;
+    getUncleByBlockNumberAndIndex<R>(callback: EthQueryMethodCallback<R>): void;
+    getCompilers<R>(callback: EthQueryMethodCallback<R>): void;
+    compileLLL<R>(callback: EthQueryMethodCallback<R>): void;
+    compileSolidity<R>(callback: EthQueryMethodCallback<R>): void;
+    compileSerpent<R>(callback: EthQueryMethodCallback<R>): void;
+    newFilter<R>(callback: EthQueryMethodCallback<R>): void;
+    newBlockFilter<R>(callback: EthQueryMethodCallback<R>): void;
+    newPendingTransactionFilter<R>(callback: EthQueryMethodCallback<R>): void;
+    uninstallFilter<R>(callback: EthQueryMethodCallback<R>): void;
+    getFilterChanges<R>(callback: EthQueryMethodCallback<R>): void;
+    getFilterLogs<R>(callback: EthQueryMethodCallback<R>): void;
+    getLogs<R>(callback: EthQueryMethodCallback<R>): void;
+    getWork<R>(callback: EthQueryMethodCallback<R>): void;
+    submitWork<R>(callback: EthQueryMethodCallback<R>): void;
+    submitHashrate<R>(callback: EthQueryMethodCallback<R>): void;
+
+    // Custom methods
+
+    sendAsync: EthQuerySendAsyncFunction;
+  }
+}

--- a/types/ethjs-provider-http.d.ts
+++ b/types/ethjs-provider-http.d.ts
@@ -1,1 +1,16 @@
-declare module 'ethjs-provider-http';
+declare module 'ethjs-provider-http' {
+  import type { JsonRpcRequest } from 'json-rpc-engine';
+  export type EthQueryMethodCallback<R> = (error: any, response: R) => void;
+
+  export default class HttpProvider {
+    host: string;
+    timeout: number;
+
+    constructor(host: string, timeout?: number);
+
+    sendAsync<P, R>(
+      request: JsonRpcRequest<P>,
+      callback: EthQueryMethodCallback<R>,
+    ): void;
+  }
+}

--- a/types/ethjs-unit.d.ts
+++ b/types/ethjs-unit.d.ts
@@ -1,1 +1,64 @@
-declare module 'ethjs-unit';
+declare module 'ethjs-unit' {
+  import type BN from 'bn.js';
+
+  // This type is derived from the logic within `number-to-bn` and represents an
+  // object obtained via `bn.js` or `bignumber.js`.
+  type BigNumberish = ({ mul: any } | { dividedToIntegerBy: any }) & {
+    toString: (base: number) => string;
+  };
+
+  type AcceptableBNInput = string | number | BigNumberish;
+
+  // This should be `keyof typeof unitMap` but really accepts anything
+  type Unitish = string | null | undefined;
+
+  type Numberish =
+    | string
+    | number
+    | (({ toTwos: any } | { dividedToIntegerBy: any }) & {
+        toPrecision?: () => string;
+        toString: (base: number) => string | number;
+      });
+
+  export const unitMap: {
+    noether: '0';
+    wei: '1';
+    kwei: '1000';
+    Kwei: '1000';
+    babbage: '1000';
+    femtoether: '1000';
+    mwei: '1000000';
+    Mwei: '1000000';
+    lovelace: '1000000';
+    picoether: '1000000';
+    gwei: '1000000000';
+    Gwei: '1000000000';
+    shannon: '1000000000';
+    nanoether: '1000000000';
+    nano: '1000000000';
+    szabo: '1000000000000';
+    microether: '1000000000000';
+    micro: '1000000000000';
+    finney: '1000000000000000';
+    milliether: '1000000000000000';
+    milli: '1000000000000000';
+    ether: '1000000000000000000';
+    kether: '1000000000000000000000';
+    grand: '1000000000000000000000';
+    mether: '1000000000000000000000000';
+    gether: '1000000000000000000000000000';
+    tether: '1000000000000000000000000000000';
+  };
+
+  export function numberToString(arg: Numberish): string;
+
+  export function getValueOfUnit(unitInput: Unitish): BN;
+
+  export function fromWei(
+    weiInput: AcceptableBNInput,
+    unit: Unitish,
+    optionsInput?: { pad?: boolean; commify?: boolean },
+  ): string;
+
+  export function toWei(etherInput: Numberish, unit: Unitish): BN;
+}


### PR DESCRIPTION
Some of our internal NPM packages are still untyped. Currently we get
around this by stubbing the types for these modules in a
`dependencies.d.ts` file, but this merely tags everything exported from
the modules as `any`.

To address this, this commit adds proper types for most of the modules
marked in `dependencies.d.ts` so that these types can be accessed and
utilized within the code that uses these modules. The modules that are
left over are those that would either take too long to fill in or those
that we are planning on removing soon anyway.

---

NOTE: These changes are not intended to be breaking. In other words, all the types here should reflect current behavior, not ideal behavior. If you see a change that could be breaking, let me know.

---

Fixes #728.