### PR TITLE
Use `github.sha` for publish jobs

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,9 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          # We check out the release pull request's base branch, which will be
-          # used as the base branch for all git operations.
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.sha }}
       - name: Get Node.js version
         id: nvm
         run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
@@ -43,9 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          # We check out the release pull request's base branch, which will be
-          # used as the base branch for all git operations.
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.sha }}
       - uses: actions/cache@v3
         id: restore-build
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           path: ./dist
           key: ${{ github.sha }}
-        # set ignore-scripts to skip prePublish
+        # Set `ignore-scripts` to skip `prepublishOnly` because the release was built already in the previous job
       - run: npm config set ignore-scripts true
       - name: Publish
         uses: MetaMask/action-npm-publish@v1.0.0

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -47,6 +47,8 @@ jobs:
         with:
           path: ./dist
           key: ${{ github.sha }}
+        # set ignore-scripts to skip prePublish
+      - run: npm config set ignore-scripts true
       - name: Publish
         uses: MetaMask/action-npm-publish@v1.0.0
         with:


### PR DESCRIPTION
It would appear that `github.event.pull_request.base.sha` is actually _not_ what we want here.

Instead we use `github.sha` which will ensure we get the "The commit SHA that triggered the workflow run."

Additionally we set `ignore-scripts true` in our npm config so we can skip the `prePublish` step (which runs `yarn build` again).