### PR TITLE
Add dry run publish just before actual publish

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -34,8 +34,7 @@ jobs:
           path: ./dist
           key: ${{ github.sha }}
 
-  publish-npm:
-    environment: npm-publish
+  publish-npm-dry-run:
     runs-on: ubuntu-latest
     needs: publish-release
     steps:
@@ -49,7 +48,26 @@ jobs:
           key: ${{ github.sha }}
         # Set `ignore-scripts` to skip `prepublishOnly` because the release was built already in the previous job
       - run: npm config set ignore-scripts true
+      - name: Dry Run Publish
+        # omit npm-token token to perform dry run publish
+        uses: MetaMask/action-npm-publish@v1.1.0
+
+  publish-npm:
+    environment: npm-publish
+    runs-on: ubuntu-latest
+    needs: publish-npm-dry-run
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.sha }}
+      - uses: actions/cache@v3
+        id: restore-build
+        with:
+          path: ./dist
+          key: ${{ github.sha }}
+        # Set `ignore-scripts` to skip `prepublishOnly` because the release was built already in the previous job
+      - run: npm config set ignore-scripts true
       - name: Publish
-        uses: MetaMask/action-npm-publish@v1.0.0
+        uses: MetaMask/action-npm-publish@v1.1.0
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

This adds a dry run publish just prior to the actual npm publish so the person approving the publish can check the dry-run output of the preceding job to verify the publish does what's expected.

I've tested this action using a similar flow in a personal project here: https://github.com/rickycodes/card/actions/runs/2391846238