### PR TITLE
Call `sinon.restore()` after each test using sinon

### DIFF
--- a/src/BaseController.test.ts
+++ b/src/BaseController.test.ts
@@ -1,4 +1,4 @@
-import { stub } from 'sinon';
+import sinon from 'sinon';
 import { BaseController, BaseConfig, BaseState } from './BaseController';
 
 const STATE = { name: 'foo' };
@@ -12,6 +12,10 @@ class TestController extends BaseController<BaseConfig, BaseState> {
 }
 
 describe('BaseController', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it('should set initial state', () => {
     const controller = new TestController(undefined, STATE);
     expect(controller.state).toStrictEqual(STATE);
@@ -45,8 +49,8 @@ describe('BaseController', () => {
 
   it('should notify all listeners', () => {
     const controller = new TestController(undefined, STATE);
-    const listenerOne = stub();
-    const listenerTwo = stub();
+    const listenerOne = sinon.stub();
+    const listenerTwo = sinon.stub();
     controller.subscribe(listenerOne);
     controller.subscribe(listenerTwo);
     controller.notify();
@@ -58,7 +62,7 @@ describe('BaseController', () => {
 
   it('should not notify unsubscribed listeners', () => {
     const controller = new TestController();
-    const listener = stub();
+    const listener = sinon.stub();
     controller.subscribe(listener);
     controller.unsubscribe(listener);
     controller.unsubscribe(() => null);

--- a/src/BaseControllerV2.test.ts
+++ b/src/BaseControllerV2.test.ts
@@ -83,6 +83,10 @@ class CountController extends BaseController<
 }
 
 describe('BaseController', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it('should set initial state', () => {
     const controller = new CountController({
       messenger: getCountMessenger(),

--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -1,4 +1,4 @@
-import { stub } from 'sinon';
+import sinon from 'sinon';
 import type { Patch } from 'immer';
 import { TokensController } from './assets/TokensController';
 import { CollectiblesController } from './assets/CollectiblesController';
@@ -87,6 +87,10 @@ class BarController extends BaseController<never, BarControllerState> {
 }
 
 describe('ComposableController', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
   describe('BaseController', () => {
     it('should compose controller state', () => {
       const preferencesController = new PreferencesController();
@@ -268,7 +272,7 @@ describe('ComposableController', () => {
     it('should notify listeners of nested state change', () => {
       const addressBookController = new AddressBookController();
       const controller = new ComposableController([addressBookController]);
-      const listener = stub();
+      const listener = sinon.stub();
       controller.subscribe(listener);
       addressBookController.set(
         '0x32Be343B94f860124dC4fEe278FDCBD38C102D88',
@@ -381,7 +385,7 @@ describe('ComposableController', () => {
         composableControllerMessenger,
       );
 
-      const listener = stub();
+      const listener = sinon.stub();
       composableController.subscribe(listener);
       fooController.updateFoo('bar');
 
@@ -486,7 +490,7 @@ describe('ComposableController', () => {
         composableControllerMessenger,
       );
 
-      const listener = stub();
+      const listener = sinon.stub();
       composableController.subscribe(listener);
       barController.updateBar('foo');
 
@@ -528,7 +532,7 @@ describe('ComposableController', () => {
         composableControllerMessenger,
       );
 
-      const listener = stub();
+      const listener = sinon.stub();
       composableController.subscribe(listener);
       fooController.updateFoo('bar');
 

--- a/src/approval/ApprovalController.test.ts
+++ b/src/approval/ApprovalController.test.ts
@@ -35,8 +35,13 @@ function getRestrictedMessenger() {
 }
 
 describe('approval controller', () => {
-  const clock = sinon.useFakeTimers(1);
-  afterAll(() => clock.restore());
+  beforeEach(() => {
+    sinon.useFakeTimers(1);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
 
   describe('add', () => {
     let approvalController: ApprovalController;

--- a/src/assets/AccountTrackerController.test.ts
+++ b/src/assets/AccountTrackerController.test.ts
@@ -1,4 +1,4 @@
-import { stub, spy } from 'sinon';
+import sinon from 'sinon';
 import HttpProvider from 'ethjs-provider-http';
 import type { ContactEntry } from '../user/AddressBookController';
 import { PreferencesController } from '../user/PreferencesController';
@@ -10,9 +10,13 @@ const provider = new HttpProvider(
 );
 
 describe('AccountTrackerController', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it('should set default state', () => {
     const controller = new AccountTrackerController({
-      onPreferencesStateChange: stub(),
+      onPreferencesStateChange: sinon.stub(),
       getIdentities: () => ({}),
     });
     expect(controller.state).toStrictEqual({
@@ -22,7 +26,7 @@ describe('AccountTrackerController', () => {
 
   it('should throw when provider property is accessed', () => {
     const controller = new AccountTrackerController({
-      onPreferencesStateChange: stub(),
+      onPreferencesStateChange: sinon.stub(),
       getIdentities: () => ({}),
     });
     expect(() => console.log(controller.provider)).toThrow(
@@ -34,7 +38,7 @@ describe('AccountTrackerController', () => {
     const address = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
     const controller = new AccountTrackerController(
       {
-        onPreferencesStateChange: stub(),
+        onPreferencesStateChange: sinon.stub(),
         getIdentities: () => {
           return { [address]: {} as ContactEntry };
         },
@@ -47,10 +51,10 @@ describe('AccountTrackerController', () => {
 
   it('should sync balance with addresses', async () => {
     const address = '0xc38bf1ad06ef69f0c04e29dbeb4152b4175f0a8d';
-    const queryStub = stub(utils, 'query');
+    const queryStub = sinon.stub(utils, 'query');
     const controller = new AccountTrackerController(
       {
-        onPreferencesStateChange: stub(),
+        onPreferencesStateChange: sinon.stub(),
         getIdentities: () => {
           return {};
         },
@@ -65,7 +69,7 @@ describe('AccountTrackerController', () => {
   it('should sync addresses', () => {
     const controller = new AccountTrackerController(
       {
-        onPreferencesStateChange: stub(),
+        onPreferencesStateChange: sinon.stub(),
         getIdentities: () => {
           return { baz: {} as ContactEntry };
         },
@@ -93,7 +97,7 @@ describe('AccountTrackerController', () => {
       },
       { provider },
     );
-    controller.refresh = stub();
+    controller.refresh = sinon.stub();
 
     preferences.setFeatureFlag('foo', true);
     expect((controller.refresh as any).called).toBe(true);
@@ -102,7 +106,7 @@ describe('AccountTrackerController', () => {
   it('should call refresh every ten seconds', async () => {
     await new Promise<void>((resolve) => {
       const preferences = new PreferencesController();
-      const poll = spy(AccountTrackerController.prototype, 'poll');
+      const poll = sinon.spy(AccountTrackerController.prototype, 'poll');
       const controller = new AccountTrackerController(
         {
           onPreferencesStateChange: (listener) =>
@@ -111,7 +115,7 @@ describe('AccountTrackerController', () => {
         },
         { provider, interval: 100 },
       );
-      stub(controller, 'refresh');
+      sinon.stub(controller, 'refresh');
 
       expect(poll.called).toBe(true);
       expect(poll.calledTwice).toBe(false);

--- a/src/assets/CollectibleDetectionController.test.ts
+++ b/src/assets/CollectibleDetectionController.test.ts
@@ -238,7 +238,6 @@ describe('CollectibleDetectionController', () => {
       expect(mockCollectibles.calledOnce).toBe(true);
       setTimeout(() => {
         expect(mockCollectibles.calledTwice).toBe(true);
-        mockCollectibles.restore();
         resolve('');
       }, 15);
     });
@@ -273,7 +272,6 @@ describe('CollectibleDetectionController', () => {
         { interval: 10, networkType: ROPSTEN },
       );
       expect(mockCollectibles.called).toBe(false);
-      mockCollectibles.restore();
       resolve('');
     });
   });

--- a/src/assets/CurrencyRateController.test.ts
+++ b/src/assets/CurrencyRateController.test.ts
@@ -1,4 +1,4 @@
-import { stub } from 'sinon';
+import sinon from 'sinon';
 import nock from 'nock';
 import { ControllerMessenger } from '../ControllerMessenger';
 import {
@@ -36,10 +36,11 @@ const getStubbedDate = () => {
 describe('CurrencyRateController', () => {
   afterEach(() => {
     nock.cleanAll();
+    sinon.restore();
   });
 
   it('should set default state', () => {
-    const fetchExchangeRateStub = stub();
+    const fetchExchangeRateStub = sinon.stub();
     const messenger = getRestrictedMessenger();
     const controller = new CurrencyRateController({
       fetchExchangeRate: fetchExchangeRateStub,
@@ -59,7 +60,7 @@ describe('CurrencyRateController', () => {
   });
 
   it('should initialize with initial state', () => {
-    const fetchExchangeRateStub = stub();
+    const fetchExchangeRateStub = sinon.stub();
     const messenger = getRestrictedMessenger();
     const existingState = { currentCurrency: 'rep' };
     const controller = new CurrencyRateController({
@@ -81,7 +82,7 @@ describe('CurrencyRateController', () => {
   });
 
   it('should not poll before being started', async () => {
-    const fetchExchangeRateStub = stub();
+    const fetchExchangeRateStub = sinon.stub();
     const messenger = getRestrictedMessenger();
     const controller = new CurrencyRateController({
       interval: 100,
@@ -96,7 +97,7 @@ describe('CurrencyRateController', () => {
   });
 
   it('should poll and update rate in the right interval', async () => {
-    const fetchExchangeRateStub = stub();
+    const fetchExchangeRateStub = sinon.stub();
     const messenger = getRestrictedMessenger();
     const controller = new CurrencyRateController({
       interval: 100,
@@ -115,7 +116,7 @@ describe('CurrencyRateController', () => {
   });
 
   it('should not poll after being stopped', async () => {
-    const fetchExchangeRateStub = stub();
+    const fetchExchangeRateStub = sinon.stub();
     const messenger = getRestrictedMessenger();
     const controller = new CurrencyRateController({
       interval: 100,
@@ -136,7 +137,7 @@ describe('CurrencyRateController', () => {
   });
 
   it('should poll correctly after being started, stopped, and started again', async () => {
-    const fetchExchangeRateStub = stub();
+    const fetchExchangeRateStub = sinon.stub();
     const messenger = getRestrictedMessenger();
     const controller = new CurrencyRateController({
       interval: 100,
@@ -160,7 +161,7 @@ describe('CurrencyRateController', () => {
   });
 
   it('should update exchange rate', async () => {
-    const fetchExchangeRateStub = stub().resolves({ conversionRate: 10 });
+    const fetchExchangeRateStub = sinon.stub().resolves({ conversionRate: 10 });
     const messenger = getRestrictedMessenger();
     const controller = new CurrencyRateController({
       interval: 10,
@@ -175,7 +176,7 @@ describe('CurrencyRateController', () => {
   });
 
   it('should update current currency', async () => {
-    const fetchExchangeRateStub = stub().resolves({ conversionRate: 10 });
+    const fetchExchangeRateStub = sinon.stub().resolves({ conversionRate: 10 });
     const messenger = getRestrictedMessenger();
     const controller = new CurrencyRateController({
       interval: 10,
@@ -190,7 +191,7 @@ describe('CurrencyRateController', () => {
   });
 
   it('should update native currency', async () => {
-    const fetchExchangeRateStub = stub().resolves({ conversionRate: 10 });
+    const fetchExchangeRateStub = sinon.stub().resolves({ conversionRate: 10 });
     const messenger = getRestrictedMessenger();
     const controller = new CurrencyRateController({
       interval: 10,
@@ -205,7 +206,7 @@ describe('CurrencyRateController', () => {
   });
 
   it('should add usd rate to state when includeUsdRate is configured true', async () => {
-    const fetchExchangeRateStub = stub().resolves({});
+    const fetchExchangeRateStub = sinon.stub().resolves({});
     const messenger = getRestrictedMessenger();
     const controller = new CurrencyRateController({
       includeUsdRate: true,

--- a/src/assets/TokenBalancesController.test.ts
+++ b/src/assets/TokenBalancesController.test.ts
@@ -66,7 +66,6 @@ describe('TokenBalancesController', () => {
       expect(mock.calledTwice).toBe(false);
       setTimeout(() => {
         expect(mock.calledTwice).toBe(true);
-        mock.restore();
         resolve();
       }, 15);
     });
@@ -103,7 +102,6 @@ describe('TokenBalancesController', () => {
       setTimeout(() => {
         tokenBalances.poll(1338);
         expect(mock.called).toBe(true);
-        mock.restore();
         resolve();
       }, 100);
     });

--- a/src/assets/TokenDetectionController.test.ts
+++ b/src/assets/TokenDetectionController.test.ts
@@ -199,7 +199,6 @@ describe('TokenDetectionController', () => {
       expect(mockTokens.calledOnce).toBe(true);
       setTimeout(() => {
         expect(mockTokens.calledTwice).toBe(true);
-        mockTokens.restore();
         resolve('');
       }, 15);
     });
@@ -234,7 +233,6 @@ describe('TokenDetectionController', () => {
         { interval: 10, networkType: ROPSTEN },
       );
       expect(mockTokens.called).toBe(false);
-      mockTokens.restore();
       resolve('');
     });
   });

--- a/src/assets/TokenListController.test.ts
+++ b/src/assets/TokenListController.test.ts
@@ -1,4 +1,4 @@
-import { stub } from 'sinon';
+import sinon from 'sinon';
 import nock from 'nock';
 import contractMap from '@metamask/contract-metadata';
 import { ControllerMessenger } from '../ControllerMessenger';
@@ -274,6 +274,7 @@ describe('TokenListController', () => {
 
   afterEach(() => {
     nock.cleanAll();
+    sinon.restore();
   });
 
   it('should set default state', async () => {
@@ -344,7 +345,10 @@ describe('TokenListController', () => {
   });
 
   it('should poll and update rate in the right interval', async () => {
-    const tokenListMock = stub(TokenListController.prototype, 'fetchTokenList');
+    const tokenListMock = sinon.stub(
+      TokenListController.prototype,
+      'fetchTokenList',
+    );
 
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
@@ -364,11 +368,13 @@ describe('TokenListController', () => {
     expect(tokenListMock.calledTwice).toBe(true);
 
     controller.destroy();
-    tokenListMock.restore();
   });
 
   it('should not poll after being stopped', async () => {
-    const tokenListMock = stub(TokenListController.prototype, 'fetchTokenList');
+    const tokenListMock = sinon.stub(
+      TokenListController.prototype,
+      'fetchTokenList',
+    );
 
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
@@ -390,11 +396,13 @@ describe('TokenListController', () => {
     expect(tokenListMock.calledTwice).toBe(false);
 
     controller.destroy();
-    tokenListMock.restore();
   });
 
   it('should poll correctly after being started, stopped, and started again', async () => {
-    const tokenListMock = stub(TokenListController.prototype, 'fetchTokenList');
+    const tokenListMock = sinon.stub(
+      TokenListController.prototype,
+      'fetchTokenList',
+    );
 
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
@@ -419,7 +427,6 @@ describe('TokenListController', () => {
     await new Promise<void>((resolve) => setTimeout(() => resolve(), 150));
     expect(tokenListMock.calledThrice).toBe(true);
     controller.destroy();
-    tokenListMock.restore();
   });
 
   it('should update token list from api', async () => {

--- a/src/assets/TokenRatesController.test.ts
+++ b/src/assets/TokenRatesController.test.ts
@@ -1,4 +1,4 @@
-import { stub } from 'sinon';
+import sinon from 'sinon';
 import nock from 'nock';
 import { PreferencesController } from '../user/PreferencesController';
 import { NetworkController } from '../network/NetworkController';
@@ -98,13 +98,14 @@ describe('TokenRatesController', () => {
 
   afterEach(() => {
     nock.cleanAll();
+    sinon.restore();
   });
 
   it('should set default state', () => {
     const controller = new TokenRatesController({
-      onTokensStateChange: stub(),
-      onCurrencyRateStateChange: stub(),
-      onNetworkStateChange: stub(),
+      onTokensStateChange: sinon.stub(),
+      onCurrencyRateStateChange: sinon.stub(),
+      onNetworkStateChange: sinon.stub(),
     });
     expect(controller.state).toStrictEqual({
       contractExchangeRates: {},
@@ -113,9 +114,9 @@ describe('TokenRatesController', () => {
 
   it('should initialize with the default config', () => {
     const controller = new TokenRatesController({
-      onTokensStateChange: stub(),
-      onCurrencyRateStateChange: stub(),
-      onNetworkStateChange: stub(),
+      onTokensStateChange: sinon.stub(),
+      onCurrencyRateStateChange: sinon.stub(),
+      onNetworkStateChange: sinon.stub(),
     });
     expect(controller.config).toStrictEqual({
       disabled: false,
@@ -129,9 +130,9 @@ describe('TokenRatesController', () => {
 
   it('should throw when tokens property is accessed', () => {
     const controller = new TokenRatesController({
-      onTokensStateChange: stub(),
-      onCurrencyRateStateChange: stub(),
-      onNetworkStateChange: stub(),
+      onTokensStateChange: sinon.stub(),
+      onCurrencyRateStateChange: sinon.stub(),
+      onNetworkStateChange: sinon.stub(),
     });
     expect(() => console.log(controller.tokens)).toThrow(
       'Property only used for setting',
@@ -166,27 +167,27 @@ describe('TokenRatesController', () => {
   it('should not update rates if disabled', async () => {
     const controller = new TokenRatesController(
       {
-        onTokensStateChange: stub(),
-        onCurrencyRateStateChange: stub(),
-        onNetworkStateChange: stub(),
+        onTokensStateChange: sinon.stub(),
+        onCurrencyRateStateChange: sinon.stub(),
+        onNetworkStateChange: sinon.stub(),
       },
       {
         interval: 10,
       },
     );
-    controller.fetchExchangeRate = stub();
+    controller.fetchExchangeRate = sinon.stub();
     controller.disabled = true;
     await controller.updateExchangeRates();
     expect((controller.fetchExchangeRate as any).called).toBe(false);
   });
 
   it('should clear previous interval', async () => {
-    const mock = stub(global, 'clearTimeout');
+    const mock = sinon.stub(global, 'clearTimeout');
     const controller = new TokenRatesController(
       {
-        onTokensStateChange: stub(),
-        onCurrencyRateStateChange: stub(),
-        onNetworkStateChange: stub(),
+        onTokensStateChange: sinon.stub(),
+        onCurrencyRateStateChange: sinon.stub(),
+        onNetworkStateChange: sinon.stub(),
       },
       { interval: 1337 },
     );
@@ -194,7 +195,6 @@ describe('TokenRatesController', () => {
       setTimeout(() => {
         controller.poll(1338);
         expect(mock.called).toBe(true);
-        mock.restore();
         resolve();
       }, 100);
     });
@@ -210,7 +210,7 @@ describe('TokenRatesController', () => {
     const controller = new TokenRatesController(
       {
         onTokensStateChange: (listener) => tokensController.subscribe(listener),
-        onCurrencyRateStateChange: stub(),
+        onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange: (listener) => network.subscribe(listener),
       },
       { interval: 10, chainId: '1' },
@@ -235,30 +235,30 @@ describe('TokenRatesController', () => {
   it('should handle balance not found in API', async () => {
     const controller = new TokenRatesController(
       {
-        onTokensStateChange: stub(),
-        onCurrencyRateStateChange: stub(),
-        onNetworkStateChange: stub(),
+        onTokensStateChange: sinon.stub(),
+        onCurrencyRateStateChange: sinon.stub(),
+        onNetworkStateChange: sinon.stub(),
       },
       { interval: 10 },
     );
-    stub(controller, 'fetchExchangeRate').throws({
+    sinon.stub(controller, 'fetchExchangeRate').throws({
       error: 'Not Found',
       message: 'Not Found',
     });
     expect(controller.state.contractExchangeRates).toStrictEqual({});
     controller.tokens = [{ address: 'bar', decimals: 0, symbol: '' }];
-    const mock = stub(controller, 'updateExchangeRates');
+    const mock = sinon.stub(controller, 'updateExchangeRates');
     await controller.updateExchangeRates();
     expect(mock).not.toThrow();
   });
 
   it('should update exchange rates when tokens change', async () => {
     let tokenStateChangeListener: (state: any) => void;
-    const onTokensStateChange = stub().callsFake((listener) => {
+    const onTokensStateChange = sinon.stub().callsFake((listener) => {
       tokenStateChangeListener = listener;
     });
-    const onCurrencyRateStateChange = stub();
-    const onNetworkStateChange = stub();
+    const onCurrencyRateStateChange = sinon.stub();
+    const onNetworkStateChange = sinon.stub();
     const controller = new TokenRatesController(
       {
         onTokensStateChange,
@@ -268,7 +268,10 @@ describe('TokenRatesController', () => {
       { interval: 10 },
     );
 
-    const updateExchangeRatesStub = stub(controller, 'updateExchangeRates');
+    const updateExchangeRatesStub = sinon.stub(
+      controller,
+      'updateExchangeRates',
+    );
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     tokenStateChangeListener!({ tokens: [] });
     // FIXME: This is now being called twice
@@ -277,11 +280,11 @@ describe('TokenRatesController', () => {
 
   it('should update exchange rates when native currency changes', async () => {
     let currencyRateStateChangeListener: (state: any) => void;
-    const onTokensStateChange = stub();
-    const onCurrencyRateStateChange = stub().callsFake((listener) => {
+    const onTokensStateChange = sinon.stub();
+    const onCurrencyRateStateChange = sinon.stub().callsFake((listener) => {
       currencyRateStateChangeListener = listener;
     });
-    const onNetworkStateChange = stub();
+    const onNetworkStateChange = sinon.stub();
     const controller = new TokenRatesController(
       {
         onTokensStateChange,
@@ -291,7 +294,10 @@ describe('TokenRatesController', () => {
       { interval: 10 },
     );
 
-    const updateExchangeRatesStub = stub(controller, 'updateExchangeRates');
+    const updateExchangeRatesStub = sinon.stub(
+      controller,
+      'updateExchangeRates',
+    );
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     currencyRateStateChangeListener!({ nativeCurrency: 'dai' });
     // FIXME: This is now being called twice
@@ -323,15 +329,15 @@ describe('TokenRatesController', () => {
     };
 
     let tokenStateChangeListener: (state: any) => void;
-    const onTokensStateChange = stub().callsFake((listener) => {
+    const onTokensStateChange = sinon.stub().callsFake((listener) => {
       tokenStateChangeListener = listener;
     });
 
-    const onNetworkStateChange = stub();
+    const onNetworkStateChange = sinon.stub();
     const controller = new TokenRatesController(
       {
         onTokensStateChange,
-        onCurrencyRateStateChange: stub(),
+        onCurrencyRateStateChange: sinon.stub(),
         onNetworkStateChange,
       },
       { interval: 10 },
@@ -380,12 +386,12 @@ describe('TokenRatesController', () => {
       .persist();
 
     let networkChangeListener: (state: any) => void;
-    const onNetworkStateChange = stub().callsFake((listener) => {
+    const onNetworkStateChange = sinon.stub().callsFake((listener) => {
       networkChangeListener = listener;
     });
 
     let tokenStateChangeListener: (state: any) => void;
-    const onTokensStateChange = stub().callsFake((listener) => {
+    const onTokensStateChange = sinon.stub().callsFake((listener) => {
       tokenStateChangeListener = listener;
     });
 
@@ -393,7 +399,7 @@ describe('TokenRatesController', () => {
       {
         onTokensStateChange,
         onNetworkStateChange,
-        onCurrencyRateStateChange: stub(),
+        onCurrencyRateStateChange: sinon.stub(),
       },
       { interval: 10 },
     );

--- a/src/assets/TokensController.test.ts
+++ b/src/assets/TokensController.test.ts
@@ -679,7 +679,7 @@ describe('TokensController', () => {
     });
 
     it('should handle ERC20 type and add to suggestedAssets', async function () {
-      const clock = sinon.useFakeTimers(1);
+      sinon.useFakeTimers(1);
       sinon
         .stub(tokensController, '_generateRandomId')
         .callsFake(() => '12345');
@@ -694,7 +694,6 @@ describe('TokensController', () => {
           asset,
         },
       ]);
-      clock.restore();
     });
 
     it('should add token correctly if user confirms', async function () {

--- a/src/gas/GasFeeController.test.ts
+++ b/src/gas/GasFeeController.test.ts
@@ -1,4 +1,4 @@
-import { useFakeTimers, SinonFakeTimers } from 'sinon';
+import sinon, { SinonFakeTimers } from 'sinon';
 import { mocked } from 'ts-jest/utils';
 import { ControllerMessenger } from '../ControllerMessenger';
 import {
@@ -190,14 +190,14 @@ describe('GasFeeController', () => {
   }
 
   beforeEach(() => {
-    clock = useFakeTimers();
+    clock = sinon.useFakeTimers();
     mockedDetermineGasFeeCalculations.mockResolvedValue(
       buildMockGasFeeStateFeeMarket(),
     );
   });
 
   afterEach(() => {
-    clock.uninstall();
+    sinon.restore();
     gasFeeController.destroy();
     jest.clearAllMocks();
   });

--- a/src/keyring/KeyringController.test.ts
+++ b/src/keyring/KeyringController.test.ts
@@ -5,7 +5,7 @@ import {
   recoverTypedSignature_v4,
   recoverTypedSignatureLegacy,
 } from 'eth-sig-util';
-import sinon, { SinonStub, stub } from 'sinon';
+import sinon, { SinonStub } from 'sinon';
 import Common from '@ethereumjs/common';
 import { TransactionFactory } from '@ethereumjs/tx';
 import { MetaMaskKeyring as QRKeyring } from '@keystonehq/metamask-airgapped-keyring';
@@ -65,6 +65,10 @@ describe('KeyringController', () => {
     );
 
     initialState = await keyringController.createNewVaultAndKeychain(password);
+  });
+
+  afterEach(() => {
+    sinon.restore();
   });
 
   it('should set default state', () => {
@@ -483,7 +487,7 @@ describe('KeyringController', () => {
   });
 
   it('should subscribe and unsubscribe', async () => {
-    const listener = stub();
+    const listener = sinon.stub();
     keyringController.subscribe(listener);
     await keyringController.importAccountWithStrategy(
       AccountImportStrategy.privateKey,
@@ -498,11 +502,11 @@ describe('KeyringController', () => {
   });
 
   it('should receive lock and unlock events', async () => {
-    const listenerLock = stub();
+    const listenerLock = sinon.stub();
     keyringController.onLock(listenerLock);
     await keyringController.setLocked();
     expect(listenerLock.called).toBe(true);
-    const listenerUnlock = stub();
+    const listenerUnlock = sinon.stub();
     keyringController.onUnlock(listenerUnlock);
     await keyringController.submitPassword(password);
     expect(listenerUnlock.called).toBe(true);
@@ -557,24 +561,15 @@ describe('KeyringController', () => {
       const qrkeyring = await signProcessKeyringController.getOrAddQRKeyring();
       qrkeyring.forgetDevice();
 
-      if (!requestSignatureStub) {
-        requestSignatureStub = sinon.stub(
-          qrkeyring.getInteraction(),
-          'requestSignature',
-        );
-      }
+      requestSignatureStub = sinon.stub(
+        qrkeyring.getInteraction(),
+        'requestSignature',
+      );
 
-      if (!readAccountSub) {
-        readAccountSub = sinon.stub(
-          qrkeyring.getInteraction(),
-          'readCryptoHDKeyOrCryptoAccount',
-        );
-      }
-    });
-
-    afterEach(() => {
-      requestSignatureStub.reset();
-      readAccountSub.reset();
+      readAccountSub = sinon.stub(
+        qrkeyring.getInteraction(),
+        'readCryptoHDKeyOrCryptoAccount',
+      );
     });
 
     it('should setup QR keyring with crypto-hdkey', async () => {

--- a/src/network/NetworkController.test.ts
+++ b/src/network/NetworkController.test.ts
@@ -1,4 +1,4 @@
-import { stub } from 'sinon';
+import sinon from 'sinon';
 import Web3ProviderEngine from 'web3-provider-engine';
 import {
   NetworkController,
@@ -10,6 +10,10 @@ import {
 const RPC_TARGET = 'http://foo';
 
 describe('NetworkController', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it('should set default state', () => {
     const controller = new NetworkController();
     expect(controller.state).toStrictEqual({
@@ -158,7 +162,7 @@ describe('NetworkController', () => {
       network: 'loading',
     });
     controller.providerConfig = {} as ProviderConfig;
-    controller.lookupNetwork = stub();
+    controller.lookupNetwork = sinon.stub();
     controller.provider.emit('error', {});
     expect((controller.lookupNetwork as any).called).toBe(true);
   });

--- a/src/third-party/PhishingController.test.ts
+++ b/src/third-party/PhishingController.test.ts
@@ -1,11 +1,12 @@
 import { strict as assert } from 'assert';
-import { stub } from 'sinon';
+import sinon from 'sinon';
 import nock from 'nock';
 import { PhishingController } from './PhishingController';
 
 describe('PhishingController', () => {
   afterEach(() => {
     nock.cleanAll();
+    sinon.restore();
   });
 
   it('should set default state', () => {
@@ -23,26 +24,27 @@ describe('PhishingController', () => {
 
   it('should poll and update rate in the right interval', async () => {
     await new Promise<void>((resolve) => {
-      const mock = stub(PhishingController.prototype, 'updatePhishingLists');
+      const mock = sinon.stub(
+        PhishingController.prototype,
+        'updatePhishingLists',
+      );
       new PhishingController({ interval: 10 });
       expect(mock.called).toBe(true);
       expect(mock.calledTwice).toBe(false);
       setTimeout(() => {
         expect(mock.calledTwice).toBe(true);
-        mock.restore();
         resolve();
       }, 15);
     });
   });
 
   it('should clear previous interval', async () => {
-    const mock = stub(global, 'clearTimeout');
+    const mock = sinon.stub(global, 'clearTimeout');
     const controller = new PhishingController({ interval: 1337 });
     await new Promise<void>((resolve) => {
       setTimeout(() => {
         controller.poll(1338);
         expect(mock.called).toBe(true);
-        mock.restore();
         resolve();
       }, 100);
     });

--- a/src/transaction/TransactionController.test.ts
+++ b/src/transaction/TransactionController.test.ts
@@ -1,4 +1,4 @@
-import { stub } from 'sinon';
+import sinon from 'sinon';
 import HttpProvider from 'ethjs-provider-http';
 import {
   NetworksChainId,
@@ -266,6 +266,10 @@ describe('TransactionController', () => {
     }
   });
 
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it('should set default state', () => {
     const controller = new TransactionController({
       getNetworkState: () => MOCK_NETWORK.state,
@@ -292,7 +296,7 @@ describe('TransactionController', () => {
 
   it('should poll and update transaction statuses in the right interval', async () => {
     await new Promise((resolve) => {
-      const mock = stub(
+      const mock = sinon.stub(
         TransactionController.prototype,
         'queryTransactionStatuses',
       );
@@ -308,14 +312,13 @@ describe('TransactionController', () => {
       expect(mock.calledTwice).toBe(false);
       setTimeout(() => {
         expect(mock.calledTwice).toBe(true);
-        mock.restore();
         resolve('');
       }, 15);
     });
   });
 
   it('should clear previous interval', async () => {
-    const mock = stub(global, 'clearTimeout');
+    const mock = sinon.stub(global, 'clearTimeout');
     const controller = new TransactionController(
       {
         getNetworkState: () => MOCK_NETWORK.state,
@@ -328,7 +331,6 @@ describe('TransactionController', () => {
       setTimeout(() => {
         controller.poll(1338);
         expect(mock.called).toBe(true);
-        mock.restore();
         resolve('');
       }, 100);
     });
@@ -344,10 +346,9 @@ describe('TransactionController', () => {
         },
         { interval: 10 },
       );
-      const func = stub(controller, 'update');
+      const func = sinon.stub(controller, 'update');
       setTimeout(() => {
         expect(func.called).toBe(false);
-        func.restore();
         resolve('');
       }, 20);
     });
@@ -390,13 +391,13 @@ describe('TransactionController', () => {
   });
 
   it('should add a valid transaction after a network switch', async () => {
-    const getNetworkState = stub().returns(MOCK_NETWORK.state);
+    const getNetworkState = sinon.stub().returns(MOCK_NETWORK.state);
     let networkStateChangeListener: ((state: NetworkState) => void) | null =
       null;
     const onNetworkStateChange = (listener: (state: NetworkState) => void) => {
       networkStateChangeListener = listener;
     };
-    const getProvider = stub().returns(PROVIDER);
+    const getProvider = sinon.stub().returns(PROVIDER);
     const controller = new TransactionController({
       getNetworkState,
       onNetworkStateChange,
@@ -429,13 +430,13 @@ describe('TransactionController', () => {
   });
 
   it('should add a valid transaction after a switch to custom network', async () => {
-    const getNetworkState = stub().returns(MOCK_NETWORK.state);
+    const getNetworkState = sinon.stub().returns(MOCK_NETWORK.state);
     let networkStateChangeListener: ((state: NetworkState) => void) | null =
       null;
     const onNetworkStateChange = (listener: (state: NetworkState) => void) => {
       networkStateChangeListener = listener;
     };
-    const getProvider = stub().returns(PROVIDER);
+    const getProvider = sinon.stub().returns(PROVIDER);
     const controller = new TransactionController({
       getNetworkState,
       onNetworkStateChange,
@@ -1008,7 +1009,7 @@ describe('TransactionController', () => {
       args: [{ type: 'uint256' }, { type: 'uint256' }],
       name: 'Eth To Token Swap Input',
     });
-    const registryLookup = stub(controller, 'registryLookup' as any);
+    const registryLookup = sinon.stub(controller, 'registryLookup' as any);
     await controller.handleMethodData('0xf39b5b9b');
     expect(registryLookup.called).toBe(false);
   });


### PR DESCRIPTION
`sinon.restore()` is now called after each test in any test suite that uses `sinon` for anything. This is recommended by the Sinon docs in their general setup instructions to avoid memory leaks.