### PR TITLE
Add token service timeout param and improve tests

### DIFF
--- a/src/apis/token-service.test.ts
+++ b/src/apis/token-service.test.ts
@@ -4,8 +4,8 @@ import { fetchTokenList, fetchTokenMetadata } from './token-service';
 
 const TOKEN_END_POINT_API = 'https://token-api.metaswap.codefi.network';
 
-const oneMillisecond = 1;
-const oneSecondInMilliseconds = 1_000;
+const ONE_MILLISECOND = 1;
+const ONE_SECOND_IN_MILLISECONDS = 1_000;
 
 const sampleTokenList = [
   {
@@ -160,7 +160,7 @@ describe('Token service', () => {
       nock(TOKEN_END_POINT_API)
         .get(`/tokens/${NetworksChainId.mainnet}`)
         // well beyond time it will take to abort
-        .delay(oneSecondInMilliseconds)
+        .delay(ONE_SECOND_IN_MILLISECONDS)
         .reply(200, sampleTokenList)
         .persist();
 
@@ -202,12 +202,12 @@ describe('Token service', () => {
       nock(TOKEN_END_POINT_API)
         .get(`/tokens/${NetworksChainId.mainnet}`)
         // well beyond timeout
-        .delay(oneSecondInMilliseconds)
+        .delay(ONE_SECOND_IN_MILLISECONDS)
         .reply(200, sampleTokenList)
         .persist();
 
       const result = await fetchTokenList(NetworksChainId.mainnet, signal, {
-        timeout: oneMillisecond,
+        timeout: ONE_MILLISECOND,
       });
 
       expect(result).toBeUndefined();
@@ -238,7 +238,7 @@ describe('Token service', () => {
       nock(TOKEN_END_POINT_API)
         .get(`/tokens/${NetworksChainId.mainnet}`)
         // well beyond time it will take to abort
-        .delay(oneSecondInMilliseconds)
+        .delay(ONE_SECOND_IN_MILLISECONDS)
         .reply(200, sampleTokenList)
         .persist();
 
@@ -289,7 +289,7 @@ describe('Token service', () => {
       nock(TOKEN_END_POINT_API)
         .get(`/tokens/${NetworksChainId.mainnet}`)
         // well beyond timeout
-        .delay(oneSecondInMilliseconds)
+        .delay(ONE_SECOND_IN_MILLISECONDS)
         .reply(200, sampleTokenList)
         .persist();
 
@@ -297,7 +297,7 @@ describe('Token service', () => {
         NetworksChainId.mainnet,
         '0x514910771af9ca656af840dff83e8264ecf986ca',
         signal,
-        { timeout: oneMillisecond },
+        { timeout: ONE_MILLISECOND },
       );
 
       expect(result).toBeUndefined();

--- a/src/apis/token-service.test.ts
+++ b/src/apis/token-service.test.ts
@@ -4,6 +4,9 @@ import { fetchTokenList, fetchTokenMetadata } from './token-service';
 
 const TOKEN_END_POINT_API = 'https://token-api.metaswap.codefi.network';
 
+const oneMillisecond = 1;
+const oneSecondInMilliseconds = 1_000;
+
 const sampleTokenList = [
   {
     address: '0xbbbbca6a901c926f240b89eacb641d8aec7aeafd',
@@ -126,7 +129,7 @@ const sampleToken = {
   name: 'Chainlink',
 };
 
-describe('fetchTokenList', () => {
+describe('Token service', () => {
   beforeAll(() => {
     nock.disableNetConnect();
   });
@@ -139,33 +142,165 @@ describe('fetchTokenList', () => {
     nock.cleanAll();
   });
 
-  it('should call the tokens api and return the list of tokens', async () => {
-    const { signal } = new AbortController();
-    nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${NetworksChainId.mainnet}`)
-      .reply(200, sampleTokenList)
-      .persist();
+  describe('fetchTokenList', () => {
+    it('should call the tokens api and return the list of tokens', async () => {
+      const { signal } = new AbortController();
+      nock(TOKEN_END_POINT_API)
+        .get(`/tokens/${NetworksChainId.mainnet}`)
+        .reply(200, sampleTokenList)
+        .persist();
 
-    const tokens = await fetchTokenList(NetworksChainId.mainnet, signal);
+      const tokens = await fetchTokenList(NetworksChainId.mainnet, signal);
 
-    expect(tokens).toStrictEqual(sampleTokenList);
+      expect(tokens).toStrictEqual(sampleTokenList);
+    });
+
+    it('should return undefined if the fetch is aborted', async () => {
+      const abortController = new AbortController();
+      nock(TOKEN_END_POINT_API)
+        .get(`/tokens/${NetworksChainId.mainnet}`)
+        // well beyond time it will take to abort
+        .delay(oneSecondInMilliseconds)
+        .reply(200, sampleTokenList)
+        .persist();
+
+      const fetchPromise = fetchTokenList(
+        NetworksChainId.mainnet,
+        abortController.signal,
+      );
+      abortController.abort();
+
+      expect(await fetchPromise).toBeUndefined();
+    });
+
+    it('should return undefined if the fetch fails with a network error', async () => {
+      const { signal } = new AbortController();
+      nock(TOKEN_END_POINT_API)
+        .get(`/tokens/${NetworksChainId.mainnet}`)
+        .replyWithError('Example network error')
+        .persist();
+
+      const result = await fetchTokenList(NetworksChainId.mainnet, signal);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined if the fetch fails with an unsuccessful status code', async () => {
+      const { signal } = new AbortController();
+      nock(TOKEN_END_POINT_API)
+        .get(`/tokens/${NetworksChainId.mainnet}`)
+        .reply(500)
+        .persist();
+
+      const result = await fetchTokenList(NetworksChainId.mainnet, signal);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined if the fetch fails with a timeout', async () => {
+      const { signal } = new AbortController();
+      nock(TOKEN_END_POINT_API)
+        .get(`/tokens/${NetworksChainId.mainnet}`)
+        // well beyond timeout
+        .delay(oneSecondInMilliseconds)
+        .reply(200, sampleTokenList)
+        .persist();
+
+      const result = await fetchTokenList(NetworksChainId.mainnet, signal, {
+        timeout: oneMillisecond,
+      });
+
+      expect(result).toBeUndefined();
+    });
   });
 
-  it('should call the api to return the token metadata for eth address provided', async () => {
-    const { signal } = new AbortController();
-    nock(TOKEN_END_POINT_API)
-      .get(
-        `/token/${NetworksChainId.mainnet}?address=0x514910771af9ca656af840dff83e8264ecf986ca`,
-      )
-      .reply(200, sampleToken)
-      .persist();
+  describe('fetchTokenMetadata', () => {
+    it('should call the api to return the token metadata for eth address provided', async () => {
+      const { signal } = new AbortController();
+      nock(TOKEN_END_POINT_API)
+        .get(
+          `/token/${NetworksChainId.mainnet}?address=0x514910771af9ca656af840dff83e8264ecf986ca`,
+        )
+        .reply(200, sampleToken)
+        .persist();
 
-    const token = await fetchTokenMetadata(
-      NetworksChainId.mainnet,
-      '0x514910771af9ca656af840dff83e8264ecf986ca',
-      signal,
-    );
+      const token = await fetchTokenMetadata(
+        NetworksChainId.mainnet,
+        '0x514910771af9ca656af840dff83e8264ecf986ca',
+        signal,
+      );
 
-    expect(token).toStrictEqual(sampleToken);
+      expect(token).toStrictEqual(sampleToken);
+    });
+
+    it('should return undefined if the fetch is aborted', async () => {
+      const abortController = new AbortController();
+      nock(TOKEN_END_POINT_API)
+        .get(`/tokens/${NetworksChainId.mainnet}`)
+        // well beyond time it will take to abort
+        .delay(oneSecondInMilliseconds)
+        .reply(200, sampleTokenList)
+        .persist();
+
+      const fetchPromise = fetchTokenMetadata(
+        NetworksChainId.mainnet,
+        '0x514910771af9ca656af840dff83e8264ecf986ca',
+        abortController.signal,
+      );
+      abortController.abort();
+
+      expect(await fetchPromise).toBeUndefined();
+    });
+
+    it('should return undefined if the fetch fails with a network error', async () => {
+      const { signal } = new AbortController();
+      nock(TOKEN_END_POINT_API)
+        .get(`/tokens/${NetworksChainId.mainnet}`)
+        .replyWithError('Example network error')
+        .persist();
+
+      const result = await fetchTokenMetadata(
+        NetworksChainId.mainnet,
+        '0x514910771af9ca656af840dff83e8264ecf986ca',
+        signal,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined if the fetch fails with an unsuccessful status code', async () => {
+      const { signal } = new AbortController();
+      nock(TOKEN_END_POINT_API)
+        .get(`/tokens/${NetworksChainId.mainnet}`)
+        .reply(500)
+        .persist();
+
+      const result = await fetchTokenMetadata(
+        NetworksChainId.mainnet,
+        '0x514910771af9ca656af840dff83e8264ecf986ca',
+        signal,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined if the fetch fails with a timeout', async () => {
+      const { signal } = new AbortController();
+      nock(TOKEN_END_POINT_API)
+        .get(`/tokens/${NetworksChainId.mainnet}`)
+        // well beyond timeout
+        .delay(oneSecondInMilliseconds)
+        .reply(200, sampleTokenList)
+        .persist();
+
+      const result = await fetchTokenMetadata(
+        NetworksChainId.mainnet,
+        '0x514910771af9ca656af840dff83e8264ecf986ca',
+        signal,
+        { timeout: oneMillisecond },
+      );
+
+      expect(result).toBeUndefined();
+    });
   });
 });

--- a/src/apis/token-service.ts
+++ b/src/apis/token-service.ts
@@ -23,9 +23,11 @@ function getTokenMetadataURL(chainId: string, tokenAddress: string) {
   return `${END_POINT}/token/${chainId}?address=${tokenAddress}`;
 }
 
+const tenSecondsInMilliseconds = 10_000;
+
 // Token list averages 1.6 MB in size
 // timeoutFetch by default has a 500ms timeout, which will almost always timeout given the response size.
-const timeout = 10000;
+const defaultTimeout = tenSecondsInMilliseconds;
 
 /**
  * Fetch the list of token metadata for a given network. This request is cancellable using the
@@ -33,14 +35,17 @@ const timeout = 10000;
  *
  * @param chainId - The chain ID of the network the requested tokens are on.
  * @param abortSignal - The abort signal used to cancel the request if necessary.
+ * @param options - Additional fetch options.
+ * @param options.timeout - The fetch timeout.
  * @returns The token list, or `undefined` if the request was cancelled.
  */
 export async function fetchTokenList(
   chainId: string,
   abortSignal: AbortSignal,
+  { timeout = defaultTimeout } = {},
 ): Promise<unknown> {
   const tokenURL = getTokensURL(chainId);
-  const response = await queryApi(tokenURL, abortSignal);
+  const response = await queryApi(tokenURL, abortSignal, timeout);
   if (response) {
     return parseJsonResponse(response);
   }
@@ -54,15 +59,18 @@ export async function fetchTokenList(
  * @param chainId - The chain ID of the network the token is on.
  * @param tokenAddress - The address of the token to fetch metadata for.
  * @param abortSignal - The abort signal used to cancel the request if necessary.
+ * @param options - Additional fetch options.
+ * @param options.timeout - The fetch timeout.
  * @returns The token metadata, or `undefined` if the request was cancelled.
  */
 export async function fetchTokenMetadata(
   chainId: string,
   tokenAddress: string,
   abortSignal: AbortSignal,
+  { timeout = defaultTimeout } = {},
 ): Promise<unknown> {
   const tokenMetadataURL = getTokenMetadataURL(chainId, tokenAddress);
-  const response = await queryApi(tokenMetadataURL, abortSignal);
+  const response = await queryApi(tokenMetadataURL, abortSignal, timeout);
   if (response) {
     return parseJsonResponse(response);
   }
@@ -74,11 +82,13 @@ export async function fetchTokenMetadata(
  *
  * @param apiURL - The URL of the API to fetch.
  * @param abortSignal - The abort signal used to cancel the request if necessary.
+ * @param timeout - The fetch timeout.
  * @returns Promise resolving request response.
  */
 async function queryApi(
   apiURL: string,
   abortSignal: AbortSignal,
+  timeout: number,
 ): Promise<Response | undefined> {
   const fetchOptions: RequestInit = {
     referrer: apiURL,


### PR DESCRIPTION
The tests for the token service API have been expanded to cover error scenarios.

A new timeout optional parameter was added to make testing easier. The default timeout remains unchanged.