### PR TITLE
Support caveats on endowment permissions

### DIFF
--- a/src/permissions/Caveat.test.ts
+++ b/src/permissions/Caveat.test.ts
@@ -133,4 +133,32 @@ describe('decorateWithCaveats', () => {
       }),
     ).toThrow(new errors.UnrecognizedCaveatTypeError('kaplar'));
   });
+
+  it('throws an error if no decorator is present', async () => {
+    const methodImplementation = () => [1, 2, 3];
+
+    const caveatSpecifications = {
+      reverse: {
+        type: 'reverse',
+      },
+    };
+
+    const permission: PermissionConstraint = {
+      id: 'foo',
+      parentCapability: 'arbitraryMethod',
+      invoker: 'arbitraryInvoker',
+      date: Date.now(),
+      caveats: [{ type: 'reverse', value: null }],
+    };
+
+    expect(() =>
+      decorateWithCaveats(
+        methodImplementation,
+        permission,
+        caveatSpecifications,
+      ),
+    ).toThrow(
+      new errors.CaveatSpecificationMismatch(caveatSpecifications.reverse),
+    );
+  });
 });

--- a/src/permissions/Caveat.test.ts
+++ b/src/permissions/Caveat.test.ts
@@ -158,7 +158,7 @@ describe('decorateWithCaveats', () => {
         caveatSpecifications,
       ),
     ).toThrow(
-      new errors.CaveatSpecificationMismatch(caveatSpecifications.reverse),
+      new errors.CaveatSpecificationMismatchError(caveatSpecifications.reverse),
     );
   });
 });

--- a/src/permissions/Caveat.test.ts
+++ b/src/permissions/Caveat.test.ts
@@ -1,5 +1,5 @@
 import * as errors from './errors';
-import { decorateWithCaveats, PermissionConstraint } from '.';
+import { decorateWithCaveats, PermissionConstraint, PermissionType } from '.';
 
 describe('decorateWithCaveats', () => {
   it('decorates a method with caveat', async () => {
@@ -158,7 +158,10 @@ describe('decorateWithCaveats', () => {
         caveatSpecifications,
       ),
     ).toThrow(
-      new errors.CaveatSpecificationMismatchError(caveatSpecifications.reverse),
+      new errors.CaveatSpecificationMismatchError(
+        caveatSpecifications.reverse,
+        PermissionType.RestrictedMethod,
+      ),
     );
   });
 });

--- a/src/permissions/Caveat.ts
+++ b/src/permissions/Caveat.ts
@@ -136,8 +136,8 @@ export type EndowmentCaveatSpecificationConstraint = CaveatSpecificationBase;
  * supported by a {@link PermissionController} must have an associated
  * specification, which is the source of truth for all caveat-related types.
  * In addition, a caveat specification may include a decorator function used
- * to apply the caveat's attenuation to a restricted method. It may also include a validator
- * function specified by the consumer.
+ * to apply the caveat's attenuation to a restricted method. It may also include
+ * a validator function specified by the consumer.
  *
  * See the README for more details.
  */

--- a/src/permissions/Caveat.ts
+++ b/src/permissions/Caveat.ts
@@ -76,15 +76,16 @@ export type CaveatDecorator<ParentCaveat extends CaveatConstraint> = (
  * @template Decorator - The {@link CaveatDecorator} to extract a caveat value
  * type from.
  */
-type ExtractCaveatValueFromDecorator<Decorator extends CaveatDecorator<any>> =
-  Decorator extends (
-    decorated: any,
-    caveat: infer ParentCaveat,
-  ) => AsyncRestrictedMethod<any, any>
-    ? ParentCaveat extends CaveatConstraint
-      ? ParentCaveat['value']
-      : never
-    : never;
+type ExtractCaveatValueFromDecorator<
+  Decorator extends CaveatDecorator<any> | undefined,
+> = Decorator extends (
+  decorated: any,
+  caveat: infer ParentCaveat,
+) => AsyncRestrictedMethod<any, any>
+  ? ParentCaveat extends CaveatConstraint
+    ? ParentCaveat['value']
+    : never
+  : never;
 
 /**
  * A function for validating caveats of a particular type.
@@ -120,7 +121,7 @@ export type CaveatSpecificationConstraint = {
    * The decorator function used to apply the caveat to restricted method
    * requests.
    */
-  decorator: CaveatDecorator<any>;
+  decorator?: CaveatDecorator<any>;
 
   /**
    * The validator function used to validate caveats of the associated type
@@ -256,7 +257,9 @@ export function decorateWithCaveats<
       throw new UnrecognizedCaveatTypeError(caveat.type);
     }
 
-    decorated = specification.decorator(decorated, caveat);
+    if (specification.decorator) {
+      decorated = specification.decorator(decorated, caveat);
+    }
   }
 
   return decorated;

--- a/src/permissions/Caveat.ts
+++ b/src/permissions/Caveat.ts
@@ -202,10 +202,14 @@ export type CaveatSpecificationMap<
 export type ExtractCaveats<
   CaveatSpecification extends CaveatSpecificationConstraint,
 > = CaveatSpecification extends any
-  ? Caveat<
-      CaveatSpecification['type'],
-      ExtractCaveatValueFromDecorator<CaveatSpecification['decorator']>
-    >
+  ? CaveatSpecification extends RestrictedMethodCaveatSpecificationConstraint
+    ? Caveat<
+        CaveatSpecification['type'],
+        ExtractCaveatValueFromDecorator<
+          RestrictedMethodCaveatSpecificationConstraint['decorator']
+        >
+      >
+    : Caveat<CaveatSpecification['type'], Json>
   : never;
 
 /**

--- a/src/permissions/Caveat.ts
+++ b/src/permissions/Caveat.ts
@@ -135,8 +135,8 @@ export type EndowmentCaveatSpecificationConstraint = CaveatSpecificationBase;
  * The constraint for caveat specification objects. Every {@link Caveat}
  * supported by a {@link PermissionController} must have an associated
  * specification, which is the source of truth for all caveat-related types.
- * In addition, a caveat specification includes the decorator function used
- * to apply the caveat's attenuation to a restricted method, and any validator
+ * In addition, a caveat specification may include a decorator function used
+ * to apply the caveat's attenuation to a restricted method. It may also include a validator
  * function specified by the consumer.
  *
  * See the README for more details.

--- a/src/permissions/Caveat.ts
+++ b/src/permissions/Caveat.ts
@@ -76,16 +76,15 @@ export type CaveatDecorator<ParentCaveat extends CaveatConstraint> = (
  * @template Decorator - The {@link CaveatDecorator} to extract a caveat value
  * type from.
  */
-type ExtractCaveatValueFromDecorator<
-  Decorator extends CaveatDecorator<any> | undefined,
-> = Decorator extends (
-  decorated: any,
-  caveat: infer ParentCaveat,
-) => AsyncRestrictedMethod<any, any>
-  ? ParentCaveat extends CaveatConstraint
-    ? ParentCaveat['value']
-    : never
-  : never;
+type ExtractCaveatValueFromDecorator<Decorator extends CaveatDecorator<any>> =
+  Decorator extends (
+    decorated: any,
+    caveat: infer ParentCaveat,
+  ) => AsyncRestrictedMethod<any, any>
+    ? ParentCaveat extends CaveatConstraint
+      ? ParentCaveat['value']
+      : never
+    : never;
 
 /**
  * A function for validating caveats of a particular type.

--- a/src/permissions/Caveat.ts
+++ b/src/permissions/Caveat.ts
@@ -1,5 +1,9 @@
 import { Json } from '@metamask/types';
-import { UnrecognizedCaveatTypeError } from './errors';
+import { hasProperty } from '../util';
+import {
+  CaveatSpecificationMismatch,
+  UnrecognizedCaveatTypeError,
+} from './errors';
 import {
   AsyncRestrictedMethod,
   RestrictedMethod,
@@ -236,15 +240,15 @@ export type ExtractCaveatValue<
 > = ExtractCaveat<CaveatSpecifications, CaveatType>['value'];
 
 /**
- * Determines whether a caveat specification has a decorator.
+ * Determines whether a caveat specification is a restricted method caveat specification.
  *
  * @param specification - The caveat specification.
- * @returns True if the caveat specification has a decorator, otherwise false.
+ * @returns True if the caveat specification is a restricted method caveat specification, otherwise false.
  */
-export function hasDecorator(
+export function isRestrictedMethodCaveatSpecification(
   specification: CaveatSpecificationConstraint,
 ): specification is RestrictedMethodCaveatSpecificationConstraint {
-  return 'decorator' in specification;
+  return hasProperty(specification, 'decorator');
 }
 
 /**
@@ -281,8 +285,10 @@ export function decorateWithCaveats<
       throw new UnrecognizedCaveatTypeError(caveat.type);
     }
 
-    if (hasDecorator(specification)) {
+    if (isRestrictedMethodCaveatSpecification(specification)) {
       decorated = specification.decorator(decorated, caveat);
+    } else {
+      throw new CaveatSpecificationMismatch(caveat);
     }
   }
 

--- a/src/permissions/Caveat.ts
+++ b/src/permissions/Caveat.ts
@@ -285,11 +285,10 @@ export function decorateWithCaveats<
       throw new UnrecognizedCaveatTypeError(caveat.type);
     }
 
-    if (isRestrictedMethodCaveatSpecification(specification)) {
-      decorated = specification.decorator(decorated, caveat);
-    } else {
+    if (!isRestrictedMethodCaveatSpecification(specification)) {
       throw new CaveatSpecificationMismatch(caveat);
     }
+    decorated = specification.decorator(decorated, caveat);
   }
 
   return decorated;

--- a/src/permissions/Caveat.ts
+++ b/src/permissions/Caveat.ts
@@ -9,6 +9,7 @@ import {
   RestrictedMethod,
   PermissionConstraint,
   RestrictedMethodParameters,
+  PermissionType,
 } from './Permission';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { PermissionController } from './PermissionController';
@@ -286,7 +287,10 @@ export function decorateWithCaveats<
     }
 
     if (!isRestrictedMethodCaveatSpecification(specification)) {
-      throw new CaveatSpecificationMismatchError(caveat);
+      throw new CaveatSpecificationMismatchError(
+        specification,
+        PermissionType.RestrictedMethod,
+      );
     }
     decorated = specification.decorator(decorated, caveat);
   }

--- a/src/permissions/Caveat.ts
+++ b/src/permissions/Caveat.ts
@@ -1,7 +1,7 @@
 import { Json } from '@metamask/types';
 import { hasProperty } from '../util';
 import {
-  CaveatSpecificationMismatch,
+  CaveatSpecificationMismatchError,
   UnrecognizedCaveatTypeError,
 } from './errors';
 import {
@@ -286,7 +286,7 @@ export function decorateWithCaveats<
     }
 
     if (!isRestrictedMethodCaveatSpecification(specification)) {
-      throw new CaveatSpecificationMismatch(caveat);
+      throw new CaveatSpecificationMismatchError(caveat);
     }
     decorated = specification.decorator(decorated, caveat);
   }

--- a/src/permissions/Permission.ts
+++ b/src/permissions/Permission.ts
@@ -460,11 +460,6 @@ export type RestrictedMethodSpecificationConstraint =
 export type EndowmentSpecificationConstraint =
   PermissionSpecificationBase<PermissionType.Endowment> & {
     /**
-     * Endowment permissions do not support caveats.
-     */
-    allowedCaveats: null;
-
-    /**
      * The {@link EndowmentGetter} function for the permission. This function
      * will be called by the {@link PermissionController} whenever the
      * permission is invoked, after which the host can apply the endowments to

--- a/src/permissions/PermissionController.test.ts
+++ b/src/permissions/PermissionController.test.ts
@@ -629,6 +629,57 @@ describe('PermissionController', () => {
           ),
       ).toThrow(new errors.UnrecognizedCaveatTypeError('foo'));
     });
+
+    it('throws if a specified caveat has a type mismatch', () => {
+      const defaultCaveats = getDefaultCaveatSpecifications();
+      expect(
+        () =>
+          new PermissionController<
+            DefaultPermissionSpecifications,
+            DefaultCaveatSpecifications
+          >(
+            getPermissionControllerOptions({
+              permissionSpecifications: {
+                ...getDefaultPermissionSpecifications(),
+                foo: {
+                  permissionType: PermissionType.Endowment,
+                  targetKey: 'foo',
+                  allowedCaveats: [defaultCaveats.reverseArrayResponse.type],
+                },
+              },
+            }),
+          ),
+      ).toThrow(
+        new errors.CaveatSpecificationMismatchError(
+          defaultCaveats.reverseArrayResponse,
+          PermissionType.Endowment,
+        ),
+      );
+
+      expect(
+        () =>
+          new PermissionController<
+            DefaultPermissionSpecifications,
+            DefaultCaveatSpecifications
+          >(
+            getPermissionControllerOptions({
+              permissionSpecifications: {
+                ...getDefaultPermissionSpecifications(),
+                foo: {
+                  permissionType: PermissionType.RestrictedMethod,
+                  targetKey: 'foo',
+                  allowedCaveats: [defaultCaveats.endowmentCaveat.type],
+                },
+              },
+            }),
+          ),
+      ).toThrow(
+        new errors.CaveatSpecificationMismatchError(
+          defaultCaveats.endowmentCaveat,
+          PermissionType.RestrictedMethod,
+        ),
+      );
+    });
   });
 
   describe('clearState', () => {

--- a/src/permissions/PermissionController.ts
+++ b/src/permissions/PermissionController.ts
@@ -27,12 +27,14 @@ import {
   ExtractCaveat,
   ExtractCaveats,
   ExtractCaveatValue,
+  isRestrictedMethodCaveatSpecification,
 } from './Caveat';
 import {
   CaveatAlreadyExistsError,
   CaveatDoesNotExistError,
   CaveatInvalidJsonError,
   CaveatMissingValueError,
+  CaveatSpecificationMismatchError,
   DuplicateCaveatError,
   EndowmentPermissionDoesNotExistError,
   ForbiddenCaveatError,
@@ -655,6 +657,25 @@ export class PermissionController<
           allowedCaveats.forEach((caveatType) => {
             if (!hasProperty(caveatSpecifications, caveatType)) {
               throw new UnrecognizedCaveatTypeError(caveatType);
+            }
+
+            const specification =
+              caveatSpecifications[
+                caveatType as ControllerCaveatSpecification['type']
+              ];
+            const isRestrictedMethodCaveat =
+              isRestrictedMethodCaveatSpecification(specification);
+
+            if (
+              (permissionType === PermissionType.RestrictedMethod &&
+                !isRestrictedMethodCaveat) ||
+              (permissionType === PermissionType.Endowment &&
+                isRestrictedMethodCaveat)
+            ) {
+              throw new CaveatSpecificationMismatchError(
+                specification,
+                permissionType,
+              );
             }
           });
         }

--- a/src/permissions/errors.ts
+++ b/src/permissions/errors.ts
@@ -1,4 +1,5 @@
 import { errorCodes, ethErrors, EthereumRpcError } from 'eth-rpc-errors';
+import { PermissionType } from './Permission';
 
 type UnauthorizedArg = {
   data?: Record<string, unknown>;
@@ -280,14 +281,18 @@ export class DuplicateCaveatError extends Error {
 
 export class CaveatSpecificationMismatchError extends Error {
   public data: {
-    caveat: Record<string, unknown>;
+    caveatSpec: Record<string, unknown>;
+    permissionType: PermissionType;
   };
 
-  constructor(caveat: Record<string, unknown>) {
+  constructor(
+    caveatSpec: Record<string, unknown>,
+    permissionType: PermissionType,
+  ) {
     super(
-      'Caveat specification uses a mismatched type. Expected restricted method caveat specification.',
+      `Caveat specification uses a mismatched type. Expected caveats for ${permissionType}`,
     );
-    this.data = { caveat };
+    this.data = { caveatSpec, permissionType };
   }
 }
 

--- a/src/permissions/errors.ts
+++ b/src/permissions/errors.ts
@@ -278,7 +278,7 @@ export class DuplicateCaveatError extends Error {
   }
 }
 
-export class CaveatSpecificationMismatch extends Error {
+export class CaveatSpecificationMismatchError extends Error {
   public data: {
     caveat: Record<string, unknown>;
   };

--- a/src/permissions/errors.ts
+++ b/src/permissions/errors.ts
@@ -278,6 +278,19 @@ export class DuplicateCaveatError extends Error {
   }
 }
 
+export class CaveatSpecificationMismatch extends Error {
+  public data: {
+    caveat: Record<string, unknown>;
+  };
+
+  constructor(caveat: Record<string, unknown>) {
+    super(
+      'Caveat specification uses a mismatched type. Expected restricted method caveat specification.',
+    );
+    this.data = { caveat };
+  }
+}
+
 export class PermissionsRequestNotFoundError extends Error {
   constructor(id: string) {
     super(`Permissions request with id "${id}" not found.`);


### PR DESCRIPTION
This PR adds caveat support for endowment permissions, see the linked issue for why this is needed now. This is mainly a typing change, but adds a small defensive validation measure to prevent type mismatches.


**Description**

_Itemize the changes you have made into the categories below_

- CHANGED:
  - Allowed endowment permissions to specify caveats


**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented

**Issue**

Resolves #877 
