### PR TITLE
Enable `restoreMocks` Jest setting

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,14 +16,14 @@ module.exports = {
   },
   moduleFileExtensions: ['js', 'json', 'ts', 'node'],
   preset: 'ts-jest',
-  // TODO: Enable resetMocks and restoreMocks
+  // TODO: Enable resetMocks
   // "resetMocks" resets all mocks, including mocked modules, to jest.fn(),
   // between each test case.
   // resetMocks: true,
   // "restoreMocks" restores all mocks created using jest.spyOn to their
   // original implementations, between each test. It does not affect mocked
   // modules.
-  // restoreMocks: true,
+  restoreMocks: true,
   setupFiles: ['./tests/setupTests.ts'],
   testEnvironment: 'jsdom',
   testRegex: ['\\.test\\.(ts|js)$'],

--- a/src/assets/CurrencyRateController.test.ts
+++ b/src/assets/CurrencyRateController.test.ts
@@ -34,10 +34,8 @@ const getStubbedDate = () => {
 };
 
 describe('CurrencyRateController', () => {
-  const realDate = Date.now;
   afterEach(() => {
     nock.cleanAll();
-    global.Date.now = realDate;
   });
 
   it('should set default state', () => {


### PR DESCRIPTION
The `restoreMocks` Jest setting has been enabled, which will automatically restore any mocks created using Jest after each test. See here for more information: https://jestjs.io/docs/configuration#restoremocks-boolean

Note that this will not affect standalone Jest mocks. It only affects mocks that replace a method/field on a pre-existing object.

A manual mock restoration was removed from the CurrencyRateController tests, as the mock should now be restored automatically instead.