### PR TITLE
Prevent third party token list polling in the Extension when token detection is OFF

### DIFF
--- a/src/assets/TokenDetectionController.test.ts
+++ b/src/assets/TokenDetectionController.test.ts
@@ -134,6 +134,7 @@ describe('TokenDetectionController', () => {
     const messenger = getTokenListMessenger();
     tokenList = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      preventPollingOnNetworkRestart: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
       messenger,
     });

--- a/src/assets/TokenListController.test.ts
+++ b/src/assets/TokenListController.test.ts
@@ -376,6 +376,7 @@ const existingState = {
       data: sampleMainnetTokensChainsCache,
     },
   },
+  preventPollingOnNetworkRestart: false,
 };
 
 const outdatedExistingState = {
@@ -409,6 +410,7 @@ const outdatedExistingState = {
       data: sampleMainnetTokensChainsCache,
     },
   },
+  preventPollingOnNetworkRestart: false,
 };
 
 const expiredCacheExistingState: TokenListState = {
@@ -465,6 +467,7 @@ const expiredCacheExistingState: TokenListState = {
       },
     },
   },
+  preventPollingOnNetworkRestart: false,
 };
 
 /**
@@ -502,6 +505,7 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      preventPollingOnNetworkRestart: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
       messenger,
     });
@@ -509,6 +513,7 @@ describe('TokenListController', () => {
     expect(controller.state).toStrictEqual({
       tokenList: {},
       tokensChainsCache: {},
+      preventPollingOnNetworkRestart: false,
     });
 
     controller.destroy();
@@ -518,6 +523,7 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      preventPollingOnNetworkRestart: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
       messenger,
       state: existingState,
@@ -553,6 +559,7 @@ describe('TokenListController', () => {
           data: sampleMainnetTokensChainsCache,
         },
       },
+      preventPollingOnNetworkRestart: false,
     });
 
     controller.destroy();
@@ -562,6 +569,7 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      preventPollingOnNetworkRestart: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
       interval: 100,
       messenger,
@@ -582,6 +590,7 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      preventPollingOnNetworkRestart: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
       interval: 100,
       messenger,
@@ -606,6 +615,7 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      preventPollingOnNetworkRestart: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
       interval: 100,
       messenger,
@@ -632,6 +642,7 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      preventPollingOnNetworkRestart: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
       interval: 100,
       messenger,
@@ -661,6 +672,7 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      preventPollingOnNetworkRestart: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
       interval: 100,
       messenger,
@@ -684,6 +696,7 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.localhost,
+      preventPollingOnNetworkRestart: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
       interval: 100,
       messenger,
@@ -706,6 +719,7 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      preventPollingOnNetworkRestart: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
       messenger,
     });
@@ -742,6 +756,7 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      preventPollingOnNetworkRestart: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
       messenger,
       interval: 100,
@@ -764,6 +779,7 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      preventPollingOnNetworkRestart: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
       messenger,
       state: existingState,
@@ -790,6 +806,7 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      preventPollingOnNetworkRestart: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
       messenger,
     });
@@ -831,6 +848,7 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      preventPollingOnNetworkRestart: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
       messenger,
     });
@@ -853,6 +871,7 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      preventPollingOnNetworkRestart: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
       messenger,
       state: outdatedExistingState,
@@ -879,6 +898,7 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      preventPollingOnNetworkRestart: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
       messenger,
       state: expiredCacheExistingState,
@@ -912,6 +932,7 @@ describe('TokenListController', () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
+      preventPollingOnNetworkRestart: false,
       onNetworkStateChange: (listener) => network.subscribe(listener),
       messenger,
       state: existingState,
@@ -958,6 +979,79 @@ describe('TokenListController', () => {
       controller.state.tokensChainsCache[NetworksChainId.mainnet].data,
     ).toStrictEqual(
       sampleTwoChainState.tokensChainsCache[NetworksChainId.mainnet].data,
+    );
+
+    expect(controller.state.tokensChainsCache['56'].data).toStrictEqual(
+      sampleTwoChainState.tokensChainsCache['56'].data,
+    );
+
+    controller.destroy();
+  });
+
+  it('should clear the tokenList and tokensChainsCache', async () => {
+    const messenger = getRestrictedMessenger();
+    const controller = new TokenListController({
+      chainId: NetworksChainId.mainnet,
+      preventPollingOnNetworkRestart: false,
+      onNetworkStateChange: (listener) => network.subscribe(listener),
+      messenger,
+      state: existingState,
+    });
+    expect(controller.state).toStrictEqual(existingState);
+    controller.clearingTokenListData();
+
+    expect(controller.state.tokenList).toStrictEqual({});
+    expect(controller.state.tokensChainsCache).toStrictEqual({});
+
+    controller.destroy();
+  });
+
+  it('should update preventPollingOnNetworkRestart and restart the polling on network restart', async () => {
+    nock(TOKEN_END_POINT_API)
+      .get(`/tokens/${NetworksChainId.mainnet}`)
+      .reply(200, sampleMainnetTokenList)
+      .get(`/tokens/${NetworksChainId.ropsten}`)
+      .reply(200, { error: 'ChainId 3 is not supported' })
+      .get(`/tokens/56`)
+      .reply(200, sampleBinanceTokenList)
+      .persist();
+    const messenger = getRestrictedMessenger();
+    const controller = new TokenListController({
+      chainId: NetworksChainId.ropsten,
+      preventPollingOnNetworkRestart: true,
+      onNetworkStateChange: (listener) => network.subscribe(listener),
+      messenger,
+      interval: 100,
+    });
+    await controller.start();
+    network.update({
+      provider: {
+        type: 'mainnet',
+        chainId: NetworksChainId.mainnet,
+      },
+    });
+
+    expect(controller.state).toStrictEqual({
+      tokenList: {},
+      tokensChainsCache: {},
+      preventPollingOnNetworkRestart: true,
+    });
+    controller.updatePreventPollingOnNetworkRestart(false);
+    expect(controller.state).toStrictEqual({
+      tokenList: {},
+      tokensChainsCache: {},
+      preventPollingOnNetworkRestart: false,
+    });
+
+    network.update({
+      provider: {
+        type: 'rpc',
+        chainId: '56',
+      },
+    });
+    await new Promise<void>((resolve) => setTimeout(() => resolve(), 10));
+    expect(controller.state.tokenList).toStrictEqual(
+      sampleTwoChainState.tokenList,
     );
 
     expect(controller.state.tokensChainsCache['56'].data).toStrictEqual(

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -307,8 +307,7 @@ export class TokenListController extends BaseController<
   }
 
   /**
-   * Clears the tokenList and tokensChainsCache from extension 
-   * when token detection is OFF
+   * Clearing tokenList and tokensChainsCache explicitly.
    */
   clearingTokenListData(): void {
     this.update(() => {
@@ -321,8 +320,9 @@ export class TokenListController extends BaseController<
   }
 
   /**
-   * Updates preventPollingOnNetworkRestart from extension
-   * @param shouldPreventPolling 
+   * Updates preventPollingOnNetworkRestart from extension.
+   *
+   * @param shouldPreventPolling - Determine whether to prevent polling on network change
    */
   updatePreventPollingOnNetworkRestart(shouldPreventPolling: boolean): void {
     this.update(() => {

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -36,6 +36,7 @@ type TokensChainsCache = {
 export type TokenListState = {
   tokenList: TokenListMap;
   tokensChainsCache: TokensChainsCache;
+  preventPollingOnNetworkRestart: boolean;
 };
 
 export type TokenListStateChange = {
@@ -59,11 +60,13 @@ type TokenListMessenger = RestrictedControllerMessenger<
 const metadata = {
   tokenList: { persist: true, anonymous: true },
   tokensChainsCache: { persist: true, anonymous: true },
+  preventPollingOnNetworkRestart: { persist: true, anonymous: true },
 };
 
 const defaultState: TokenListState = {
   tokenList: {},
   tokensChainsCache: {},
+  preventPollingOnNetworkRestart: false,
 };
 
 /**
@@ -96,9 +99,11 @@ export class TokenListController extends BaseController<
    * @param options.cacheRefreshThreshold - The token cache expiry time, in milliseconds.
    * @param options.messenger - A restricted controller messenger.
    * @param options.state - Initial state to set on this controller.
+   * @param options.preventPollingOnNetworkRestart - Determines whether to prevent poilling on network restart in extension.
    */
   constructor({
     chainId,
+    preventPollingOnNetworkRestart = false,
     onNetworkStateChange,
     interval = DEFAULT_INTERVAL,
     cacheRefreshThreshold = DEFAULT_THRESHOLD,
@@ -106,6 +111,7 @@ export class TokenListController extends BaseController<
     state,
   }: {
     chainId: string;
+    preventPollingOnNetworkRestart: boolean;
     onNetworkStateChange: (
       listener: (networkState: NetworkState) => void,
     ) => void;
@@ -123,20 +129,25 @@ export class TokenListController extends BaseController<
     this.intervalDelay = interval;
     this.cacheRefreshThreshold = cacheRefreshThreshold;
     this.chainId = chainId;
+    this.updatePreventPollingOnNetworkRestart(preventPollingOnNetworkRestart);
     this.abortController = new AbortController();
     onNetworkStateChange(async (networkState) => {
       if (this.chainId !== networkState.provider.chainId) {
         this.abortController.abort();
         this.abortController = new AbortController();
         this.chainId = networkState.provider.chainId;
-        // Ensure tokenList is referencing data from correct network
-        this.update(() => {
-          return {
-            ...this.state,
-            tokenList: this.state.tokensChainsCache[this.chainId]?.data || {},
-          };
-        });
-        await this.restart();
+        if (this.state.preventPollingOnNetworkRestart) {
+          this.clearingTokenListData();
+        } else {
+          // Ensure tokenList is referencing data from correct network
+          this.update(() => {
+            return {
+              ...this.state,
+              tokenList: this.state.tokensChainsCache[this.chainId]?.data || {},
+            };
+          });
+          await this.restart();
+        }
       }
     });
   }
@@ -218,6 +229,7 @@ export class TokenListController extends BaseController<
 
           this.update(() => {
             return {
+              ...this.state,
               tokenList,
               tokensChainsCache,
             };
@@ -264,6 +276,7 @@ export class TokenListController extends BaseController<
       };
       this.update(() => {
         return {
+          ...this.state,
           tokenList,
           tokensChainsCache: updatedTokensChainsCache,
         };
@@ -291,6 +304,33 @@ export class TokenListController extends BaseController<
       return dataCache.data;
     }
     return null;
+  }
+
+  /**
+   * Clears the tokenList and tokensChainsCache from extension 
+   * when token detection is OFF
+   */
+  clearingTokenListData(): void {
+    this.update(() => {
+      return {
+        ...this.state,
+        tokenList: {},
+        tokensChainsCache: {},
+      };
+    });
+  }
+
+  /**
+   * Updates preventPollingOnNetworkRestart from extension
+   * @param shouldPreventPolling 
+   */
+  updatePreventPollingOnNetworkRestart(shouldPreventPolling: boolean): void {
+    this.update(() => {
+      return {
+        ...this.state,
+        preventPollingOnNetworkRestart: shouldPreventPolling,
+      };
+    });
   }
 }
 


### PR DESCRIPTION
We are introducing a new state variable `preventPollingOnNetworkRestart` which has a default value of `false` in order to prevent third-party token list polling while changing the network when token detection is OFF. This is intended for use in the extension now in order to enable the user from opting out of using the third-party api. A true value for the variable will clear out the `tokenList` and `tokensChainsCache` and we are stopping the polling from the extension side and a false value will restart the polling and continue with the previous behavior.