### PR TITLE
Fix publishing configuration, closes #858

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,28 +1,31 @@
 name: Publish Release
 
 on:
-  pull_request:
-    types: [closed]
+  push:
+    branches: [main]
 
 jobs:
   publish-release:
     permissions:
       contents: write
-    if: |
-      github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'release/')
+    # release merge commits come from GitHub user
+    if: github.event.head_commit.committer.name == 'GitHub'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.sha }}
+          # we need this commit + the last so we can compare below
+          fetch-depth: 2
+      # exit early if the version has not changed
+      - run: ./scripts/check-version.sh ${{ github.event.before }}
       - name: Get Node.js version
         id: nvm
         run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
-      - uses: MetaMask/action-publish-release@v1
+      - uses: MetaMask/action-publish-release@v2.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: |
@@ -31,7 +34,9 @@ jobs:
       - uses: actions/cache@v3
         id: restore-build
         with:
-          path: ./dist
+          path: |
+            ./dist
+            ./node_modules
           key: ${{ github.sha }}
 
   publish-npm-dry-run:
@@ -44,13 +49,17 @@ jobs:
       - uses: actions/cache@v3
         id: restore-build
         with:
-          path: ./dist
+          path: |
+            ./dist
+            ./node_modules
           key: ${{ github.sha }}
         # Set `ignore-scripts` to skip `prepublishOnly` because the release was built already in the previous job
       - run: npm config set ignore-scripts true
       - name: Dry Run Publish
         # omit npm-token token to perform dry run publish
         uses: MetaMask/action-npm-publish@v1.1.0
+        env:
+          SKIP_PREPACK: true
 
   publish-npm:
     environment: npm-publish
@@ -63,7 +72,9 @@ jobs:
       - uses: actions/cache@v3
         id: restore-build
         with:
-          path: ./dist
+          path: |
+            ./dist
+            ./node_modules
           key: ${{ github.sha }}
         # Set `ignore-scripts` to skip `prepublishOnly` because the release was built already in the previous job
       - run: npm config set ignore-scripts true
@@ -71,3 +82,5 @@ jobs:
         uses: MetaMask/action-npm-publish@v1.1.0
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
+        env:
+          SKIP_PREPACK: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -34,9 +34,7 @@ jobs:
       - uses: actions/cache@v3
         id: restore-build
         with:
-          path: |
-            ./dist
-            ./node_modules
+          path: ./dist
           key: ${{ github.sha }}
 
   publish-npm-dry-run:
@@ -49,9 +47,7 @@ jobs:
       - uses: actions/cache@v3
         id: restore-build
         with:
-          path: |
-            ./dist
-            ./node_modules
+          path: ./dist
           key: ${{ github.sha }}
         # Set `ignore-scripts` to skip `prepublishOnly` because the release was built already in the previous job
       - run: npm config set ignore-scripts true
@@ -72,9 +68,7 @@ jobs:
       - uses: actions/cache@v3
         id: restore-build
         with:
-          path: |
-            ./dist
-            ./node_modules
+          path: ./dist
           key: ${{ github.sha }}
         # Set `ignore-scripts` to skip `prepublishOnly` because the release was built already in the previous job
       - run: npm config set ignore-scripts true

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' '!.yarnrc.yml' --ignore-path .gitignore",
-    "prepack": "yarn build",
+    "prepack": "./scripts/prepack.sh",
     "setup": "yarn install",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/scripts/check-version.sh
+++ b/scripts/check-version.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+set -o pipefail
+
+BEFORE="${1}"
+
+if [[ -z $BEFORE ]]; then
+  echo "Error: Before SHA not specified."
+  exit 1
+fi
+
+VERSION_BEFORE="$(git show "$BEFORE":package.json | jq --raw-output .version)"
+VERSION_AFTER="$(jq --raw-output .version package.json)"
+if [[ "$VERSION_BEFORE" == "$VERSION_AFTER" ]]; then
+  echo "Notice: version unchanged. Skipping release."
+  exit 1
+fi

--- a/scripts/prepack.sh
+++ b/scripts/prepack.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+set -o pipefail
+
+if [[ -n $SKIP_PREPACK ]]; then
+  echo "Notice: skipping prepack."
+  exit 0
+fi
+
+yarn build


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

This introduces some changes to our publishing configuration such that we release from `main` instead of `release/*` branches

<strike>I'm opening this as a WIP Draft PR because this relies on: https://github.com/MetaMask/action-publish-release/pull/46 and a release of it.</strike>

(that's been addressed now and this is fully ready)

I've created a script for `prepack` that can be skipped in CI via `SKIP_PREPACK` environment variable. this is because we don't want a new build in CI prior to publish, we just want to pick up the cache from the previous build. <strike>I still needed to cache `node_modules` because yarn now complains about the state file and it'll halt you from running any yarn scripts if that's not in order (even if we're not using those files for the actual deployment).</strike> I'm also not happy about the early exit code I've added here. Ideally, I'd like to see if the version has incremented in the filter and then skip if it hasn't, but I don't believe that's possible

- FIXED:

  - #858 

**Issue**

Resolves #858 
