### PR TITLE
Fix inclusion of module-augmenting .d.ts's

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,6 +6,5 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["./src/**/*.ts"],
   "exclude": ["**/*.test.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,11 +5,9 @@
     "inlineSources": true,
     "module": "commonjs",
     "moduleResolution": "node",
-    "paths": {
-      "*": ["./types/*"]
-    },
     "sourceMap": true,
     "strict": true,
     "target": "es6"
-  }
+  },
+  "include": ["./types/**/*.d.ts", "./src/**/*.ts"]
 }


### PR DESCRIPTION
A previous commit updated the TypeScript configuration so TypeScript
would better recognize type definition files whose purpose was to
backfill types for existing packages. After testing, this revealed a
misunderstanding of the `paths` option in `tsconfig.json`.

It turns out that `paths` completely overrides how TypeScript resolves
modules and locates type definition files for modules. The consequence
of this option is that if a module includes type definitions, but we
also supply type definitions for that module in `types/`, then our type
definitions will win. This degrades the developer experience: sometimes,
a package already has types, but we merely need to *augment* those
types in some way. The `paths` option makes it impossible to do this.

This commit keeps the `types/` directory (as it'll be important later)
but informs TypeScript about the type definition files here by adding
them to the `include` option in `tsconfig.json` (which was the original
strategy).