### PR TITLE
Copy .gitattributes from template repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+
+yarn.lock linguist-generated=false


### PR DESCRIPTION
This normalizes line endings and instructs GitHub not to collapse
`yarn.lock`.