### PR TITLE
NFT auto detect metrics

### DIFF
--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -122,6 +122,7 @@ describe('ComposableController', () => {
         getERC1155TokenURI: assetContractController.getERC1155TokenURI.bind(
           assetContractController,
         ),
+        trackMetaMetricsEvent: jest.fn(),
       });
       const tokensController = new TokensController({
         onPreferencesStateChange: (listener) =>
@@ -206,6 +207,7 @@ describe('ComposableController', () => {
         getERC1155TokenURI: assetContractController.getERC1155TokenURI.bind(
           assetContractController,
         ),
+        trackMetaMetricsEvent: jest.fn(),
       });
       const tokensController = new TokensController({
         onPreferencesStateChange: (listener) =>

--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -122,7 +122,7 @@ describe('ComposableController', () => {
         getERC1155TokenURI: assetContractController.getERC1155TokenURI.bind(
           assetContractController,
         ),
-        trackMetaMetricsEvent: jest.fn(),
+        onCollectibleAdded: jest.fn(),
       });
       const tokensController = new TokensController({
         onPreferencesStateChange: (listener) =>
@@ -207,7 +207,7 @@ describe('ComposableController', () => {
         getERC1155TokenURI: assetContractController.getERC1155TokenURI.bind(
           assetContractController,
         ),
-        trackMetaMetricsEvent: jest.fn(),
+        onCollectibleAdded: jest.fn(),
       });
       const tokensController = new TokensController({
         onPreferencesStateChange: (listener) =>

--- a/src/assets/CollectibleDetectionController.test.ts
+++ b/src/assets/CollectibleDetectionController.test.ts
@@ -39,6 +39,7 @@ describe('CollectibleDetectionController', () => {
         assetsContract.getERC1155BalanceOf.bind(assetsContract),
       getERC1155TokenURI:
         assetsContract.getERC1155TokenURI.bind(assetsContract),
+      trackMetaMetricsEvent: jest.fn(),
     });
 
     collectibleDetection = new CollectibleDetectionController({

--- a/src/assets/CollectibleDetectionController.test.ts
+++ b/src/assets/CollectibleDetectionController.test.ts
@@ -29,20 +29,16 @@ describe('CollectibleDetectionController', () => {
     collectiblesController = new CollectiblesController({
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) => network.subscribe(listener),
-      getERC721AssetName: assetsContract.getERC721AssetName.bind(
-        assetsContract,
-      ),
-      getERC721AssetSymbol: assetsContract.getERC721AssetSymbol.bind(
-        assetsContract,
-      ),
+      getERC721AssetName:
+        assetsContract.getERC721AssetName.bind(assetsContract),
+      getERC721AssetSymbol:
+        assetsContract.getERC721AssetSymbol.bind(assetsContract),
       getERC721TokenURI: assetsContract.getERC721TokenURI.bind(assetsContract),
       getERC721OwnerOf: assetsContract.getERC721OwnerOf.bind(assetsContract),
-      getERC1155BalanceOf: assetsContract.getERC1155BalanceOf.bind(
-        assetsContract,
-      ),
-      getERC1155TokenURI: assetsContract.getERC1155TokenURI.bind(
-        assetsContract,
-      ),
+      getERC1155BalanceOf:
+        assetsContract.getERC1155BalanceOf.bind(assetsContract),
+      getERC1155TokenURI:
+        assetsContract.getERC1155TokenURI.bind(assetsContract),
       onCollectibleAdded: jest.fn(),
     });
 
@@ -222,21 +218,22 @@ describe('CollectibleDetectionController', () => {
         CollectibleDetectionController.prototype,
         'detectCollectibles',
       );
-      const collectiblesDetectionController = new CollectibleDetectionController(
-        {
-          onCollectiblesStateChange: (listener) =>
-            collectiblesController.subscribe(listener),
-          onPreferencesStateChange: (listener) =>
-            preferences.subscribe(listener),
-          onNetworkStateChange: (listener) => network.subscribe(listener),
-          getOpenSeaApiKey: () => collectiblesController.openSeaApiKey,
-          addCollectible: collectiblesController.addCollectible.bind(
-            collectiblesController,
-          ),
-          getCollectiblesState: () => collectiblesController.state,
-        },
-        { interval: 10 },
-      );
+      const collectiblesDetectionController =
+        new CollectibleDetectionController(
+          {
+            onCollectiblesStateChange: (listener) =>
+              collectiblesController.subscribe(listener),
+            onPreferencesStateChange: (listener) =>
+              preferences.subscribe(listener),
+            onNetworkStateChange: (listener) => network.subscribe(listener),
+            getOpenSeaApiKey: () => collectiblesController.openSeaApiKey,
+            addCollectible: collectiblesController.addCollectible.bind(
+              collectiblesController,
+            ),
+            getCollectiblesState: () => collectiblesController.state,
+          },
+          { interval: 10 },
+        );
       collectiblesDetectionController.configure({ disabled: false });
       collectiblesDetectionController.start();
       expect(mockCollectibles.calledOnce).toBe(true);

--- a/src/assets/CollectibleDetectionController.test.ts
+++ b/src/assets/CollectibleDetectionController.test.ts
@@ -29,17 +29,21 @@ describe('CollectibleDetectionController', () => {
     collectiblesController = new CollectiblesController({
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) => network.subscribe(listener),
-      getERC721AssetName:
-        assetsContract.getERC721AssetName.bind(assetsContract),
-      getERC721AssetSymbol:
-        assetsContract.getERC721AssetSymbol.bind(assetsContract),
+      getERC721AssetName: assetsContract.getERC721AssetName.bind(
+        assetsContract,
+      ),
+      getERC721AssetSymbol: assetsContract.getERC721AssetSymbol.bind(
+        assetsContract,
+      ),
       getERC721TokenURI: assetsContract.getERC721TokenURI.bind(assetsContract),
       getERC721OwnerOf: assetsContract.getERC721OwnerOf.bind(assetsContract),
-      getERC1155BalanceOf:
-        assetsContract.getERC1155BalanceOf.bind(assetsContract),
-      getERC1155TokenURI:
-        assetsContract.getERC1155TokenURI.bind(assetsContract),
-      trackMetaMetricsEvent: jest.fn(),
+      getERC1155BalanceOf: assetsContract.getERC1155BalanceOf.bind(
+        assetsContract,
+      ),
+      getERC1155TokenURI: assetsContract.getERC1155TokenURI.bind(
+        assetsContract,
+      ),
+      onCollectibleAdded: jest.fn(),
     });
 
     collectibleDetection = new CollectibleDetectionController({
@@ -218,22 +222,21 @@ describe('CollectibleDetectionController', () => {
         CollectibleDetectionController.prototype,
         'detectCollectibles',
       );
-      const collectiblesDetectionController =
-        new CollectibleDetectionController(
-          {
-            onCollectiblesStateChange: (listener) =>
-              collectiblesController.subscribe(listener),
-            onPreferencesStateChange: (listener) =>
-              preferences.subscribe(listener),
-            onNetworkStateChange: (listener) => network.subscribe(listener),
-            getOpenSeaApiKey: () => collectiblesController.openSeaApiKey,
-            addCollectible: collectiblesController.addCollectible.bind(
-              collectiblesController,
-            ),
-            getCollectiblesState: () => collectiblesController.state,
-          },
-          { interval: 10 },
-        );
+      const collectiblesDetectionController = new CollectibleDetectionController(
+        {
+          onCollectiblesStateChange: (listener) =>
+            collectiblesController.subscribe(listener),
+          onPreferencesStateChange: (listener) =>
+            preferences.subscribe(listener),
+          onNetworkStateChange: (listener) => network.subscribe(listener),
+          getOpenSeaApiKey: () => collectiblesController.openSeaApiKey,
+          addCollectible: collectiblesController.addCollectible.bind(
+            collectiblesController,
+          ),
+          getCollectiblesState: () => collectiblesController.state,
+        },
+        { interval: 10 },
+      );
       collectiblesDetectionController.configure({ disabled: false });
       collectiblesDetectionController.start();
       expect(mockCollectibles.calledOnce).toBe(true);

--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -69,7 +69,7 @@ describe('CollectiblesController', () => {
         assetsContract.getERC1155BalanceOf.bind(assetsContract),
       getERC1155TokenURI:
         assetsContract.getERC1155TokenURI.bind(assetsContract),
-      trackMetaMetricsEvent: trackEventSpy,
+      onCollectibleAdded: trackEventSpy,
     });
 
     preferences.update({
@@ -245,16 +245,12 @@ describe('CollectiblesController', () => {
       });
 
       expect(trackEventSpy).toHaveBeenCalledWith({
-        category: 'Wallet',
-        event: 'Token Added',
-        sensitiveProperties: {
-          asset_type: ASSET_TYPES.COLLECTIBLE,
-          source: 'custom',
-          tokenId: '1',
-          token_contract_address: '0x01',
-          token_standard: 'ERC1155',
-          token_symbol: 'FOO',
-        },
+        asset_type: ASSET_TYPES.COLLECTIBLE,
+        source: 'custom',
+        tokenId: '1',
+        token_contract_address: '0x01',
+        token_standard: 'ERC1155',
+        token_symbol: 'FOO',
       });
     });
 
@@ -274,16 +270,12 @@ describe('CollectiblesController', () => {
       );
 
       expect(trackEventSpy).toHaveBeenCalledWith({
-        category: 'Wallet',
-        event: 'Token Added',
-        sensitiveProperties: {
-          asset_type: ASSET_TYPES.COLLECTIBLE,
-          source: 'detected',
-          tokenId: '2',
-          token_contract_address: '0x01',
-          token_standard: 'ERC721',
-          token_symbol: 'FOO',
-        },
+        asset_type: ASSET_TYPES.COLLECTIBLE,
+        source: 'detected',
+        tokenId: '2',
+        token_contract_address: '0x01',
+        token_standard: 'ERC721',
+        token_symbol: 'FOO',
       });
     });
 

--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -47,7 +47,7 @@ describe('CollectiblesController', () => {
   let preferences: PreferencesController;
   let network: NetworkController;
   let assetsContract: AssetsContractController;
-  const trackEventSpy = jest.fn();
+  const onCollectibleAddedSpy = jest.fn();
 
   beforeEach(() => {
     preferences = new PreferencesController();
@@ -69,7 +69,7 @@ describe('CollectiblesController', () => {
         assetsContract.getERC1155BalanceOf.bind(assetsContract),
       getERC1155TokenURI:
         assetsContract.getERC1155TokenURI.bind(assetsContract),
-      onCollectibleAdded: trackEventSpy,
+      onCollectibleAdded: onCollectibleAddedSpy,
     });
 
     preferences.update({
@@ -235,7 +235,7 @@ describe('CollectiblesController', () => {
       });
     });
 
-    it('should call track events method correctly when collectible is manually added', async () => {
+    it('should call onCollectibleAdded callback correctly when collectible is manually added', async () => {
       await collectiblesController.addCollectible('0x01', '1', {
         name: 'name',
         image: 'image',
@@ -244,7 +244,7 @@ describe('CollectiblesController', () => {
         favorite: false,
       });
 
-      expect(trackEventSpy).toHaveBeenCalledWith({
+      expect(onCollectibleAddedSpy).toHaveBeenCalledWith({
         asset_type: ASSET_TYPES.COLLECTIBLE,
         source: 'custom',
         tokenId: '1',
@@ -254,7 +254,7 @@ describe('CollectiblesController', () => {
       });
     });
 
-    it('should call track events method correctly when collectible is added via detection', async () => {
+    it('should call onCollectibleAdded callback correctly when collectible is added via detection', async () => {
       const detectedUserAddress = '0x123';
       await collectiblesController.addCollectible(
         '0x01',
@@ -266,10 +266,11 @@ describe('CollectiblesController', () => {
           standard: 'ERC721',
           favorite: false,
         },
+        // this object in the third argument slot is only defined when the collectible is added via detection
         { userAddress: detectedUserAddress, chainId: '0x2' },
       );
 
-      expect(trackEventSpy).toHaveBeenCalledWith({
+      expect(onCollectibleAddedSpy).toHaveBeenCalledWith({
         asset_type: ASSET_TYPES.COLLECTIBLE,
         source: 'detected',
         tokenId: '2',

--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -7,7 +7,6 @@ import {
   NetworksChainId,
 } from '../network/NetworkController';
 import { getFormattedIpfsUrl } from '../util';
-import { ASSET_TYPES } from '../constants';
 import { AssetsContractController } from './AssetsContractController';
 import { CollectiblesController } from './CollectiblesController';
 
@@ -245,12 +244,11 @@ describe('CollectiblesController', () => {
       });
 
       expect(onCollectibleAddedSpy).toHaveBeenCalledWith({
-        asset_type: ASSET_TYPES.COLLECTIBLE,
         source: 'custom',
         tokenId: '1',
-        token_contract_address: '0x01',
-        token_standard: 'ERC1155',
-        token_symbol: 'FOO',
+        address: '0x01',
+        standard: 'ERC1155',
+        symbol: 'FOO',
       });
     });
 
@@ -271,12 +269,11 @@ describe('CollectiblesController', () => {
       );
 
       expect(onCollectibleAddedSpy).toHaveBeenCalledWith({
-        asset_type: ASSET_TYPES.COLLECTIBLE,
         source: 'detected',
         tokenId: '2',
-        token_contract_address: '0x01',
-        token_standard: 'ERC721',
-        token_symbol: 'FOO',
+        address: '0x01',
+        standard: 'ERC721',
+        symbol: 'FOO',
       });
     });
 

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -837,7 +837,8 @@ export class CollectiblesController extends BaseController<
    * @param options.getERC721OwnerOf - Get the owner of a ERC-721 collectible.
    * @param options.getERC1155BalanceOf - Gets balance of a ERC-1155 collectible.
    * @param options.getERC1155TokenURI - Gets the URI of the ERC1155 token at the given address, with the given ID.
-   * @param options.onCollectibleAdded - Event hook currently used to emit a track event for the collectible added.
+   * @param options.onCollectibleAdded - Callback that is called when a collectible is added. Currently used pass data 
+   * for tracking the collectible added event.
    * @param config - Initial options used to configure this controller.
    * @param state - Initial state to set on this controller.
    */

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -837,7 +837,7 @@ export class CollectiblesController extends BaseController<
    * @param options.getERC721OwnerOf - Get the owner of a ERC-721 collectible.
    * @param options.getERC1155BalanceOf - Gets balance of a ERC-1155 collectible.
    * @param options.getERC1155TokenURI - Gets the URI of the ERC1155 token at the given address, with the given ID.
-   * @param options.onCollectibleAdded - Callback that is called when a collectible is added. Currently used pass data 
+   * @param options.onCollectibleAdded - Callback that is called when a collectible is added. Currently used pass data
    * for tracking the collectible added event.
    * @param config - Initial options used to configure this controller.
    * @param state - Initial state to set on this controller.

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -18,7 +18,6 @@ import {
   IPFS_DEFAULT_GATEWAY_URL,
   ERC721,
   ERC1155,
-  ASSET_TYPES,
 } from '../constants';
 
 import type {
@@ -599,11 +598,10 @@ export class CollectiblesController extends BaseController<
       );
 
       this.onCollectibleAdded({
-        token_contract_address: address,
-        token_symbol: collectibleContract.symbol,
+        address,
+        symbol: collectibleContract.symbol,
         tokenId: tokenId.toString(),
-        asset_type: ASSET_TYPES.COLLECTIBLE,
-        token_standard: collectibleMetadata.standard,
+        standard: collectibleMetadata.standard,
         source: detection ? 'detected' : 'custom',
       });
 
@@ -817,11 +815,10 @@ export class CollectiblesController extends BaseController<
   private getERC1155TokenURI: AssetsContractController['getERC1155TokenURI'];
 
   private onCollectibleAdded: (data: {
-    token_contract_address: string;
-    token_symbol: string | undefined;
+    address: string;
+    symbol: string | undefined;
     tokenId: string;
-    asset_type: string;
-    token_standard: string | null;
+    standard: string | null;
     source: string;
   }) => void;
 
@@ -866,12 +863,11 @@ export class CollectiblesController extends BaseController<
       getERC721OwnerOf: AssetsContractController['getERC721OwnerOf'];
       getERC1155BalanceOf: AssetsContractController['getERC1155BalanceOf'];
       getERC1155TokenURI: AssetsContractController['getERC1155TokenURI'];
-      onCollectibleAdded: (sensitiveProperties: {
-        token_contract_address: string;
-        token_symbol?: string;
+      onCollectibleAdded: (data: {
+        address: string;
+        symbol: string | undefined;
         tokenId: string;
-        asset_type: string;
-        token_standard: string | null;
+        standard: string | null;
         source: string;
       }) => void;
     },

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -816,9 +816,9 @@ export class CollectiblesController extends BaseController<
 
   private getERC1155TokenURI: AssetsContractController['getERC1155TokenURI'];
 
-  private onCollectibleAdded: (sensitiveProperties: {
+  private onCollectibleAdded: (data: {
     token_contract_address: string;
-    token_symbol?: string;
+    token_symbol: string | undefined;
     tokenId: string;
     asset_type: string;
     token_standard: string | null;

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -598,17 +598,13 @@ export class CollectiblesController extends BaseController<
         { chainId, userAddress: selectedAddress },
       );
 
-      this.trackMetaMetricsEvent({
-        event: 'Token Added',
-        category: 'Wallet',
-        sensitiveProperties: {
-          token_contract_address: address,
-          token_symbol: collectibleContract.symbol,
-          tokenId: tokenId.toString(),
-          asset_type: ASSET_TYPES.COLLECTIBLE,
-          token_standard: collectibleMetadata.standard,
-          source: detection ? 'detected' : 'custom',
-        },
+      this.onCollectibleAdded({
+        token_contract_address: address,
+        token_symbol: collectibleContract.symbol,
+        tokenId: tokenId.toString(),
+        asset_type: ASSET_TYPES.COLLECTIBLE,
+        token_standard: collectibleMetadata.standard,
+        source: detection ? 'detected' : 'custom',
       });
 
       return newCollectibles;
@@ -820,10 +816,13 @@ export class CollectiblesController extends BaseController<
 
   private getERC1155TokenURI: AssetsContractController['getERC1155TokenURI'];
 
-  private trackMetaMetricsEvent: (eventObject: {
-    event: string;
-    category: string;
-    sensitiveProperties: any;
+  private onCollectibleAdded: (sensitiveProperties: {
+    token_contract_address: string;
+    token_symbol?: string;
+    tokenId: string;
+    asset_type: string;
+    token_standard: string | null;
+    source: string;
   }) => void;
 
   /**
@@ -838,7 +837,7 @@ export class CollectiblesController extends BaseController<
    * @param options.getERC721OwnerOf - Get the owner of a ERC-721 collectible.
    * @param options.getERC1155BalanceOf - Gets balance of a ERC-1155 collectible.
    * @param options.getERC1155TokenURI - Gets the URI of the ERC1155 token at the given address, with the given ID.
-   * @param options.trackMetaMetricsEvent - Creates and broadcasts a track event.
+   * @param options.onCollectibleAdded - Event hook currently used to emit a track event for the collectible added.
    * @param config - Initial options used to configure this controller.
    * @param state - Initial state to set on this controller.
    */
@@ -852,7 +851,7 @@ export class CollectiblesController extends BaseController<
       getERC721OwnerOf,
       getERC1155BalanceOf,
       getERC1155TokenURI,
-      trackMetaMetricsEvent,
+      onCollectibleAdded,
     }: {
       onPreferencesStateChange: (
         listener: (preferencesState: PreferencesState) => void,
@@ -866,10 +865,13 @@ export class CollectiblesController extends BaseController<
       getERC721OwnerOf: AssetsContractController['getERC721OwnerOf'];
       getERC1155BalanceOf: AssetsContractController['getERC1155BalanceOf'];
       getERC1155TokenURI: AssetsContractController['getERC1155TokenURI'];
-      trackMetaMetricsEvent: (eventObject: {
-        event: string;
-        category: string;
-        sensitiveProperties: any;
+      onCollectibleAdded: (sensitiveProperties: {
+        token_contract_address: string;
+        token_symbol?: string;
+        tokenId: string;
+        asset_type: string;
+        token_standard: string | null;
+        source: string;
       }) => void;
     },
     config?: Partial<BaseConfig>,
@@ -897,7 +899,7 @@ export class CollectiblesController extends BaseController<
     this.getERC721OwnerOf = getERC721OwnerOf;
     this.getERC1155BalanceOf = getERC1155BalanceOf;
     this.getERC1155TokenURI = getERC1155TokenURI;
-    this.trackMetaMetricsEvent = trackMetaMetricsEvent;
+    this.onCollectibleAdded = onCollectibleAdded;
 
     onPreferencesStateChange(
       ({ selectedAddress, ipfsGateway, openSeaEnabled }) => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,3 +21,11 @@ export const ERC1155_TOKEN_RECEIVER_INTERFACE_ID = '0x4e2312e0';
 
 // UNITS
 export const GWEI = 'gwei';
+
+// ASSET TYPES
+export const ASSET_TYPES = {
+  NATIVE: 'NATIVE',
+  TOKEN: 'TOKEN',
+  COLLECTIBLE: 'COLLECTIBLE',
+  UNKNOWN: 'UNKNOWN',
+};


### PR DESCRIPTION
Addresses subtasks on https://github.com/MetaMask/metamask-extension/issues/13477

**BREAKING** - add method `trackMetaMetricsEvent` passed to `CollectiblesController` in options object to and call it to broadcast `Token Added` event when a `collectible`/`nft` is added to state.