### PR TITLE
Add local ganache network chainId as a SupportedTokenListNetwork

### DIFF
--- a/src/apis/token-service.ts
+++ b/src/apis/token-service.ts
@@ -1,4 +1,4 @@
-import { isTokenDetectionSupportedForNetwork, timeoutFetch } from '../util';
+import { isTokenListSupportedForNetwork, timeoutFetch } from '../util';
 
 export const TOKEN_END_POINT_API = 'https://token-api.metaswap.codefi.network';
 export const TOKEN_METADATA_NO_SUPPORT_ERROR =
@@ -71,7 +71,7 @@ export async function fetchTokenMetadata<T>(
   abortSignal: AbortSignal,
   { timeout = defaultTimeout } = {},
 ): Promise<T | undefined> {
-  if (!isTokenDetectionSupportedForNetwork(chainId)) {
+  if (!isTokenListSupportedForNetwork(chainId)) {
     throw new Error(TOKEN_METADATA_NO_SUPPORT_ERROR);
   }
   const tokenMetadataURL = getTokenMetadataURL(chainId, tokenAddress);

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -3,7 +3,7 @@ import { Mutex } from 'async-mutex';
 import { AbortController } from 'abort-controller';
 import { BaseController } from '../BaseControllerV2';
 import type { RestrictedControllerMessenger } from '../ControllerMessenger';
-import { safelyExecute, isTokenDetectionSupportedForNetwork } from '../util';
+import { safelyExecute, isTokenListSupportedForNetwork } from '../util';
 import { fetchTokenList } from '../apis/token-service';
 import { NetworkState } from '../network/NetworkController';
 import { formatAggregatorNames, formatIconUrlWithProxy } from './assetsUtil';
@@ -145,7 +145,7 @@ export class TokenListController extends BaseController<
    * Start polling for the token list.
    */
   async start() {
-    if (!isTokenDetectionSupportedForNetwork(this.chainId)) {
+    if (!isTokenListSupportedForNetwork(this.chainId)) {
       return;
     }
     await this.startPolling();

--- a/src/assets/assetsUtil.ts
+++ b/src/assets/assetsUtil.ts
@@ -1,4 +1,3 @@
-import { isHexString } from 'ethereumjs-util';
 import { convertHexToDecimal } from '../util';
 import { Collectible, CollectibleMetadata } from './CollectiblesController';
 
@@ -95,9 +94,6 @@ export const formatIconUrlWithProxy = ({
   chainId: string;
   tokenAddress: string;
 }) => {
-  let chainIdDec = chainId;
-  if (isHexString(chainId)) {
-    chainIdDec = convertHexToDecimal(chainId).toString();
-  }
-  return `https://static.metaswap.codefi.network/api/v1/tokenIcons/${chainIdDec}/${tokenAddress.toLowerCase()}.png`;
+  const chainIdDecimal = convertHexToDecimal(chainId).toString();
+  return `https://static.metaswap.codefi.network/api/v1/tokenIcons/${chainIdDecimal}/${tokenAddress.toLowerCase()}.png`;
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ export const IPFS_DEFAULT_GATEWAY_URL = 'https://cloudflare-ipfs.com/ipfs/';
 
 // NETWORKS ID
 export const RINKEBY_CHAIN_ID = '4';
+export const GANACHE_CHAIN_ID = '1337';
 
 // TOKEN STANDARDS
 export const ERC721 = 'ERC721';

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,6 +1,7 @@
 import 'isomorphic-fetch';
 import { BN } from 'ethereumjs-util';
 import nock from 'nock';
+import { GANACHE_CHAIN_ID } from './constants';
 import * as util from './util';
 import {
   Transaction,
@@ -1288,5 +1289,33 @@ describe('isTokenDetectionSupportedForNetwork', () => {
     expect(
       util.isTokenDetectionSupportedForNetwork(NetworksChainId.ropsten),
     ).toBe(false);
+  });
+});
+
+describe('isTokenListSupportedForNetwork', () => {
+  it('returns true for Mainnet', () => {
+    expect(
+      util.isTokenListSupportedForNetwork(
+        util.SupportedTokenDetectionNetworks.mainnet,
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for ganache local network', () => {
+    expect(util.isTokenListSupportedForNetwork(GANACHE_CHAIN_ID)).toBe(true);
+  });
+
+  it('returns true for custom network such as Polygon', () => {
+    expect(
+      util.isTokenListSupportedForNetwork(
+        util.SupportedTokenDetectionNetworks.polygon,
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for testnets such as Ropsten', () => {
+    expect(util.isTokenListSupportedForNetwork(NetworksChainId.ropsten)).toBe(
+      false,
+    );
   });
 });

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -972,6 +972,14 @@ describe('util', () => {
     it('should return zero when undefined', () => {
       expect(util.convertHexToDecimal(undefined)).toStrictEqual(0);
     });
+
+    it('should return a decimal string as the same decimal number', () => {
+      expect(util.convertHexToDecimal('1611')).toStrictEqual(1611);
+    });
+
+    it('should return 0 when passed an invalid hex string', () => {
+      expect(util.convertHexToDecimal('0x12398u12')).toStrictEqual(0);
+    });
   });
 
   describe('getIncreasedPriceHex', () => {
@@ -1293,12 +1301,16 @@ describe('isTokenDetectionSupportedForNetwork', () => {
 });
 
 describe('isTokenListSupportedForNetwork', () => {
-  it('returns true for Mainnet', () => {
+  it('returns true for Mainnet when chainId is passed as a decimal string', () => {
     expect(
       util.isTokenListSupportedForNetwork(
         util.SupportedTokenDetectionNetworks.mainnet,
       ),
     ).toBe(true);
+  });
+
+  it('returns true for Mainnet when chainId is passed as a hexadecimal string', () => {
+    expect(util.isTokenListSupportedForNetwork('0x1')).toBe(true);
   });
 
   it('returns true for ganache local network', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -792,8 +792,21 @@ export const isEIP1559Transaction = (transaction: Transaction): boolean => {
   );
 };
 
-export const convertHexToDecimal = (value: string | undefined): number =>
-  parseInt(value === undefined ? '0x0' : value, 16);
+/**
+ * Converts valid hex strings to decimal numbers, and handles unexpected arg types.
+ *
+ * @param value - a string that is either a hexadecimal with `0x` prefix or a decimal string.
+ * @returns a decimal number.
+ */
+export const convertHexToDecimal = (
+  value: string | undefined = '0x0',
+): number => {
+  if (isHexString(value)) {
+    return parseInt(value, 16);
+  }
+
+  return Number(value) ? Number(value) : 0;
+};
 
 export const getIncreasedPriceHex = (value: number, rate: number): string =>
   addHexPrefix(`${parseInt(`${value * rate}`, 10).toString(16)}`);
@@ -1005,8 +1018,10 @@ export function isTokenDetectionSupportedForNetwork(chainId: string): boolean {
  * @returns Whether the current network supports tokenlists
  */
 export function isTokenListSupportedForNetwork(chainId: string): boolean {
+  const chainIdDecimal = convertHexToDecimal(chainId).toString();
   return (
-    isTokenDetectionSupportedForNetwork(chainId) || chainId === GANACHE_CHAIN_ID
+    isTokenDetectionSupportedForNetwork(chainIdDecimal) ||
+    chainIdDecimal === GANACHE_CHAIN_ID
   );
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -24,7 +24,7 @@ import { MessageParams } from './message-manager/MessageManager';
 import { PersonalMessageParams } from './message-manager/PersonalMessageManager';
 import { TypedMessageParams } from './message-manager/TypedMessageManager';
 import { Token } from './assets/TokenRatesController';
-import { MAINNET } from './constants';
+import { MAINNET, GANACHE_CHAIN_ID } from './constants';
 import { Json } from './BaseControllerV2';
 
 const TIMEOUT_ERROR = new Error('timeout');
@@ -983,7 +983,6 @@ export enum SupportedTokenDetectionNetworks {
   bsc = '56',
   polygon = '137',
   avax = '43114',
-  local = '1337',
 }
 
 /**
@@ -995,6 +994,19 @@ export enum SupportedTokenDetectionNetworks {
 export function isTokenDetectionSupportedForNetwork(chainId: string): boolean {
   return Object.values<string>(SupportedTokenDetectionNetworks).includes(
     chainId,
+  );
+}
+
+/**
+ * Check if token list polling is enabled for a given network.
+ * Currently this method is used to support e2e testing for consumers of this package.
+ *
+ * @param chainId - ChainID of network
+ * @returns Whether the current network supports tokenlists
+ */
+export function isTokenListSupportedForNetwork(chainId: string): boolean {
+  return (
+    isTokenDetectionSupportedForNetwork(chainId) || chainId === GANACHE_CHAIN_ID
   );
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -983,6 +983,7 @@ export enum SupportedTokenDetectionNetworks {
   bsc = '56',
   polygon = '137',
   avax = '43114',
+  local = '1337',
 }
 
 /**


### PR DESCRIPTION
A semi breaking change was introduced here https://github.com/MetaMask/controllers/pull/806/files#diff-c2ec75b01a3b2e2e1284df7c48ad4c80a26ea7f1455167cc8390d91ca865b854R149 which prevents an [extension e2e test](https://github.com/MetaMask/metamask-extension/blob/develop/test/e2e/tests/add-hide-token.spec.js#L69) which mocks an API request for the token-list [here](https://github.com/MetaMask/metamask-extension/blob/develop/test/e2e/mock-e2e.js#L128) from working properly.

cc @Cal-L 