### PR TITLE
turn check-release step into job

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,9 +5,7 @@ on:
     branches: [main]
 
 jobs:
-  publish-release:
-    permissions:
-      contents: write
+  check-release:
     # release merge commits come from GitHub user
     if: github.event.head_commit.committer.name == 'GitHub'
     outputs:
@@ -23,26 +21,32 @@ jobs:
       - name: Check Release
         id: check-release
         run: ./scripts/check-release.sh ${{ github.event.before }}
+
+  publish-release:
+    permissions:
+      contents: write
+    if: needs.check-release.outputs.IS_RELEASE == 'true'
+    runs-on: ubuntu-latest
+    needs: check-release
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.sha }}
       - name: Get Node.js version
-        if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
         id: nvm
         run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
       - name: Setup Node
-        if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
         uses: actions/setup-node@v2
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - uses: MetaMask/action-publish-release@v2.0.0
-        if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install
-        if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
         run: |
           yarn install
           yarn build
       - uses: actions/cache@v3
-        if: ${{ steps.check-release.outputs.IS_RELEASE == 'true' }}
         id: restore-build
         with:
           path: ./dist
@@ -51,7 +55,6 @@ jobs:
   publish-npm-dry-run:
     runs-on: ubuntu-latest
     needs: publish-release
-    if: ${{ needs.publish-release.outputs.IS_RELEASE == 'true' }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -73,7 +76,6 @@ jobs:
     environment: npm-publish
     runs-on: ubuntu-latest
     needs: publish-npm-dry-run
-    if: ${{ needs.publish-release.outputs.IS_RELEASE == 'true' }}
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
in #873 I added several filters to steps and @mcmire had some feedback:

> I wish we could only check for IS_RELEASE == 'true' a few times

so I thought on it and realised that the `check-release` _step_ could instead be a _job_ and the following jobs would rely on it.

This removes the need for so many `if:` filters

example of a skip: https://github.com/rickycodes/controllers/actions/runs/2657273697 (again this should only happen if the GitHub actions bot should do something _other_ than release... which hasn't happened in this repository... _yet_).

example of release: https://github.com/rickycodes/controllers/actions/runs/2657220356 (again, last publish job is failing because the `NPM_TOKEN` is not correctly set in that environment).