### PR TITLE
Update to TypeScript v4.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "ts-jest": "^26.5.2",
     "typedoc": "^0.22.15",
     "typedoc-plugin-missing-exports": "^0.22.6",
-    "typescript": "~4.5.5"
+    "typescript": "~4.6.3"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8091,10 +8091,10 @@ typedoc@^0.22.15:
     minimatch "^5.0.1"
     shiki "^0.10.1"
 
-typescript@~4.5.5:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+typescript@~4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
+  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
See the TypeScript v4.6 release announcement for more information: https://devblogs.microsoft.com/typescript/announcing-typescript-4-6/

This update included no breaking changes for this repository.

Closes #792