### PR TITLE
Add PermissionController:hasAllPermissions

### DIFF
--- a/src/permissions/PermissionController.test.ts
+++ b/src/permissions/PermissionController.test.ts
@@ -4384,6 +4384,74 @@ describe('PermissionController', () => {
       expect(hasPermissionsSpy).toHaveBeenNthCalledWith(2, 'foo');
     });
 
+    it('action: PermissionController:hasAllPermissions', () => {
+      const messenger = getUnrestrictedMessenger();
+      const options = getPermissionControllerOptions({
+        messenger: getPermissionControllerMessenger(messenger),
+      });
+      const controller = new PermissionController<
+        DefaultPermissionSpecifications,
+        DefaultCaveatSpecifications
+      >(options);
+      const hasAllPermissionsSpy = jest.spyOn(controller, 'hasAllPermissions');
+
+      const origin = 'foo';
+      const permissions = ['wallet_getSecretArray', 'endowmentPermission1'];
+      expect(
+        messenger.call(
+          'PermissionController:hasAllPermissions',
+          origin,
+          permissions,
+        ),
+      ).toStrictEqual(false);
+
+      controller.grantPermissions({
+        subject: { origin },
+        approvedPermissions: {
+          wallet_getSecretArray: {},
+        },
+      });
+
+      expect(
+        messenger.call(
+          'PermissionController:hasAllPermissions',
+          origin,
+          permissions,
+        ),
+      ).toStrictEqual(false);
+
+      controller.grantPermissions({
+        subject: { origin },
+        approvedPermissions: {
+          endowmentPermission1: {},
+        },
+      });
+
+      expect(
+        messenger.call(
+          'PermissionController:hasAllPermissions',
+          origin,
+          permissions,
+        ),
+      ).toStrictEqual(true);
+      expect(hasAllPermissionsSpy).toHaveBeenCalledTimes(3);
+      expect(hasAllPermissionsSpy).toHaveBeenNthCalledWith(
+        1,
+        origin,
+        permissions,
+      );
+      expect(hasAllPermissionsSpy).toHaveBeenNthCalledWith(
+        2,
+        origin,
+        permissions,
+      );
+      expect(hasAllPermissionsSpy).toHaveBeenNthCalledWith(
+        3,
+        origin,
+        permissions,
+      );
+    });
+
     it('action: PermissionController:getPermissions', () => {
       const messenger = getUnrestrictedMessenger();
       const options = getPermissionControllerOptions({

--- a/src/permissions/PermissionController.test.ts
+++ b/src/permissions/PermissionController.test.ts
@@ -4440,11 +4440,13 @@ describe('PermissionController', () => {
         origin,
         permissions,
       );
+
       expect(hasAllPermissionsSpy).toHaveBeenNthCalledWith(
         2,
         origin,
         permissions,
       );
+
       expect(hasAllPermissionsSpy).toHaveBeenNthCalledWith(
         3,
         origin,

--- a/src/permissions/PermissionController.ts
+++ b/src/permissions/PermissionController.ts
@@ -213,6 +213,14 @@ export type HasPermission = {
 };
 
 /**
+ * Checks whether the specified subject has all specified permissions.
+ */
+export type HasAllPermissions = {
+  type: `${typeof controllerName}:hasAllPermissions`;
+  handler: GenericPermissionController['hasAllPermissions'];
+};
+
+/**
  * Requests given permissions for a specified origin
  */
 export type RequestPermissions = {
@@ -263,6 +271,7 @@ export type PermissionControllerActions =
   | GetPermissions
   | HasPermission
   | HasPermissions
+  | HasAllPermissions
   | RevokePermissions
   | RevokeAllPermissions
   | RequestPermissions;
@@ -686,6 +695,12 @@ export class PermissionController<
     );
 
     this.messagingSystem.registerActionHandler(
+      `${controllerName}:hasAllPermissions` as const,
+      (origin: OriginString, targets: string[]) =>
+        this.hasAllPermissions(origin, targets),
+    );
+
+    this.messagingSystem.registerActionHandler(
       `${controllerName}:revokeAllPermissions` as const,
       (origin: OriginString) => this.revokeAllPermissions(origin),
     );
@@ -843,6 +858,24 @@ export class PermissionController<
     >['parentCapability'],
   ): boolean {
     return Boolean(this.getPermission(origin, target));
+  }
+
+  /**
+   * Checks whether the subject with the specified origin has all the specified
+   * permissions.
+   *
+   * @param origin - The origin of the subject.
+   * @param targets - The target names of every permission.
+   * @returns Whether the subject has all the permissions.
+   */
+  hasAllPermissions(
+    origin: OriginString,
+    targets: ExtractPermission<
+      ControllerPermissionSpecification,
+      ControllerCaveatSpecification
+    >['parentCapability'][],
+  ): boolean {
+    return targets.every((target) => this.hasPermission(origin, target));
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

Add `hasAllPermissions` function to `PermissionController`.

**Description**
- ADDED:
  - Add `hasAllPermissions` function to `PermissionController`.
    - For use in `snaps-skunkworks` to check for multiple permissions in one call

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented
