### PR TITLE
Making preventPollingOnNetworkRestart optional in TokenListController

### DIFF
--- a/src/assets/TokenListController.test.ts
+++ b/src/assets/TokenListController.test.ts
@@ -565,6 +565,23 @@ describe('TokenListController', () => {
     controller.destroy();
   });
 
+  it('should set initiate without preventPollingOnNetworkRestart', async () => {
+    const messenger = getRestrictedMessenger();
+    const controller = new TokenListController({
+      chainId: NetworksChainId.mainnet,
+      onNetworkStateChange: (listener) => network.subscribe(listener),
+      messenger,
+    });
+
+    expect(controller.state).toStrictEqual({
+      tokenList: {},
+      tokensChainsCache: {},
+      preventPollingOnNetworkRestart: false,
+    });
+
+    controller.destroy();
+  });
+
   it('should not poll before being started', async () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -111,7 +111,7 @@ export class TokenListController extends BaseController<
     state,
   }: {
     chainId: string;
-    preventPollingOnNetworkRestart: boolean;
+    preventPollingOnNetworkRestart?: boolean;
     onNetworkStateChange: (
       listener: (networkState: NetworkState) => void,
     ) => void;


### PR DESCRIPTION
preventPollingOnNetworkRestart property is introduced in [#861](https://github.com/MetaMask/controllers/pull/861) to prevent the third party token list fetch in extension during network restart. This property should be optional as this is extension-specific and can be avoided on mobile.