### PR TITLE
Replace WeakMap with private fields

### DIFF
--- a/src/keyring/KeyringController.ts
+++ b/src/keyring/KeyringController.ts
@@ -29,8 +29,6 @@ import { PersonalMessageParams } from '../message-manager/PersonalMessageManager
 import { TypedMessageParams } from '../message-manager/TypedMessageManager';
 import { toChecksumHexAddress } from '../util';
 
-const privates = new WeakMap();
-
 /**
  * Available keyring types
  */
@@ -148,6 +146,8 @@ export class KeyringController extends BaseController<
 
   private setAccountLabel?: PreferencesController['setAccountLabel'];
 
+  #keyring: typeof Keyring;
+
   /**
    * Creates a KeyringController instance.
    *
@@ -178,12 +178,10 @@ export class KeyringController extends BaseController<
     state?: Partial<KeyringState>,
   ) {
     super(config, state);
-    privates.set(this, {
-      keyring: new Keyring(Object.assign({ initState: state }, config)),
-    });
+    this.#keyring = new Keyring(Object.assign({ initState: state }, config));
 
     this.defaultState = {
-      ...privates.get(this).keyring.store.getState(),
+      ...this.#keyring.store.getState(),
       keyrings: [],
     };
     this.removeIdentity = removeIdentity;
@@ -201,16 +199,14 @@ export class KeyringController extends BaseController<
    * @returns Promise resolving to current state when the account is added.
    */
   async addNewAccount(): Promise<KeyringMemState> {
-    const primaryKeyring = privates
-      .get(this)
-      .keyring.getKeyringsByType('HD Key Tree')[0];
+    const primaryKeyring = this.#keyring.getKeyringsByType('HD Key Tree')[0];
     /* istanbul ignore if */
     if (!primaryKeyring) {
       throw new Error('No HD keyring found');
     }
-    const oldAccounts = await privates.get(this).keyring.getAccounts();
-    await privates.get(this).keyring.addNewAccount(primaryKeyring);
-    const newAccounts = await privates.get(this).keyring.getAccounts();
+    const oldAccounts = await this.#keyring.getAccounts();
+    await this.#keyring.addNewAccount(primaryKeyring);
+    const newAccounts = await this.#keyring.getAccounts();
 
     await this.verifySeedPhrase();
 
@@ -229,14 +225,12 @@ export class KeyringController extends BaseController<
    * @returns Promise resolving to current state when the account is added.
    */
   async addNewAccountWithoutUpdate(): Promise<KeyringMemState> {
-    const primaryKeyring = privates
-      .get(this)
-      .keyring.getKeyringsByType('HD Key Tree')[0];
+    const primaryKeyring = this.#keyring.getKeyringsByType('HD Key Tree')[0];
     /* istanbul ignore if */
     if (!primaryKeyring) {
       throw new Error('No HD keyring found');
     }
-    await privates.get(this).keyring.addNewAccount(primaryKeyring);
+    await this.#keyring.addNewAccount(primaryKeyring);
     await this.verifySeedPhrase();
     return this.fullUpdate();
   }
@@ -253,10 +247,11 @@ export class KeyringController extends BaseController<
     const releaseLock = await this.mutex.acquire();
     try {
       this.updateIdentities([]);
-      const vault = await privates
-        .get(this)
-        .keyring.createNewVaultAndRestore(password, seed);
-      this.updateIdentities(await privates.get(this).keyring.getAccounts());
+      const vault = await this.#keyring.createNewVaultAndRestore(
+        password,
+        seed,
+      );
+      this.updateIdentities(await this.#keyring.getAccounts());
       this.fullUpdate();
       return vault;
     } finally {
@@ -273,10 +268,8 @@ export class KeyringController extends BaseController<
   async createNewVaultAndKeychain(password: string) {
     const releaseLock = await this.mutex.acquire();
     try {
-      const vault = await privates
-        .get(this)
-        .keyring.createNewVaultAndKeychain(password);
-      this.updateIdentities(await privates.get(this).keyring.getAccounts());
+      const vault = await this.#keyring.createNewVaultAndKeychain(password);
+      this.updateIdentities(await this.#keyring.getAccounts());
       this.fullUpdate();
       return vault;
     } finally {
@@ -290,7 +283,7 @@ export class KeyringController extends BaseController<
    * @returns Boolean returning true if the vault is unlocked.
    */
   isUnlocked(): boolean {
-    return privates.get(this).keyring.memStore.getState().isUnlocked;
+    return this.#keyring.memStore.getState().isUnlocked;
   }
 
   /**
@@ -300,8 +293,8 @@ export class KeyringController extends BaseController<
    * @returns Promise resolving to the seed phrase.
    */
   exportSeedPhrase(password: string) {
-    if (privates.get(this).keyring.password === password) {
-      return privates.get(this).keyring.keyrings[0].mnemonic;
+    if (this.#keyring.password === password) {
+      return this.#keyring.keyrings[0].mnemonic;
     }
     throw new Error('Invalid password');
   }
@@ -314,8 +307,8 @@ export class KeyringController extends BaseController<
    * @returns Promise resolving to the private key for an address.
    */
   exportAccount(password: string, address: string): Promise<string> {
-    if (privates.get(this).keyring.password === password) {
-      return privates.get(this).keyring.exportAccount(address);
+    if (this.#keyring.password === password) {
+      return this.#keyring.exportAccount(address);
     }
     throw new Error('Invalid password');
   }
@@ -326,7 +319,7 @@ export class KeyringController extends BaseController<
    * @returns A promise resolving to an array of addresses.
    */
   getAccounts(): Promise<string[]> {
-    return privates.get(this).keyring.getAccounts();
+    return this.#keyring.getAccounts();
   }
 
   /**
@@ -377,11 +370,11 @@ export class KeyringController extends BaseController<
       default:
         throw new Error(`Unexpected import strategy: '${strategy}'`);
     }
-    const newKeyring = await privates
-      .get(this)
-      .keyring.addNewKeyring(KeyringTypes.simple, [privateKey]);
+    const newKeyring = await this.#keyring.addNewKeyring(KeyringTypes.simple, [
+      privateKey,
+    ]);
     const accounts = await newKeyring.getAccounts();
-    const allAccounts = await privates.get(this).keyring.getAccounts();
+    const allAccounts = await this.#keyring.getAccounts();
     this.updateIdentities(allAccounts);
     this.setSelectedAddress(accounts[0]);
     return this.fullUpdate();
@@ -395,7 +388,7 @@ export class KeyringController extends BaseController<
    */
   async removeAccount(address: string): Promise<KeyringMemState> {
     this.removeIdentity(address);
-    await privates.get(this).keyring.removeAccount(address);
+    await this.#keyring.removeAccount(address);
     return this.fullUpdate();
   }
 
@@ -405,7 +398,7 @@ export class KeyringController extends BaseController<
    * @returns Promise resolving to current state.
    */
   setLocked(): Promise<KeyringMemState> {
-    return privates.get(this).keyring.setLocked();
+    return this.#keyring.setLocked();
   }
 
   /**
@@ -415,7 +408,7 @@ export class KeyringController extends BaseController<
    * @returns Promise resolving to a signed message string.
    */
   signMessage(messageParams: PersonalMessageParams) {
-    return privates.get(this).keyring.signMessage(messageParams);
+    return this.#keyring.signMessage(messageParams);
   }
 
   /**
@@ -425,7 +418,7 @@ export class KeyringController extends BaseController<
    * @returns Promise resolving to a signed message string.
    */
   signPersonalMessage(messageParams: PersonalMessageParams) {
-    return privates.get(this).keyring.signPersonalMessage(messageParams);
+    return this.#keyring.signPersonalMessage(messageParams);
   }
 
   /**
@@ -457,12 +450,10 @@ export class KeyringController extends BaseController<
         ) {
           messageParamsClone.data = JSON.parse(messageParamsClone.data);
         }
-        return privates
-          .get(this)
-          .keyring.signTypedMessage(messageParamsClone, { version });
+        return this.#keyring.signTypedMessage(messageParamsClone, { version });
       }
 
-      const { password } = privates.get(this).keyring;
+      const { password } = this.#keyring;
       const privateKey = await this.exportAccount(password, address);
       const privateKeyBuffer = toBuffer(addHexPrefix(privateKey));
       switch (version) {
@@ -495,7 +486,7 @@ export class KeyringController extends BaseController<
    * @returns Promise resolving to a signed transaction string.
    */
   signTransaction(transaction: unknown, from: string) {
-    return privates.get(this).keyring.signTransaction(transaction, from);
+    return this.#keyring.signTransaction(transaction, from);
   }
 
   /**
@@ -505,8 +496,8 @@ export class KeyringController extends BaseController<
    * @returns Promise resolving to the current state.
    */
   async submitPassword(password: string): Promise<KeyringMemState> {
-    await privates.get(this).keyring.submitPassword(password);
-    const accounts = await privates.get(this).keyring.getAccounts();
+    await this.#keyring.submitPassword(password);
+    const accounts = await this.#keyring.getAccounts();
     await this.syncIdentities(accounts);
     return this.fullUpdate();
   }
@@ -517,7 +508,7 @@ export class KeyringController extends BaseController<
    * @param listener - Callback triggered when state changes.
    */
   override subscribe(listener: Listener<KeyringState>) {
-    privates.get(this).keyring.store.subscribe(listener);
+    this.#keyring.store.subscribe(listener);
   }
 
   /**
@@ -527,7 +518,7 @@ export class KeyringController extends BaseController<
    * @returns True if a listener is found and unsubscribed.
    */
   override unsubscribe(listener: Listener<KeyringState>) {
-    return privates.get(this).keyring.store.unsubscribe(listener);
+    return this.#keyring.store.unsubscribe(listener);
   }
 
   /**
@@ -537,7 +528,7 @@ export class KeyringController extends BaseController<
    * @returns EventEmitter if listener added.
    */
   onLock(listener: () => void) {
-    return privates.get(this).keyring.on('lock', listener);
+    return this.#keyring.on('lock', listener);
   }
 
   /**
@@ -547,7 +538,7 @@ export class KeyringController extends BaseController<
    * @returns EventEmitter if listener added.
    */
   onUnlock(listener: () => void) {
-    return privates.get(this).keyring.on('unlock', listener);
+    return this.#keyring.on('unlock', listener);
   }
 
   /**
@@ -556,9 +547,7 @@ export class KeyringController extends BaseController<
    * @returns Whether the verification succeeds.
    */
   async verifySeedPhrase(): Promise<string> {
-    const primaryKeyring = privates
-      .get(this)
-      .keyring.getKeyringsByType(KeyringTypes.hd)[0];
+    const primaryKeyring = this.#keyring.getKeyringsByType(KeyringTypes.hd)[0];
     /* istanbul ignore if */
     if (!primaryKeyring) {
       throw new Error('No HD keyring found.');
@@ -571,9 +560,9 @@ export class KeyringController extends BaseController<
       throw new Error('Cannot verify an empty keyring.');
     }
 
-    const TestKeyringClass = privates
-      .get(this)
-      .keyring.getKeyringClassForType(KeyringTypes.hd);
+    const TestKeyringClass = this.#keyring.getKeyringClassForType(
+      KeyringTypes.hd,
+    );
     const testKeyring = new TestKeyringClass({
       mnemonic: seedWords,
       numberOfAccounts: accounts.length,
@@ -601,24 +590,22 @@ export class KeyringController extends BaseController<
    */
   async fullUpdate(): Promise<KeyringMemState> {
     const keyrings: Keyring[] = await Promise.all<Keyring>(
-      privates
-        .get(this)
-        .keyring.keyrings.map(
-          async (keyring: KeyringObject, index: number): Promise<Keyring> => {
-            const keyringAccounts = await keyring.getAccounts();
-            const accounts = Array.isArray(keyringAccounts)
-              ? keyringAccounts.map((address) => toChecksumHexAddress(address))
-              : /* istanbul ignore next */ [];
-            return {
-              accounts,
-              index,
-              type: keyring.type,
-            };
-          },
-        ),
+      this.#keyring.keyrings.map(
+        async (keyring: KeyringObject, index: number): Promise<Keyring> => {
+          const keyringAccounts = await keyring.getAccounts();
+          const accounts = Array.isArray(keyringAccounts)
+            ? keyringAccounts.map((address) => toChecksumHexAddress(address))
+            : /* istanbul ignore next */ [];
+          return {
+            accounts,
+            index,
+            type: keyring.type,
+          };
+        },
+      ),
     );
     this.update({ keyrings: [...keyrings] });
-    return privates.get(this).keyring.fullUpdate();
+    return this.#keyring.fullUpdate();
   }
 
   // QR Hardware related methods
@@ -629,9 +616,7 @@ export class KeyringController extends BaseController<
    * @returns The added keyring
    */
   private async addQRKeyring(): Promise<QRKeyring> {
-    const keyring = await privates
-      .get(this)
-      .keyring.addNewKeyring(KeyringTypes.qr);
+    const keyring = await this.#keyring.addNewKeyring(KeyringTypes.qr);
     await this.fullUpdate();
     return keyring;
   }
@@ -642,15 +627,13 @@ export class KeyringController extends BaseController<
    * @returns The added keyring
    */
   async getOrAddQRKeyring(): Promise<QRKeyring> {
-    const keyring = privates
-      .get(this)
-      .keyring.getKeyringsByType(KeyringTypes.qr)[0];
+    const keyring = this.#keyring.getKeyringsByType(KeyringTypes.qr)[0];
     return keyring || (await this.addQRKeyring());
   }
 
   async restoreQRKeyring(serialized: any): Promise<void> {
     (await this.getOrAddQRKeyring()).deserialize(serialized);
-    this.updateIdentities(await privates.get(this).keyring.getAccounts());
+    this.updateIdentities(await this.#keyring.getAccounts());
     await this.fullUpdate();
   }
 
@@ -712,9 +695,9 @@ export class KeyringController extends BaseController<
     const keyring = await this.getOrAddQRKeyring();
 
     keyring.setAccountToUnlock(index);
-    const oldAccounts = await privates.get(this).keyring.getAccounts();
-    await privates.get(this).keyring.addNewAccount(keyring);
-    const newAccounts = await privates.get(this).keyring.getAccounts();
+    const oldAccounts = await this.#keyring.getAccounts();
+    await this.#keyring.addNewAccount(keyring);
+    const newAccounts = await this.#keyring.getAccounts();
     this.updateIdentities(newAccounts);
     newAccounts.forEach((address: string) => {
       if (!oldAccounts.includes(address)) {
@@ -724,25 +707,22 @@ export class KeyringController extends BaseController<
         this.setSelectedAddress(address);
       }
     });
-    await privates.get(this).keyring.persistAllKeyrings();
+    await this.#keyring.persistAllKeyrings();
     await this.fullUpdate();
   }
 
   async getAccountKeyringType(account: string): Promise<KeyringTypes> {
-    return (await privates.get(this).keyring.getKeyringForAccount(account))
-      .type;
+    return (await this.#keyring.getKeyringForAccount(account)).type;
   }
 
   async forgetQRDevice(): Promise<void> {
     const keyring = await this.getOrAddQRKeyring();
     keyring.forgetDevice();
-    const accounts = (await privates
-      .get(this)
-      .keyring.getAccounts()) as string[];
+    const accounts = (await this.#keyring.getAccounts()) as string[];
     accounts.forEach((account) => {
       this.setSelectedAddress(account);
     });
-    await privates.get(this).keyring.persistAllKeyrings();
+    await this.#keyring.persistAllKeyrings();
     await this.fullUpdate();
   }
 }


### PR DESCRIPTION
The `KeyringController` used a WeakMap to keep the keyring as a truly private field, such that code with a reference to the controller still could not access it.

This strategy is no longer necessary as of TypeScript 4.3 because we now have support for true private fields. The TypeScript compiler will compile this to a similar WeakMap-based strategy.

This should include no functional changes.