### PR TITLE
Remove unused `retry` parameter from `safelyExecute`

### DIFF
--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -291,20 +291,6 @@ describe('util', () => {
         }),
       ).toBeUndefined();
     });
-
-    it('should call retry function', async () => {
-      const mockRetry = jest.fn();
-      new Promise(() => {
-        util.safelyExecute(
-          () => {
-            throw new Error('ahh');
-          },
-          false,
-          mockRetry,
-        );
-      });
-      expect(mockRetry).toHaveBeenCalledWith(new Error('ahh'));
-    });
   });
 
   describe('safelyExecuteWithTimeout', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -316,13 +316,11 @@ export function normalizeTransaction(transaction: Transaction) {
  *
  * @param operation - Function returning a Promise.
  * @param logError - Determines if the error should be logged.
- * @param retry - Function called if an error is caught.
  * @returns Promise resolving to the result of the async operation.
  */
 export async function safelyExecute(
   operation: () => Promise<any>,
   logError = false,
-  retry?: (error: Error) => void,
 ) {
   try {
     return await operation();
@@ -331,7 +329,6 @@ export async function safelyExecute(
     if (logError) {
       console.error(error);
     }
-    retry?.(error);
     return undefined;
   }
 }


### PR DESCRIPTION
The `retry` parameter of `safelyExecute` was unused, so it has been removed. Generally this parameter does not seem useful, and we are trying to remove all uses of this function anyway.

This makes updating to TypeScript v4.4 slightly easier, because the invocation of the retry function is a type error on that version (because `error` is `unknown`).