### PR TITLE
update `is-release` filter

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,8 +6,8 @@ on:
 
 jobs:
   is-release:
-    # release merge commits come from GitHub user
-    if: github.event.head_commit.committer.name == 'GitHub'
+    # release merge commits come from github-actions[bot]
+    if: github.event.commits[0].author.name == 'github-actions[bot]'
     outputs:
       IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently this filter will apply to _any_ gh merge. This wasn't quite what was intended.

This will ensure that the entire workflow run in skipped vs only the jobs after `is-release`. 

I've tested this in my fork here: https://github.com/rickycodes/controllers/actions/runs/2834082496