### PR TITLE
[Token Detection V2] Refining the polling interval and the occurrences limit for the Dynamic token list

### DIFF
--- a/src/assets/TokenListController.test.ts
+++ b/src/assets/TokenListController.test.ts
@@ -122,12 +122,12 @@ const sampleWithDuplicateSymbolsTokensChainsCache =
     return output;
   }, {} as TokenListMap);
 
-const sampleWithLessThan2Occurences = [
+const sampleWithLessThan3Occurences = [
   {
     address: '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f',
     symbol: 'SNX',
     decimals: 18,
-    occurrences: 2,
+    occurrences: 3,
     name: 'Synthetix',
     iconUrl:
       'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f.png',
@@ -170,8 +170,8 @@ const sampleWithLessThan2Occurences = [
   },
 ];
 
-const sampleWithLessThan2OccurencesTokensChainsCache =
-  sampleWithLessThan2Occurences.reduce((output, current) => {
+const sampleWithLessThan3OccurencesTokensChainsCache =
+  sampleWithLessThan3Occurences.reduce((output, current) => {
     output[current.address] = current;
     return output;
   }, {} as TokenListMap);
@@ -436,7 +436,7 @@ const expiredCacheExistingState: TokenListState = {
   },
   tokensChainsCache: {
     '1': {
-      timestamp: timestamp - 1800000,
+      timestamp: timestamp - 86400000,
       data: {
         '0x514910771af9ca656af840dff83e8264ecf986ca': {
           address: '0x514910771af9ca656af840dff83e8264ecf986ca',
@@ -821,10 +821,10 @@ describe('TokenListController', () => {
     controller.destroy();
   });
 
-  it('should update token list after removing data less than 2 occurrences', async () => {
+  it('should update token list after removing data less than 3 occurrences', async () => {
     nock(TOKEN_END_POINT_API)
       .get(`/tokens/${NetworksChainId.mainnet}`)
-      .reply(200, sampleWithLessThan2Occurences)
+      .reply(200, sampleWithLessThan3Occurences)
       .persist();
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
@@ -838,7 +838,7 @@ describe('TokenListController', () => {
         address: '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f',
         symbol: 'SNX',
         decimals: 18,
-        occurrences: 2,
+        occurrences: 3,
         name: 'Synthetix',
         iconUrl:
           'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f.png',
@@ -883,7 +883,7 @@ describe('TokenListController', () => {
 
     expect(
       controller.state.tokensChainsCache[NetworksChainId.mainnet].data,
-    ).toStrictEqual(sampleWithLessThan2OccurencesTokensChainsCache);
+    ).toStrictEqual(sampleWithLessThan3OccurencesTokensChainsCache);
     controller.destroy();
   });
 

--- a/src/assets/TokenListController.test.ts
+++ b/src/assets/TokenListController.test.ts
@@ -127,7 +127,7 @@ const sampleWithLessThan3Occurences = [
     address: '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f',
     symbol: 'SNX',
     decimals: 18,
-    occurrences: 3,
+    occurrences: 2,
     name: 'Synthetix',
     iconUrl:
       'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f.png',
@@ -171,10 +171,12 @@ const sampleWithLessThan3Occurences = [
 ];
 
 const sampleWithLessThan3OccurencesTokensChainsCache =
-  sampleWithLessThan3Occurences.reduce((output, current) => {
-    output[current.address] = current;
-    return output;
-  }, {} as TokenListMap);
+  sampleWithLessThan3Occurences
+    .filter(({ occurrences }) => occurrences >= 3)
+    .reduce((output, current) => {
+      output[current.address] = current;
+      return output;
+    }, {} as TokenListMap);
 
 const sampleBinanceTokenList = [
   {
@@ -834,29 +836,6 @@ describe('TokenListController', () => {
     });
     await controller.start();
     expect(controller.state.tokenList).toStrictEqual({
-      '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f': {
-        address: '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f',
-        symbol: 'SNX',
-        decimals: 18,
-        occurrences: 3,
-        name: 'Synthetix',
-        iconUrl:
-          'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f.png',
-        aggregators: [
-          'Aave',
-          'Bancor',
-          'CMC',
-          'Crypto.com',
-          'CoinGecko',
-          '1inch',
-          'Paraswap',
-          'PMM',
-          'Synthetix',
-          'Zapper',
-          'Zerion',
-          '0x',
-        ],
-      },
       '0x514910771af9ca656af840dff83e8264ecf986ca': {
         address: '0x514910771af9ca656af840dff83e8264ecf986ca',
         symbol: 'LINK',

--- a/src/assets/TokenListController.test.ts
+++ b/src/assets/TokenListController.test.ts
@@ -122,7 +122,7 @@ const sampleWithDuplicateSymbolsTokensChainsCache =
     return output;
   }, {} as TokenListMap);
 
-const sampleWithLessThan3Occurences = [
+const sampleWithLessThan3OccurencesResponse = [
   {
     address: '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f',
     symbol: 'SNX',
@@ -170,13 +170,13 @@ const sampleWithLessThan3Occurences = [
   },
 ];
 
-const sampleWithLessThan3OccurencesTokensChainsCache =
-  sampleWithLessThan3Occurences
-    .filter(({ occurrences }) => occurrences >= 3)
-    .reduce((output, current) => {
-      output[current.address] = current;
-      return output;
-    }, {} as TokenListMap);
+const sampleWith3OrMoreOccurrences =
+  sampleWithLessThan3OccurencesResponse.reduce((output, token) => {
+    if (token.occurrences >= 3) {
+      output[token.address] = token;
+    }
+    return output;
+  }, {} as TokenListMap);
 
 const sampleBinanceTokenList = [
   {
@@ -826,7 +826,7 @@ describe('TokenListController', () => {
   it('should update token list after removing data less than 3 occurrences', async () => {
     nock(TOKEN_END_POINT_API)
       .get(`/tokens/${NetworksChainId.mainnet}`)
-      .reply(200, sampleWithLessThan3Occurences)
+      .reply(200, sampleWithLessThan3OccurencesResponse)
       .persist();
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
@@ -835,34 +835,13 @@ describe('TokenListController', () => {
       messenger,
     });
     await controller.start();
-    expect(controller.state.tokenList).toStrictEqual({
-      '0x514910771af9ca656af840dff83e8264ecf986ca': {
-        address: '0x514910771af9ca656af840dff83e8264ecf986ca',
-        symbol: 'LINK',
-        decimals: 18,
-        occurrences: 11,
-        name: 'Chainlink',
-        iconUrl:
-          'https://static.metaswap.codefi.network/api/v1/tokenIcons/1/0x514910771af9ca656af840dff83e8264ecf986ca.png',
-        aggregators: [
-          'Aave',
-          'Bancor',
-          'CMC',
-          'Crypto.com',
-          'CoinGecko',
-          '1inch',
-          'Paraswap',
-          'PMM',
-          'Zapper',
-          'Zerion',
-          '0x',
-        ],
-      },
-    });
+    expect(controller.state.tokenList).toStrictEqual(
+      sampleWith3OrMoreOccurrences,
+    );
 
     expect(
       controller.state.tokensChainsCache[NetworksChainId.mainnet].data,
-    ).toStrictEqual(sampleWithLessThan3OccurencesTokensChainsCache);
+    ).toStrictEqual(sampleWith3OrMoreOccurrences);
     controller.destroy();
   });
 

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -9,8 +9,8 @@ import { fetchTokenList } from '../apis/token-service';
 import { NetworkState } from '../network/NetworkController';
 import { formatAggregatorNames, formatIconUrlWithProxy } from './assetsUtil';
 
-const DEFAULT_INTERVAL = 60 * 60 * 1000;
-const DEFAULT_THRESHOLD = 60 * 30 * 1000;
+const DEFAULT_INTERVAL = 24 * 60 * 60 * 1000;
+const DEFAULT_THRESHOLD = 24 * 60 * 60 * 1000;
 
 const name = 'TokenListController';
 
@@ -225,11 +225,11 @@ export class TokenListController extends BaseController<
           });
           return;
         }
-        // Filtering out tokens with less than 2 occurrences and native tokens
+        // Filtering out tokens with less than 3 occurrences and native tokens
         const filteredTokenList = tokensFromAPI.filter(
           (token) =>
             token.occurrences &&
-            token.occurrences >= 2 &&
+            token.occurrences >= 3 &&
             token.address !== '0x0000000000000000000000000000000000000000',
         );
         // Removing the tokens with symbol conflicts


### PR DESCRIPTION
This is a part of #763 
Based on the recent conversation with the core team, a proposal was made to update the `polling interval for the token list api to 24 hrs` rather than the current 1 hour and we are also updating the `occurrences limit to 3`, ie the dynamic list will contain only those tokens that will be present in at least 3 lists/aggregators.

Related Notion doc: 
https://www.notion.so/Improve-token-detection-support-custom-networks-aka-TDF-v2-fb3ef7b7299c4ddb8e9481c2b22f1e87#af9a0a475d024c5d8e8ada65cf9e764f