### PR TITLE
Catch errors thrown from ethereumjs-util methods in keyring controller

### DIFF
--- a/src/keyring/KeyringController.test.ts
+++ b/src/keyring/KeyringController.test.ts
@@ -155,10 +155,23 @@ describe('KeyringController', () => {
     } catch (e) {
       error2 = e;
     }
+
+    let error3;
+    try {
+      await keyringController.importAccountWithStrategy(
+        AccountImportStrategy.privateKey,
+        ['0xblahblah'],
+      );
+    } catch (e) {
+      error3 = e;
+    }
+
     expect(error1.message).toBe('Cannot import an empty key.');
     expect(error2.message).toBe(
       'Expected private key to be an Uint8Array with length 32',
     );
+    expect(error3.message).toBe('Cannot import invalid private key.');
+
     const address = '0x51253087e6f8358b5f10c0a94315d69db3357859';
     const newKeyring = { accounts: [address], type: 'Simple Key Pair' };
     const obj = await keyringController.importAccountWithStrategy(

--- a/src/keyring/KeyringController.test.ts
+++ b/src/keyring/KeyringController.test.ts
@@ -137,40 +137,31 @@ describe('KeyringController', () => {
   });
 
   it('should import account with strategy privateKey', async () => {
-    let error1;
-    try {
-      await keyringController.importAccountWithStrategy(
-        AccountImportStrategy.privateKey,
-        [],
-      );
-    } catch (e) {
-      error1 = e;
-    }
-    let error2;
-    try {
-      await keyringController.importAccountWithStrategy(
-        AccountImportStrategy.privateKey,
-        ['123'],
-      );
-    } catch (e) {
-      error2 = e;
-    }
+    await expect(
+      async () =>
+        await keyringController.importAccountWithStrategy(
+          AccountImportStrategy.privateKey,
+          [],
+        ),
+    ).rejects.toThrow('Cannot import an empty key.');
 
-    let error3;
-    try {
-      await keyringController.importAccountWithStrategy(
-        AccountImportStrategy.privateKey,
-        ['0xblahblah'],
-      );
-    } catch (e) {
-      error3 = e;
-    }
-
-    expect(error1.message).toBe('Cannot import an empty key.');
-    expect(error2.message).toBe(
+    await expect(
+      async () =>
+        await keyringController.importAccountWithStrategy(
+          AccountImportStrategy.privateKey,
+          ['123'],
+        ),
+    ).rejects.toThrow(
       'Expected private key to be an Uint8Array with length 32',
     );
-    expect(error3.message).toBe('Cannot import invalid private key.');
+
+    await expect(
+      async () =>
+        await keyringController.importAccountWithStrategy(
+          AccountImportStrategy.privateKey,
+          ['0xblahblah'],
+        ),
+    ).rejects.toThrow('Cannot import invalid private key.');
 
     const address = '0x51253087e6f8358b5f10c0a94315d69db3357859';
     const newKeyring = { accounts: [address], type: 'Simple Key Pair' };

--- a/src/keyring/KeyringController.ts
+++ b/src/keyring/KeyringController.ts
@@ -337,10 +337,19 @@ export class KeyringController extends BaseController<
           throw new Error('Cannot import an empty key.');
         }
         const prefixed = addHexPrefix(importedKey);
-        /* istanbul ignore if */
-        if (!isValidPrivate(toBuffer(prefixed))) {
+
+        let bufferedPrivateKey;
+        try {
+          bufferedPrivateKey = toBuffer(prefixed);
+        } catch {
           throw new Error('Cannot import invalid private key.');
         }
+
+        /* istanbul ignore if */
+        if (!isValidPrivate(bufferedPrivateKey)) {
+          throw new Error('Cannot import invalid private key.');
+        }
+
         privateKey = stripHexPrefix(prefixed);
         break;
       case 'json':


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/pm-security/issues/45

Catch and ignore errors thrown by `ethereumjs-util` methods `toBuffer` or `isValidPrivate` while importing an account. Throw an error we control (`Cannot import invalid private key.`) instead.