### PR TITLE
check release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,6 +10,8 @@ jobs:
       contents: write
     # release merge commits come from GitHub user
     if: github.event.head_commit.committer.name == 'GitHub'
+    outputs:
+      IS_RELEASE: ${{ steps.check-release.outputs.IS_RELEASE }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -18,20 +20,29 @@ jobs:
           # we need this commit + the last so we can compare below
           fetch-depth: 2
       # exit early if the version has not changed
-      - run: ./scripts/check-version.sh ${{ github.event.before }}
+      - name: Check Release
+        id: check-release
+        run: ./scripts/check-release.sh ${{ github.event.before }}
       - name: Get Node.js version
+        if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
         id: nvm
         run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-      - uses: actions/setup-node@v2
+      - name: Setup Node
+        if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - uses: MetaMask/action-publish-release@v2.0.0
+        if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: |
+      - name: Install
+        if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
+        run: |
           yarn install
           yarn build
       - uses: actions/cache@v3
+        if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
         id: restore-build
         with:
           path: ./dist
@@ -40,6 +51,7 @@ jobs:
   publish-npm-dry-run:
     runs-on: ubuntu-latest
     needs: publish-release
+    if: ${{ needs.publish-release.outputs.IS_RELEASE == 'true' }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -61,6 +73,7 @@ jobs:
     environment: npm-publish
     runs-on: ubuntu-latest
     needs: publish-npm-dry-run
+    if: ${{ needs.publish-release.outputs.IS_RELEASE == 'true' }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/scripts/check-release.sh
+++ b/scripts/check-release.sh
@@ -15,5 +15,8 @@ VERSION_BEFORE="$(git show "$BEFORE":package.json | jq --raw-output .version)"
 VERSION_AFTER="$(jq --raw-output .version package.json)"
 if [[ "$VERSION_BEFORE" == "$VERSION_AFTER" ]]; then
   echo "Notice: version unchanged. Skipping release."
-  exit 1
+  echo "::set-output name=IS_RELEASE::false"
+  exit 0
 fi
+ 
+echo "::set-output name=IS_RELEASE::true"


### PR DESCRIPTION
Previously in #863 we were calling `exit 1` which meant that the job would fail for that edge case

instead of doing that we set an output `IS_RELEASE` and check that instead. If it's set to `'false'` we skip all further steps/jobs:

example: https://github.com/rickycodes/controllers/actions/runs/2651728968

if it's set to `'true'` we continue with the release:

example: https://github.com/rickycodes/controllers/actions/runs/2651693157 (keep in mind the last step is only "failing" because the `NPM_TOKEN` set in that environment is invalid).