### PR TITLE
Update TypeScript to v4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "ts-jest": "^26.5.2",
     "typedoc": "^0.22.15",
     "typedoc-plugin-missing-exports": "^0.22.6",
-    "typescript": "~4.4.4"
+    "typescript": "~4.5.5"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8091,10 +8091,10 @@ typedoc@^0.22.15:
     minimatch "^5.0.1"
     shiki "^0.10.1"
 
-typescript@~4.4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
+typescript@~4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
See the TypeScript v4.5 release announcement for more information: https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/

None of the breaking changes affected this repository.