### PR TITLE
Added GrantPermissions action to PermissionsController

### DIFF
--- a/src/permissions/PermissionController.test.ts
+++ b/src/permissions/PermissionController.test.ts
@@ -30,7 +30,6 @@ import {
   RestrictedMethodParameters,
   ValidPermission,
 } from '.';
-
 // Caveat types and specifications
 
 const CaveatTypes = {
@@ -4490,6 +4489,27 @@ describe('PermissionController', () => {
         1,
         'wallet_getSecretArray',
       );
+    });
+
+    it('action: PermissionsController:grantPermissions', async () => {
+      const messenger = getUnrestrictedMessenger();
+      const options = getPermissionControllerOptions({
+        messenger: getPermissionControllerMessenger(messenger),
+      });
+      const controller = new PermissionController<
+        DefaultPermissionSpecifications,
+        DefaultCaveatSpecifications
+      >(options);
+
+      const result = messenger.call('PermissionController:grantPermissions', {
+        subject: { origin: 'foo' },
+        approvedPermissions: { wallet_getSecretArray: {} },
+      });
+
+      expect(result).toHaveProperty('wallet_getSecretArray');
+      expect(
+        controller.hasPermission('foo', 'wallet_getSecretArray'),
+      ).toStrictEqual(true);
     });
 
     it('action: PermissionsController:requestPermissions', async () => {

--- a/src/permissions/PermissionController.ts
+++ b/src/permissions/PermissionController.ts
@@ -213,6 +213,14 @@ export type HasPermission = {
 };
 
 /**
+ * Directly grants given permissions for a specificed origin without requesting user approval
+ */
+export type GrantPermissions = {
+  type: `${typeof controllerName}:grantPermissions`;
+  handler: GenericPermissionController['grantPermissions'];
+};
+
+/**
  * Requests given permissions for a specified origin
  */
 export type RequestPermissions = {
@@ -272,6 +280,7 @@ export type PermissionControllerActions =
   | GetPermissions
   | HasPermission
   | HasPermissions
+  | GrantPermissions
   | RequestPermissions
   | RevokeAllPermissions
   | RevokePermissionForAllSubjects
@@ -688,6 +697,11 @@ export class PermissionController<
     this.messagingSystem.registerActionHandler(
       `${controllerName}:hasPermissions` as const,
       (origin: OriginString) => this.hasPermissions(origin),
+    );
+
+    this.messagingSystem.registerActionHandler(
+      `${controllerName}:grantPermissions` as const,
+      this.grantPermissions.bind(this),
     );
 
     this.messagingSystem.registerActionHandler(


### PR DESCRIPTION
This is needed to allow a new UI page for Snaps. We want to ask the user for approval for an update, showing new permissions on the same page. This will be implemented as a new ApprovalController request in SnapController and then call to grantPermissions in PermissionController. Related PR: https://github.com/MetaMask/snaps-skunkworks/pull/322