### PR TITLE
Exporting formatIconUrlWithProxy to format iconUrl Proxy for tokens from swaps api

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,5 +40,4 @@ export * from './permissions';
 export * from './subject-metadata';
 export * from './ratelimit/RateLimitController';
 export * from './notification/NotificationController';
-export { util };
-export { formatIconUrlWithProxy };
+export { util, formatIconUrlWithProxy };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import 'isomorphic-fetch';
 import * as util from './util';
+import { formatIconUrlWithProxy } from './assets/assetsUtil';
 
 export * from './assets/AccountTrackerController';
 export * from './user/AddressBookController';
@@ -40,3 +41,4 @@ export * from './subject-metadata';
 export * from './ratelimit/RateLimitController';
 export * from './notification/NotificationController';
 export { util };
+export { formatIconUrlWithProxy };


### PR DESCRIPTION
We need to use `formatIconUrlWithProxy` in extension for formating the token iconURL to proxy for the tokens from swap API. Since the extension is currently using a static token list for the scenario when token detection is OFF on MAINNET, we cannot use the proxy iconUrl from the dynamic token list as the default one for swap.