### PR TITLE
Update `is-release` filter

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,8 +6,8 @@ on:
 
 jobs:
   is-release:
-    # release merge commits come from github-actions[bot]
-    if: github.event.commits[0].author.name == 'github-actions[bot]'
+    # release merge commits come from github-actions
+    if: startsWith(github.event.commits[0].author.name, 'github-actions')
     outputs:
       IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Slight update to the filter to ensure it also meets criteria in the off chance the release PR is merged without squash.