### PR TITLE
Fix the capitalization on two describe blocks

### DIFF
--- a/src/apis/token-service.test.ts
+++ b/src/apis/token-service.test.ts
@@ -126,7 +126,7 @@ const sampleToken = {
   name: 'Chainlink',
 };
 
-describe('FetchtokenList', () => {
+describe('fetchTokenList', () => {
   beforeAll(() => {
     nock.disableNetConnect();
   });

--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -717,7 +717,7 @@ describe('CollectiblesController', () => {
     });
   });
 
-  describe('RemoveCollectible', () => {
+  describe('removeCollectible', () => {
     it('should remove collectible and collectible contract', async () => {
       const { selectedAddress, chainId } = collectiblesController.config;
 


### PR DESCRIPTION
These describe blocks reference a method name. The capitalization now matches the method name.