### PR TITLE
Revert "[Token Detection V2] 1 of 7 - Throw on failure for fetchTokenMetadata in token service (#812)"

### DIFF
--- a/src/apis/token-service.test.ts
+++ b/src/apis/token-service.test.ts
@@ -1,10 +1,6 @@
 import nock from 'nock';
 import { NetworksChainId } from '../network/NetworkController';
-import {
-  fetchTokenList,
-  fetchTokenMetadata,
-  FETCH_TOKEN_METADATA_ERROR,
-} from './token-service';
+import { fetchTokenList, fetchTokenMetadata } from './token-service';
 
 const TOKEN_END_POINT_API = 'https://token-api.metaswap.codefi.network';
 
@@ -237,7 +233,7 @@ describe('Token service', () => {
       expect(token).toStrictEqual(sampleToken);
     });
 
-    it('should throw error if the fetch is aborted', async () => {
+    it('should return undefined if the fetch is aborted', async () => {
       const abortController = new AbortController();
       nock(TOKEN_END_POINT_API)
         .get(`/tokens/${NetworksChainId.mainnet}`)
@@ -246,49 +242,49 @@ describe('Token service', () => {
         .reply(200, sampleTokenList)
         .persist();
 
-      await expect(async () => {
-        await fetchTokenMetadata(
-          NetworksChainId.mainnet,
-          '0x514910771af9ca656af840dff83e8264ecf986ca',
-          abortController.signal,
-        );
-        abortController.abort();
-      }).rejects.toThrow(FETCH_TOKEN_METADATA_ERROR);
+      const fetchPromise = fetchTokenMetadata(
+        NetworksChainId.mainnet,
+        '0x514910771af9ca656af840dff83e8264ecf986ca',
+        abortController.signal,
+      );
+      abortController.abort();
+
+      expect(await fetchPromise).toBeUndefined();
     });
 
-    it('should throw error if the fetch fails with a network error', async () => {
+    it('should return undefined if the fetch fails with a network error', async () => {
       const { signal } = new AbortController();
       nock(TOKEN_END_POINT_API)
         .get(`/tokens/${NetworksChainId.mainnet}`)
         .replyWithError('Example network error')
         .persist();
 
-      await expect(async () => {
-        await fetchTokenMetadata(
-          NetworksChainId.mainnet,
-          '0x514910771af9ca656af840dff83e8264ecf986ca',
-          signal,
-        );
-      }).rejects.toThrow(FETCH_TOKEN_METADATA_ERROR);
+      const result = await fetchTokenMetadata(
+        NetworksChainId.mainnet,
+        '0x514910771af9ca656af840dff83e8264ecf986ca',
+        signal,
+      );
+
+      expect(result).toBeUndefined();
     });
 
-    it('should throw error if the fetch fails with an unsuccessful status code', async () => {
+    it('should return undefined if the fetch fails with an unsuccessful status code', async () => {
       const { signal } = new AbortController();
       nock(TOKEN_END_POINT_API)
         .get(`/tokens/${NetworksChainId.mainnet}`)
         .reply(500)
         .persist();
 
-      await expect(async () => {
-        await fetchTokenMetadata(
-          NetworksChainId.mainnet,
-          '0x514910771af9ca656af840dff83e8264ecf986ca',
-          signal,
-        );
-      }).rejects.toThrow(FETCH_TOKEN_METADATA_ERROR);
+      const result = await fetchTokenMetadata(
+        NetworksChainId.mainnet,
+        '0x514910771af9ca656af840dff83e8264ecf986ca',
+        signal,
+      );
+
+      expect(result).toBeUndefined();
     });
 
-    it('should throw error if the fetch fails with a timeout', async () => {
+    it('should return undefined if the fetch fails with a timeout', async () => {
       const { signal } = new AbortController();
       nock(TOKEN_END_POINT_API)
         .get(`/tokens/${NetworksChainId.mainnet}`)
@@ -297,26 +293,14 @@ describe('Token service', () => {
         .reply(200, sampleTokenList)
         .persist();
 
-      await expect(async () => {
-        await fetchTokenMetadata(
-          NetworksChainId.mainnet,
-          '0x514910771af9ca656af840dff83e8264ecf986ca',
-          signal,
-          { timeout: ONE_MILLISECOND },
-        );
-      }).rejects.toThrow(FETCH_TOKEN_METADATA_ERROR);
+      const result = await fetchTokenMetadata(
+        NetworksChainId.mainnet,
+        '0x514910771af9ca656af840dff83e8264ecf986ca',
+        signal,
+        { timeout: ONE_MILLISECOND },
+      );
+
+      expect(result).toBeUndefined();
     });
-  });
-
-  it('should call the tokens api and return undefined', async () => {
-    const { signal } = new AbortController();
-    nock(TOKEN_END_POINT_API)
-      .get(`/tokens/${NetworksChainId.mainnet}`)
-      .reply(404, undefined)
-      .persist();
-
-    const tokens = await fetchTokenList(NetworksChainId.mainnet, signal);
-
-    expect(tokens).toBeUndefined();
   });
 });

--- a/src/apis/token-service.ts
+++ b/src/apis/token-service.ts
@@ -1,8 +1,6 @@
 import { timeoutFetch } from '../util';
 
 const END_POINT = 'https://token-api.metaswap.codefi.network';
-export const FETCH_TOKEN_METADATA_ERROR =
-  'TokenService Error: No response from fetchTokenMetadata';
 
 /**
  * Get the tokens URL for a specific network.
@@ -65,18 +63,18 @@ export async function fetchTokenList(
  * @param options.timeout - The fetch timeout.
  * @returns The token metadata, or `undefined` if the request was cancelled.
  */
-export async function fetchTokenMetadata<T>(
+export async function fetchTokenMetadata(
   chainId: string,
   tokenAddress: string,
   abortSignal: AbortSignal,
   { timeout = defaultTimeout } = {},
-): Promise<T> {
+): Promise<unknown> {
   const tokenMetadataURL = getTokenMetadataURL(chainId, tokenAddress);
   const response = await queryApi(tokenMetadataURL, abortSignal, timeout);
   if (response) {
-    return parseJsonResponse(response) as Promise<T>;
+    return parseJsonResponse(response);
   }
-  throw new Error(FETCH_TOKEN_METADATA_ERROR);
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
Reverts [this commit](https://github.com/MetaMask/controllers/commit/d4030cff97344d6a919bfc0cf1dc786e771e27b5) so that we can cut a patch release for this package (v29.0.1). Will re-add this commit after the release is cut/published.
