### PR TITLE
Move new keystone package to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@ethereumjs/common": "^2.3.1",
     "@ethereumjs/tx": "^3.2.1",
+    "@keystonehq/metamask-airgapped-keyring": "^0.3.0",
     "@metamask/contract-metadata": "^1.33.0",
     "@metamask/metamask-eth-abis": "3.0.0",
     "@metamask/types": "^1.1.0",
@@ -72,7 +73,6 @@
   },
   "devDependencies": {
     "@keystonehq/bc-ur-registry-eth": "^0.9.0",
-    "@keystonehq/metamask-airgapped-keyring": "^0.3.0",
     "@lavamoat/allow-scripts": "^1.0.6",
     "@metamask/auto-changelog": "^2.5.0",
     "@metamask/eslint-config": "^9.0.0",


### PR DESCRIPTION
KeyringController now imports `@keystonehq/metamask-airgapped-keyring`.
This should not be included in `devDependencies`, but rather
`dependencies`. This is causing issues downstream.