### PR TITLE
@lavamoat/allow-scripts@2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@keystonehq/bc-ur-registry-eth": "^0.9.0",
-    "@lavamoat/allow-scripts": "^1.0.6",
+    "@lavamoat/allow-scripts": "^2.0.2",
     "@metamask/auto-changelog": "^2.5.0",
     "@metamask/eslint-config": "^9.0.0",
     "@metamask/eslint-config-jest": "^9.0.0",
@@ -119,10 +119,13 @@
   "lavamoat": {
     "allowScripts": {
       "@lavamoat/preinstall-always-fail": false,
-      "core-js": false,
-      "keccak": true,
-      "secp256k1": true,
-      "sha3": true
+      "@keystonehq/bc-ur-registry-eth>hdkey>secp256k1": true,
+      "babel-runtime>core-js": false,
+      "eth-sig-util>ethereumjs-abi>ethereumjs-util>keccakjs>sha3": true,
+      "eth-sig-util>ethereumjs-util>keccak": true,
+      "eth-sig-util>ethereumjs-util>secp256k1": true,
+      "ethereumjs-util>ethereum-cryptography>keccak": true,
+      "ethereumjs-util>ethereum-cryptography>secp256k1": true
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1112,23 +1112,21 @@
     rlp "^2.2.6"
     uuid "^8.3.2"
 
-"@lavamoat/allow-scripts@^1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@lavamoat/allow-scripts/-/allow-scripts-1.0.6.tgz#fbdf7c35a5c2c2cff05ba002b7bc8f3355bda22c"
-  integrity sha512-bBUN2xuQEXWmWTJrfkwaM8Ige7TNfTTRodyW353VYnzX7kW866Tm/Ag0hdbukFvJfNjRHabVmLKxYYL8l/uyZQ==
+"@lavamoat/aa@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@lavamoat/aa/-/aa-2.0.1.tgz#fff7605101c9b7a5dd6495e999a492010fba702f"
+  integrity sha512-lS0DccPZaZyxEqs3+zj76cITrJdaazfIoTs8J3tjS9uA3yvFmZ/QFPsgE5AZxyoO8HPtaz5bGa8x605iNlBVXA==
   dependencies:
-    "@lavamoat/preinstall-always-fail" "^1.0.0"
-    "@npmcli/run-script" "^1.8.1"
-    "@yarnpkg/lockfile" "^1.1.0"
-    npm-logical-tree "^1.2.1"
     resolve "^1.20.0"
-    semver "^7.3.4"
-    yargs "^16.2.0"
 
-"@lavamoat/preinstall-always-fail@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@lavamoat/preinstall-always-fail/-/preinstall-always-fail-1.0.0.tgz#e78a6e3d9e212a4fef869ec37d4f5fb498dea373"
-  integrity sha512-vD2DcC0ffJj1w2y1Lu0OU39wHmlPEd2tCDW04Bm6Kf4LyRnCHCezTsS8yzeSJ+4so7XP+TITuR5FGJRWxPb+GA==
+"@lavamoat/allow-scripts@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@lavamoat/allow-scripts/-/allow-scripts-2.0.2.tgz#57b4670e30ff720c306fff9adf775689bba0d999"
+  integrity sha512-bJUXKDau/NgAGngKKLDfbx72gBhgTOUSRgYA8RuHuEX1OgAIk8QMlcPDvwhBCb26mjEHDnxlp5F/Uov0uPEbQw==
+  dependencies:
+    "@lavamoat/aa" "^2.0.1"
+    "@npmcli/run-script" "^1.8.1"
+    yargs "^16.2.0"
 
 "@metamask/auto-changelog@^2.5.0":
   version "2.5.0"
@@ -1640,11 +1638,6 @@
   dependencies:
     "@typescript-eslint/types" "4.22.0"
     eslint-visitor-keys "^2.0.0"
-
-"@yarnpkg/lockfile@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
-  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
 abab@^2.0.0:
   version "2.0.5"
@@ -6303,11 +6296,6 @@ normalize-path@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-npm-logical-tree@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz#44610141ca24664cad35d1e607176193fd8f5b88"
-  integrity sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==
-
 npm-normalize-package-bin@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
@@ -7366,7 +7354,7 @@ semaphore@>=1.0.1, semaphore@^1.0.3:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
+semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==


### PR DESCRIPTION
Bumps @lavamoat/allow-scripts to version 2.0.2. This required re-running `yarn allow-scripts auto` and rewriting most of the LavaMoat config.