### PR TITLE
Fix keep nft when transaction fail

### DIFF
--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -58,16 +58,20 @@ describe('CollectiblesController', () => {
     collectiblesController = new CollectiblesController({
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
       onNetworkStateChange: (listener) => network.subscribe(listener),
-      getERC721AssetName:
-        assetsContract.getERC721AssetName.bind(assetsContract),
-      getERC721AssetSymbol:
-        assetsContract.getERC721AssetSymbol.bind(assetsContract),
+      getERC721AssetName: assetsContract.getERC721AssetName.bind(
+        assetsContract,
+      ),
+      getERC721AssetSymbol: assetsContract.getERC721AssetSymbol.bind(
+        assetsContract,
+      ),
       getERC721TokenURI: assetsContract.getERC721TokenURI.bind(assetsContract),
       getERC721OwnerOf: assetsContract.getERC721OwnerOf.bind(assetsContract),
-      getERC1155BalanceOf:
-        assetsContract.getERC1155BalanceOf.bind(assetsContract),
-      getERC1155TokenURI:
-        assetsContract.getERC1155TokenURI.bind(assetsContract),
+      getERC1155BalanceOf: assetsContract.getERC1155BalanceOf.bind(
+        assetsContract,
+      ),
+      getERC1155TokenURI: assetsContract.getERC1155TokenURI.bind(
+        assetsContract,
+      ),
       onCollectibleAdded: onCollectibleAddedSpy,
     });
 
@@ -1330,11 +1334,10 @@ describe('CollectiblesController', () => {
           .stub(collectiblesController, 'isCollectibleOwner' as any)
           .returns(false);
 
-        const updatedCollectible =
-          await collectiblesController.checkAndUpdateSingleCollectibleOwnershipStatus(
-            collectible,
-            true,
-          );
+        const updatedCollectible = await collectiblesController.checkAndUpdateSingleCollectibleOwnershipStatus(
+          collectible,
+          true,
+        );
 
         expect(
           collectiblesController.state.allCollectibles[selectedAddress][
@@ -1406,6 +1409,160 @@ describe('CollectiblesController', () => {
             NetworksChainId[firstNetworkType]
           ][0].isCurrentlyOwned,
         ).toBe(false);
+      });
+    });
+
+    describe('findCollectibleByAddressAndTokenId', () => {
+      const mockCollectible = {
+        address: '0x02',
+        tokenId: '1',
+        name: 'name',
+        image: 'image',
+        description: 'description',
+        standard: 'standard',
+        favorite: false,
+      };
+
+      const { selectedAddress, chainId } = collectiblesController.config;
+
+      it('should return null if the collectible does not exist in the state', async () => {
+        expect(
+          collectiblesController.findCollectibleByAddressAndTokenId(
+            mockCollectible.address,
+            mockCollectible.tokenId,
+            selectedAddress,
+            chainId,
+          ),
+        ).toBeNull();
+      });
+
+      it('should return the collectible by the address and tokenId', () => {
+        collectiblesController.state.allCollectibles = {
+          [selectedAddress]: { [chainId]: [mockCollectible] },
+        };
+
+        expect(
+          collectiblesController.findCollectibleByAddressAndTokenId(
+            mockCollectible.address,
+            mockCollectible.tokenId,
+            selectedAddress,
+            chainId,
+          ),
+        ).toStrictEqual({ collectible: mockCollectible, index: 0 });
+      });
+    });
+
+    describe('updateCollectibleByAddressAndTokenId', () => {
+      const mockTransactionId = '60d36710-b150-11ec-8a49-c377fbd05e27';
+
+      const mockCollectible = {
+        address: '0x02',
+        tokenId: '1',
+        name: 'name',
+        image: 'image',
+        description: 'description',
+        standard: 'standard',
+        favorite: false,
+      };
+
+      const expectedMockCollectible = {
+        address: '0x02',
+        description: 'description',
+        favorite: false,
+        image: 'image',
+        name: 'name',
+        standard: 'standard',
+        tokenId: '1',
+        transactionId: mockTransactionId,
+      };
+
+      const { selectedAddress, chainId } = collectiblesController.config;
+      it('should update the collectible if the collectible exist', async () => {
+        collectiblesController.state.allCollectibles = {
+          [selectedAddress]: { [chainId]: [mockCollectible] },
+        };
+
+        collectiblesController.updateCollectible(
+          mockCollectible,
+          {
+            transactionId: mockTransactionId,
+          },
+          selectedAddress,
+          chainId,
+        );
+
+        expect(
+          collectiblesController.state.allCollectibles[selectedAddress][
+            chainId
+          ][0],
+        ).toStrictEqual(expectedMockCollectible);
+      });
+
+      it('should return undefined if the collectible does not exist', () => {
+        expect(
+          collectiblesController.updateCollectible(
+            mockCollectible,
+            {
+              transactionId: mockTransactionId,
+            },
+            selectedAddress,
+            chainId,
+          ),
+        ).toBeUndefined();
+      });
+    });
+
+    describe('resetCollectibleTransactionStatusByTransactionId', () => {
+      const mockTransactionId = '60d36710-b150-11ec-8a49-c377fbd05e27';
+      const nonExistTransactionId = '0123';
+
+      const mockCollectible = {
+        address: '0x02',
+        tokenId: '1',
+        name: 'name',
+        image: 'image',
+        description: 'description',
+        standard: 'standard',
+        favorite: false,
+        transactionId: mockTransactionId,
+      };
+
+      const { selectedAddress, chainId } = collectiblesController.config;
+
+      it('should not update any collectible state and should return false when passed a transaction id that does not match that of any collectible', async () => {
+        expect(
+          collectiblesController.resetCollectibleTransactionStatusByTransactionId(
+            nonExistTransactionId,
+            selectedAddress,
+            chainId,
+          ),
+        ).toBe(false);
+      });
+
+      it('should set the transaction id of a collectible in state to undefined, and return true when it has successfully updated this state', async () => {
+        collectiblesController.state.allCollectibles = {
+          [selectedAddress]: { [chainId]: [mockCollectible] },
+        };
+
+        expect(
+          collectiblesController.state.allCollectibles[selectedAddress][
+            chainId
+          ][0].transactionId,
+        ).toBe(mockTransactionId);
+
+        expect(
+          collectiblesController.resetCollectibleTransactionStatusByTransactionId(
+            mockTransactionId,
+            selectedAddress,
+            chainId,
+          ),
+        ).toBe(true);
+
+        expect(
+          collectiblesController.state.allCollectibles[selectedAddress][
+            chainId
+          ][0].transactionId,
+        ).toBeUndefined();
       });
     });
   });

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -48,6 +48,7 @@ import { compareCollectiblesMetadata } from './assetsUtil';
  * @property externalLink - External link containing additional information
  * @property creator - The collectible owner information object
  * @property isCurrentlyOwned - Boolean indicating whether the address/chainId combination where it's currently stored currently owns this collectible
+ * @property transactionId - Transaction Id associated with the collectible
  */
 export interface Collectible extends CollectibleMetadata {
   tokenId: string;
@@ -117,6 +118,7 @@ export interface CollectibleMetadata {
   externalLink?: string;
   creator?: ApiCollectibleCreator;
   lastSale?: ApiCollectibleLastSale;
+  transactionId?: string;
 }
 
 interface AccountParams {
@@ -1185,6 +1187,119 @@ export class CollectiblesController extends BaseController<
 
     this.updateNestedCollectibleState(collectibles, ALL_COLLECTIBLES_STATE_KEY);
   }
+
+   /**
+   * Returns the collectible by the address and token id.
+   *
+   * @param address - Hex address of the collectible contract.
+   * @param tokenId - Number that represents the id of the token.
+   * @param selectedAddress - Hex address of the user account.
+   * @param chainId - Id of the current network.
+   * @returns Object containing the Collectible and their position in the array
+   */
+    findCollectibleByAddressAndTokenId(
+      address: string,
+      tokenId: string,
+      selectedAddress: string,
+      chainId: string
+    ): { collectible: Collectible; index: number } | null {
+      const { allCollectibles } = this.state;
+      const collectibles = allCollectibles[selectedAddress]?.[chainId] || [];
+  
+      const index: number = collectibles.findIndex(
+        (collectible) =>
+          collectible.address.toLowerCase() === address.toLowerCase() &&
+          collectible.tokenId === tokenId,
+      );
+  
+      if (index === -1) {
+        return null;
+      }
+  
+      return { collectible: collectibles[index], index };
+    }
+  
+    /**
+     * Update collectible data.
+     *
+     * @param collectible - Collectible object to find the right collectible to updates.
+     * @param updates - Collectible partial object to update properties of the collectible.
+     * @param selectedAddress - Hex address of the user account.
+     * @param chainId - Id of the current network.
+     */
+    updateCollectible(collectible: Collectible, updates: Partial<Collectible>, selectedAddress: string, chainId:string) {
+      const { allCollectibles } = this.state;
+      const collectibles = allCollectibles[selectedAddress]?.[chainId] || [];
+      const collectibleInfo = this.findCollectibleByAddressAndTokenId(
+        collectible.address,
+        collectible.tokenId,
+        selectedAddress,
+        chainId
+      );
+  
+      if (!collectibleInfo) {
+        return;
+      }
+  
+      const updatedCollectible: Collectible = {
+        ...collectible,
+        ...updates,
+      };
+  
+      // Update Collectibles array
+  
+      const newCollectibles = [
+        ...collectibles.slice(0, collectibleInfo.index),
+        updatedCollectible,
+        ...collectibles.slice(collectibleInfo.index + 1),
+      ];
+  
+      this.updateNestedCollectibleState(
+        newCollectibles,
+        ALL_COLLECTIBLES_STATE_KEY,
+      );
+    }
+  
+    /**
+     * Resets the transaction status of a collectible.
+     *
+     * @param transactionId - Collectible transaction id.
+     * @param selectedAddress - Hex address of the user account.
+     * @param chainId - Id of the current network.
+     * @returns a boolean indicating if the reset was well succeded or not
+     */
+    resetCollectibleTransactionStatusByTransactionId(
+      transactionId: string,
+      selectedAddress: string,
+      chainId: string
+    ): boolean {
+      const { allCollectibles } = this.state;
+      const collectibles = allCollectibles[selectedAddress]?.[chainId] || [];
+      const index: number = collectibles.findIndex(
+        (collectible) => collectible.transactionId === transactionId,
+      );
+  
+      if (index === -1) {
+        return false;
+      }
+      const updatedCollectible: Collectible = {
+        ...collectibles[index],
+        transactionId: undefined,
+      };
+  
+      // Update Collectibles array
+      const newCollectibles = [
+        ...collectibles.slice(0, index),
+        updatedCollectible,
+        ...collectibles.slice(index + 1),
+      ];
+  
+      this.updateNestedCollectibleState(
+        newCollectibles,
+        ALL_COLLECTIBLES_STATE_KEY,
+      );
+      return true;
+    }
 }
 
 export default CollectiblesController;


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Keep nft when transaction fail -> when the NFT is being transacted, was needed some changes**

- Was added two new props to the collectible interface in CollectibleController, for when a collectible is being transacted we have can know about it and change the UI according to that.

**Description**

_Itemize the changes you have made into the categories below_

- CHANGED:

  - Changed the Collectible Props to have more two optional props


- ADDED:

  - It was added 3 functions:
  - One to get the collectible transaction status, it will return if the collectible is being transacted and the id of that transaction
  - One to update the properties transactionId and isTransacting of the collectible
  - One to reset the transaction status of the collectible that updates the prop isTransacting for false and the transactionId to an empty string. It returns true if have success, false if have not

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented

**Issue**

Resolves #https://github.com/MetaMask/metamask-mobile/issues/2784

It will have an impact on this [PR](https://github.com/MetaMask/metamask-mobile/pull/3753) of metamask mobile
