### PR TITLE
Add `override` keyword

### DIFF
--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -74,7 +74,7 @@ class BarController extends BaseController<never, BarControllerState> {
     bar: 'bar',
   };
 
-  name = 'BarController';
+  override name = 'BarController';
 
   constructor() {
     super();

--- a/src/ComposableController.ts
+++ b/src/ComposableController.ts
@@ -32,7 +32,7 @@ export class ComposableController extends BaseController<never, any> {
   /**
    * Name of this controller used during composition
    */
-  name = 'ComposableController';
+  override name = 'ComposableController';
 
   /**
    * Creates a ComposableController instance.

--- a/src/assets/AccountTrackerController.ts
+++ b/src/assets/AccountTrackerController.ts
@@ -71,7 +71,7 @@ export class AccountTrackerController extends BaseController<
   /**
    * Name of this controller used during composition
    */
-  name = 'AccountTrackerController';
+  override name = 'AccountTrackerController';
 
   private getIdentities: () => PreferencesState['identities'];
 

--- a/src/assets/AssetsContractController.ts
+++ b/src/assets/AssetsContractController.ts
@@ -53,7 +53,7 @@ export class AssetsContractController extends BaseController<
   /**
    * Name of this controller used during composition
    */
-  name = 'AssetsContractController';
+  override name = 'AssetsContractController';
 
   /**
    * Creates a AssetsContractController instance.

--- a/src/assets/CollectibleDetectionController.ts
+++ b/src/assets/CollectibleDetectionController.ts
@@ -166,7 +166,7 @@ export class CollectibleDetectionController extends BaseController<
   /**
    * Name of this controller used during composition
    */
-  name = 'CollectibleDetectionController';
+  override name = 'CollectibleDetectionController';
 
   private getOpenSeaApiKey: () => string | undefined;
 

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -789,7 +789,7 @@ export class CollectiblesController extends BaseController<
   /**
    * Name of this controller used during composition
    */
-  name = 'CollectiblesController';
+  override name = 'CollectiblesController';
 
   private getERC721AssetName: AssetsContractController['getERC721AssetName'];
 

--- a/src/assets/CurrencyRateController.ts
+++ b/src/assets/CurrencyRateController.ts
@@ -139,7 +139,7 @@ export class CurrencyRateController extends BaseController<
    *
    * This stops any active polling.
    */
-  destroy() {
+  override destroy() {
     super.destroy();
     this.stopPolling();
   }

--- a/src/assets/TokenBalancesController.ts
+++ b/src/assets/TokenBalancesController.ts
@@ -44,7 +44,7 @@ export class TokenBalancesController extends BaseController<
   /**
    * Name of this controller used during composition
    */
-  name = 'TokenBalancesController';
+  override name = 'TokenBalancesController';
 
   private getSelectedAddress: () => PreferencesState['selectedAddress'];
 

--- a/src/assets/TokenDetectionController.ts
+++ b/src/assets/TokenDetectionController.ts
@@ -39,7 +39,7 @@ export class TokenDetectionController extends BaseController<
   /**
    * Name of this controller used during composition
    */
-  name = 'TokenDetectionController';
+  override name = 'TokenDetectionController';
 
   private getBalancesInSingleCall: AssetsContractController['getBalancesInSingleCall'];
 

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -203,7 +203,7 @@ export class TokenListController extends BaseController<
    *
    * This stops any active polling.
    */
-  destroy() {
+  override destroy() {
     super.destroy();
     this.stopPolling();
   }

--- a/src/assets/TokenRatesController.ts
+++ b/src/assets/TokenRatesController.ts
@@ -150,7 +150,7 @@ export class TokenRatesController extends BaseController<
   /**
    * Name of this controller used during composition
    */
-  name = 'TokenRatesController';
+  override name = 'TokenRatesController';
 
   /**
    * Creates a TokenRatesController instance.

--- a/src/assets/TokensController.ts
+++ b/src/assets/TokensController.ts
@@ -124,7 +124,7 @@ export class TokensController extends BaseController<
   /**
    * Name of this controller used during composition
    */
-  name = 'TokensController';
+  override name = 'TokensController';
 
   /**
    * Creates a TokensController instance.

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -455,7 +455,7 @@ export class GasFeeController extends BaseController<
    *
    * This stops any active polling.
    */
-  destroy() {
+  override destroy() {
     super.destroy();
     this.stopPolling();
   }

--- a/src/keyring/KeyringController.ts
+++ b/src/keyring/KeyringController.ts
@@ -136,7 +136,7 @@ export class KeyringController extends BaseController<
   /**
    * Name of this controller used during composition
    */
-  name = 'KeyringController';
+  override name = 'KeyringController';
 
   private removeIdentity: PreferencesController['removeIdentity'];
 
@@ -516,7 +516,7 @@ export class KeyringController extends BaseController<
    *
    * @param listener - Callback triggered when state changes.
    */
-  subscribe(listener: Listener<KeyringState>) {
+  override subscribe(listener: Listener<KeyringState>) {
     privates.get(this).keyring.store.subscribe(listener);
   }
 
@@ -526,7 +526,7 @@ export class KeyringController extends BaseController<
    * @param listener - Callback to remove.
    * @returns True if a listener is found and unsubscribed.
    */
-  unsubscribe(listener: Listener<KeyringState>) {
+  override unsubscribe(listener: Listener<KeyringState>) {
     return privates.get(this).keyring.store.unsubscribe(listener);
   }
 

--- a/src/message-manager/AbstractMessageManager.ts
+++ b/src/message-manager/AbstractMessageManager.ts
@@ -129,7 +129,7 @@ export abstract class AbstractMessageManager<
   /**
    * Name of this controller used during composition
    */
-  name = 'AbstractMessageManager';
+  override name = 'AbstractMessageManager';
 
   /**
    * Creates an AbstractMessageManager instance.

--- a/src/message-manager/MessageManager.ts
+++ b/src/message-manager/MessageManager.ts
@@ -60,7 +60,7 @@ export class MessageManager extends AbstractMessageManager<
   /**
    * Name of this controller used during composition
    */
-  name = 'MessageManager';
+  override name = 'MessageManager';
 
   /**
    * Creates a new Message with an 'unapproved' status using the passed messageParams.

--- a/src/message-manager/PersonalMessageManager.ts
+++ b/src/message-manager/PersonalMessageManager.ts
@@ -61,7 +61,7 @@ export class PersonalMessageManager extends AbstractMessageManager<
   /**
    * Name of this controller used during composition
    */
-  name = 'PersonalMessageManager';
+  override name = 'PersonalMessageManager';
 
   /**
    * Creates a new Message with an 'unapproved' status using the passed messageParams.

--- a/src/message-manager/TypedMessageManager.ts
+++ b/src/message-manager/TypedMessageManager.ts
@@ -78,7 +78,7 @@ export class TypedMessageManager extends AbstractMessageManager<
   /**
    * Name of this controller used during composition
    */
-  name = 'TypedMessageManager';
+  override name = 'TypedMessageManager';
 
   /**
    * Creates a new TypedMessage with an 'unapproved' status using the passed messageParams.

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -210,7 +210,7 @@ export class NetworkController extends BaseController<
   /**
    * Name of this controller used during composition
    */
-  name = 'NetworkController';
+  override name = 'NetworkController';
 
   /**
    * Ethereum provider object for the current network

--- a/src/permissions/errors.ts
+++ b/src/permissions/errors.ts
@@ -182,7 +182,7 @@ export class CaveatAlreadyExistsError extends Error {
 }
 
 export class InvalidCaveatError extends EthereumRpcError<unknown> {
-  public data: { origin: string; target: string };
+  public override data: { origin: string; target: string };
 
   constructor(receivedCaveat: unknown, origin: string, target: string) {
     super(

--- a/src/third-party/EnsController.ts
+++ b/src/third-party/EnsController.ts
@@ -37,7 +37,7 @@ export class EnsController extends BaseController<BaseConfig, EnsState> {
   /**
    * Name of this controller used during composition
    */
-  name = 'EnsController';
+  override name = 'EnsController';
 
   /**
    * Creates an EnsController instance.

--- a/src/third-party/PhishingController.ts
+++ b/src/third-party/PhishingController.ts
@@ -62,7 +62,7 @@ export class PhishingController extends BaseController<
   /**
    * Name of this controller used during composition
    */
-  name = 'PhishingController';
+  override name = 'PhishingController';
 
   /**
    * Creates a PhishingController instance.

--- a/src/transaction/TransactionController.ts
+++ b/src/transaction/TransactionController.ts
@@ -388,7 +388,7 @@ export class TransactionController extends BaseController<
   /**
    * Name of this controller used during composition
    */
-  name = 'TransactionController';
+  override name = 'TransactionController';
 
   /**
    * Method used to sign transactions

--- a/src/user/AddressBookController.ts
+++ b/src/user/AddressBookController.ts
@@ -57,7 +57,7 @@ export class AddressBookController extends BaseController<
   /**
    * Name of this controller used during composition
    */
-  name = 'AddressBookController';
+  override name = 'AddressBookController';
 
   /**
    * Creates an AddressBookController instance.

--- a/src/user/PreferencesController.ts
+++ b/src/user/PreferencesController.ts
@@ -60,7 +60,7 @@ export class PreferencesController extends BaseController<
   /**
    * Name of this controller used during composition
    */
-  name = 'PreferencesController';
+  override name = 'PreferencesController';
 
   /**
    * Creates a PreferencesController instance.


### PR DESCRIPTION
The `override` keyword has been added in all places where we are overriding a method or field. This was done by temporarily enabling the `noImplicitOverride` flag. I didn't leave the flag set because there is still an error to resolve in a dependency before we can leave it on.