### PR TITLE
Make `onCollectibleAdded` parameter optional

### DIFF
--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -61,7 +61,9 @@ function setupController({
     onPreferencesStateChange: (listener) => preferences.subscribe(listener),
     onNetworkStateChange: (listener) => network.subscribe(listener),
   });
-  const onCollectibleAddedSpy = jest.fn();
+  const onCollectibleAddedSpy = includeOnCollectibleAdded
+    ? jest.fn()
+    : undefined;
 
   const collectiblesController = new CollectiblesController({
     onPreferencesStateChange: (listener) => preferences.subscribe(listener),
@@ -74,9 +76,7 @@ function setupController({
     getERC1155BalanceOf:
       assetsContract.getERC1155BalanceOf.bind(assetsContract),
     getERC1155TokenURI: assetsContract.getERC1155TokenURI.bind(assetsContract),
-    onCollectibleAdded: includeOnCollectibleAdded
-      ? onCollectibleAddedSpy
-      : undefined,
+    onCollectibleAdded: onCollectibleAddedSpy,
   });
 
   preferences.update({

--- a/src/assets/CollectiblesController.test.ts
+++ b/src/assets/CollectiblesController.test.ts
@@ -53,7 +53,7 @@ const DEPRESSIONIST_CLOUDFLARE_IPFS_SUBDOMAIN_PATH = getFormattedIpfsUrl(
  * @returns A collection of test controllers and stubs.
  */
 function setupController({
-  includeOnCollectibleAdded = true,
+  includeOnCollectibleAdded = false,
 }: { includeOnCollectibleAdded?: boolean } = {}) {
   const preferences = new PreferencesController();
   const network = new NetworkController();
@@ -216,52 +216,10 @@ describe('CollectiblesController', () => {
       });
     });
 
-    it('should add collectible and collectible contract even when "onCollectibleAdded" is unset', async () => {
-      const { collectiblesController } = setupController({
-        includeOnCollectibleAdded: false,
-      });
-
-      const { selectedAddress, chainId } = collectiblesController.config;
-      await collectiblesController.addCollectible('0x01', '1', {
-        name: 'name',
-        image: 'image',
-        description: 'description',
-        standard: 'standard',
-        favorite: false,
-      });
-
-      expect(
-        collectiblesController.state.allCollectibles[selectedAddress][
-          chainId
-        ][0],
-      ).toStrictEqual({
-        address: '0x01',
-        description: 'description',
-        image: 'image',
-        name: 'name',
-        tokenId: '1',
-        standard: 'standard',
-        favorite: false,
-        isCurrentlyOwned: true,
-      });
-
-      expect(
-        collectiblesController.state.allCollectibleContracts[selectedAddress][
-          chainId
-        ][0],
-      ).toStrictEqual({
-        address: '0x01',
-        description: 'Description',
-        logo: 'url',
-        name: 'Name',
-        symbol: 'FOO',
-        totalSupply: 0,
-      });
-    });
-
     it('should call onCollectibleAdded callback correctly when collectible is manually added', async () => {
-      const { collectiblesController, onCollectibleAddedSpy } =
-        setupController();
+      const { collectiblesController, onCollectibleAddedSpy } = setupController(
+        { includeOnCollectibleAdded: true },
+      );
 
       await collectiblesController.addCollectible('0x01', '1', {
         name: 'name',
@@ -281,8 +239,9 @@ describe('CollectiblesController', () => {
     });
 
     it('should call onCollectibleAdded callback correctly when collectible is added via detection', async () => {
-      const { collectiblesController, onCollectibleAddedSpy } =
-        setupController();
+      const { collectiblesController, onCollectibleAddedSpy } = setupController(
+        { includeOnCollectibleAdded: true },
+      );
 
       const detectedUserAddress = '0x123';
       await collectiblesController.addCollectible(

--- a/src/assets/CollectiblesController.ts
+++ b/src/assets/CollectiblesController.ts
@@ -682,13 +682,15 @@ export class CollectiblesController extends BaseController<
         { chainId, userAddress: selectedAddress },
       );
 
-      this.onCollectibleAdded({
-        address,
-        symbol: collectibleContract.symbol,
-        tokenId: tokenId.toString(),
-        standard: collectibleMetadata.standard,
-        source: detection ? 'detected' : 'custom',
-      });
+      if (this.onCollectibleAdded) {
+        this.onCollectibleAdded({
+          address,
+          symbol: collectibleContract.symbol,
+          tokenId: tokenId.toString(),
+          standard: collectibleMetadata.standard,
+          source: detection ? 'detected' : 'custom',
+        });
+      }
 
       return newCollectibles;
     } finally {
@@ -897,7 +899,7 @@ export class CollectiblesController extends BaseController<
 
   private getERC1155TokenURI: AssetsContractController['getERC1155TokenURI'];
 
-  private onCollectibleAdded: (data: {
+  private onCollectibleAdded?: (data: {
     address: string;
     symbol: string | undefined;
     tokenId: string;
@@ -946,7 +948,7 @@ export class CollectiblesController extends BaseController<
       getERC721OwnerOf: AssetsContractController['getERC721OwnerOf'];
       getERC1155BalanceOf: AssetsContractController['getERC1155BalanceOf'];
       getERC1155TokenURI: AssetsContractController['getERC1155TokenURI'];
-      onCollectibleAdded: (data: {
+      onCollectibleAdded?: (data: {
         address: string;
         symbol: string | undefined;
         tokenId: string;


### PR DESCRIPTION
The `onCollectibleAdded` constructor parameter for the `CollectiblesController` is now optional. This parameter is meant for making it easier to add metrics. If the caller does not need to use this event, there is no reason to require it.

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented