### PR TITLE
Phishing controller test method should be async and it should not poll

### DIFF
--- a/src/third-party/PhishingController.test.ts
+++ b/src/third-party/PhishingController.test.ts
@@ -352,7 +352,7 @@ describe('PhishingController', () => {
       true,
       'Example unsafe domain seems to be safe',
     );
-    await controller.bypass(unsafeDomain);
+    controller.bypass(unsafeDomain);
     expect(
       await controller.test(unsafeDomain),
     ).toMatchObject<EthPhishingDetectResult>({
@@ -369,8 +369,8 @@ describe('PhishingController', () => {
       true,
       'Example unsafe domain seems to be safe',
     );
-    await controller.bypass(unsafeDomain);
-    await controller.bypass(unsafeDomain);
+    controller.bypass(unsafeDomain);
+    controller.bypass(unsafeDomain);
     expect(
       await controller.test(unsafeDomain),
     ).toMatchObject<EthPhishingDetectResult>({
@@ -387,7 +387,7 @@ describe('PhishingController', () => {
       true,
       'Example unsafe domain seems to be safe',
     );
-    await controller.bypass(unsafeDomain);
+    controller.bypass(unsafeDomain);
     expect(
       await controller.test(unsafeDomain),
     ).toMatchObject<EthPhishingDetectResult>({
@@ -404,7 +404,7 @@ describe('PhishingController', () => {
       true,
       'Example unsafe domain seems to be safe',
     );
-    await controller.bypass(unsafeDomain);
+    controller.bypass(unsafeDomain);
     expect(
       await controller.test(unsafeDomain),
     ).toMatchObject<EthPhishingDetectResult>({

--- a/src/third-party/PhishingController.test.ts
+++ b/src/third-party/PhishingController.test.ts
@@ -26,35 +26,69 @@ describe('PhishingController', () => {
 
   it('should set default config', () => {
     const controller = new PhishingController();
-    expect(controller.config).toStrictEqual({ interval: 3_600_000 });
+    expect(controller.config).toStrictEqual({ refreshInterval: 3600000 });
   });
 
-  it('should poll and update rate in the right interval', async () => {
-    await new Promise<void>((resolve) => {
-      const mock = sinon.stub(
-        PhishingController.prototype,
-        'updatePhishingLists',
-      );
-      new PhishingController({ interval: 10 });
-      expect(mock.called).toBe(true);
-      expect(mock.calledTwice).toBe(false);
-      setTimeout(() => {
-        expect(mock.calledTwice).toBe(true);
-        resolve();
-      }, 15);
-    });
+  it('does not fetch or do anything async upon construction', async () => {
+    const mock = sinon.stub(
+      PhishingController.prototype,
+      'updatePhishingLists',
+    );
+    new PhishingController({});
+    expect(mock.called).toBe(false);
   });
 
-  it('should clear previous interval', async () => {
-    const mock = sinon.stub(global, 'clearTimeout');
-    const controller = new PhishingController({ interval: 1337 });
-    await new Promise<void>((resolve) => {
-      setTimeout(() => {
-        controller.poll(1338);
-        expect(mock.called).toBe(true);
-        resolve();
-      }, 100);
-    });
+  it('fetches the first time test is used', async () => {
+    const mock = sinon.stub(
+      PhishingController.prototype,
+      'updatePhishingLists',
+    );
+    const ctrl = new PhishingController({});
+    expect(mock.called).toBe(false);
+    await ctrl.test('metamask.io');
+    expect(mock.called).toBe(true);
+  });
+
+  it('does not fetch the second time test is used in shorter time than the refreshInterval', async () => {
+    const mock = sinon.stub(
+      PhishingController.prototype,
+      'updatePhishingLists',
+    );
+    const ctrl = new PhishingController({});
+    expect(mock.callCount).toBe(0);
+    await ctrl.test('metamask.io');
+    expect(mock.callCount).toBe(1);
+    await ctrl.test('metamask.io');
+    expect(mock.callCount).toBe(1);
+  });
+
+  it('fetch the second time test is used in longer time than the refreshInterval', async () => {
+    const mock = sinon.stub(
+      PhishingController.prototype,
+      'updatePhishingLists',
+    );
+    const ctrl = new PhishingController({});
+    expect(mock.callCount).toBe(0);
+    await ctrl.test('metamask.io');
+    expect(mock.callCount).toBe(1);
+    ctrl.lastFetched = 1;
+    await ctrl.test('metamask.io');
+    expect(mock.callCount).toBe(2);
+  });
+
+  it('should be able to change the refreshInterval', async () => {
+    const mock = sinon.stub(
+      PhishingController.prototype,
+      'updatePhishingLists',
+    );
+    const ctrl = new PhishingController({});
+    ctrl.setRefreshInterval(0);
+
+    await ctrl.test('metamask.io');
+    await ctrl.test('metamask.io');
+    await ctrl.test('metamask.io');
+
+    expect(mock.callCount).toBe(3);
   });
 
   it('should update lists', async () => {
@@ -85,16 +119,16 @@ describe('PhishingController', () => {
       .persist();
     const controller = new PhishingController({
       disabled: true,
-      interval: 10,
+      refreshInterval: 10,
     });
 
     expect(async () => await controller.updatePhishingLists()).not.toThrow();
   });
 
-  it('should return negative result for safe domain from default config', () => {
+  it('should return negative result for safe domain from default config', async () => {
     const controller = new PhishingController();
     expect(
-      controller.test('metamask.io'),
+      await controller.test('metamask.io'),
     ).toMatchObject<EthPhishingDetectResult>({
       result: false,
       type: 'allowlist',
@@ -102,28 +136,30 @@ describe('PhishingController', () => {
     });
   });
 
-  it('should return negative result for safe unicode domain from default config', () => {
-    const controller = new PhishingController();
-    expect(controller.test('i❤.ws')).toMatchObject<EthPhishingDetectResult>({
-      result: false,
-      type: 'all',
-    });
-  });
-
-  it('should return negative result for safe punycode domain from default config', () => {
+  it('should return negative result for safe unicode domain from default config', async () => {
     const controller = new PhishingController();
     expect(
-      controller.test('xn--i-7iq.ws'),
+      await controller.test('i❤.ws'),
     ).toMatchObject<EthPhishingDetectResult>({
       result: false,
       type: 'all',
     });
   });
 
-  it('should return positive result for unsafe domain from default config', () => {
+  it('should return negative result for safe punycode domain from default config', async () => {
     const controller = new PhishingController();
     expect(
-      controller.test('etnerscan.io'),
+      await controller.test('xn--i-7iq.ws'),
+    ).toMatchObject<EthPhishingDetectResult>({
+      result: false,
+      type: 'all',
+    });
+  });
+
+  it('should return positive result for unsafe domain from default config', async () => {
+    const controller = new PhishingController();
+    expect(
+      await controller.test('etnerscan.io'),
     ).toMatchObject<EthPhishingDetectResult>({
       result: true,
       type: 'blocklist',
@@ -131,10 +167,10 @@ describe('PhishingController', () => {
     });
   });
 
-  it('should return positive result for unsafe unicode domain from default config', () => {
+  it('should return positive result for unsafe unicode domain from default config', async () => {
     const controller = new PhishingController();
     expect(
-      controller.test('myetherẉalletṭ.com'),
+      await controller.test('myetherẉalletṭ.com'),
     ).toMatchObject<EthPhishingDetectResult>({
       result: true,
       type: 'blocklist',
@@ -142,10 +178,10 @@ describe('PhishingController', () => {
     });
   });
 
-  it('should return positive result for unsafe punycode domain from default config', () => {
+  it('should return positive result for unsafe punycode domain from default config', async () => {
     const controller = new PhishingController();
     expect(
-      controller.test('xn--myetherallet-4k5fwn.com'),
+      await controller.test('xn--myetherallet-4k5fwn.com'),
     ).toMatchObject<EthPhishingDetectResult>({
       result: true,
       type: 'blocklist',
@@ -157,7 +193,7 @@ describe('PhishingController', () => {
     const controller = new PhishingController();
     await controller.updatePhishingLists();
     expect(
-      controller.test('metamask.io'),
+      await controller.test('metamask.io'),
     ).toMatchObject<EthPhishingDetectResult>({
       result: false,
       type: 'allowlist',
@@ -168,7 +204,9 @@ describe('PhishingController', () => {
   it('should return negative result for safe unicode domain from MetaMask config', async () => {
     const controller = new PhishingController();
     await controller.updatePhishingLists();
-    expect(controller.test('i❤.ws')).toMatchObject<EthPhishingDetectResult>({
+    expect(
+      await controller.test('i❤.ws'),
+    ).toMatchObject<EthPhishingDetectResult>({
       result: false,
       type: 'all',
     });
@@ -178,7 +216,7 @@ describe('PhishingController', () => {
     const controller = new PhishingController();
     await controller.updatePhishingLists();
     expect(
-      controller.test('xn--i-7iq.ws'),
+      await controller.test('xn--i-7iq.ws'),
     ).toMatchObject<EthPhishingDetectResult>({
       result: false,
       type: 'all',
@@ -189,7 +227,7 @@ describe('PhishingController', () => {
     const controller = new PhishingController();
     await controller.updatePhishingLists();
     expect(
-      controller.test('etnerscan.io'),
+      await controller.test('etnerscan.io'),
     ).toMatchObject<EthPhishingDetectResult>({
       result: true,
       type: 'blocklist',
@@ -201,7 +239,7 @@ describe('PhishingController', () => {
     const controller = new PhishingController();
     await controller.updatePhishingLists();
     expect(
-      controller.test('myetherẉalletṭ.com'),
+      await controller.test('myetherẉalletṭ.com'),
     ).toMatchObject<EthPhishingDetectResult>({
       result: true,
       type: 'blocklist',
@@ -217,7 +255,7 @@ describe('PhishingController', () => {
     const controller = new PhishingController();
     await controller.updatePhishingLists();
     expect(
-      controller.test('myetherẉalletṭ.com'),
+      await controller.test('myetherẉalletṭ.com'),
     ).toMatchObject<EthPhishingDetectResult>({
       result: false,
       type: 'all',
@@ -228,7 +266,7 @@ describe('PhishingController', () => {
     const controller = new PhishingController();
     await controller.updatePhishingLists();
     expect(
-      controller.test('xn--myetherallet-4k5fwn.com'),
+      await controller.test('xn--myetherallet-4k5fwn.com'),
     ).toMatchObject<EthPhishingDetectResult>({
       result: true,
       type: 'blocklist',
@@ -240,7 +278,7 @@ describe('PhishingController', () => {
     const controller = new PhishingController();
     await controller.updatePhishingLists();
     expect(
-      controller.test('e4d600ab9141b7a9859511c77e63b9b3.com'),
+      await controller.test('e4d600ab9141b7a9859511c77e63b9b3.com'),
     ).toMatchObject<EthPhishingDetectResult>({
       result: true,
       type: 'blocklist',
@@ -256,7 +294,7 @@ describe('PhishingController', () => {
     const controller = new PhishingController();
     await controller.updatePhishingLists();
     expect(
-      controller.test('e4d600ab9141b7a9859511c77e63b9b3.com'),
+      await controller.test('e4d600ab9141b7a9859511c77e63b9b3.com'),
     ).toMatchObject<EthPhishingDetectResult>({
       result: false,
       type: 'all',
@@ -267,7 +305,7 @@ describe('PhishingController', () => {
     const controller = new PhishingController();
     await controller.updatePhishingLists();
     expect(
-      controller.test('opensea.io'),
+      await controller.test('opensea.io'),
     ).toMatchObject<EthPhishingDetectResult>({
       result: false,
       type: 'allowlist',
@@ -279,7 +317,7 @@ describe('PhishingController', () => {
     const controller = new PhishingController();
     await controller.updatePhishingLists();
     expect(
-      controller.test('ohpensea.io'),
+      await controller.test('ohpensea.io'),
     ).toMatchObject<EthPhishingDetectResult>({
       result: true,
       type: 'fuzzy',
@@ -296,7 +334,7 @@ describe('PhishingController', () => {
     const controller = new PhishingController();
     await controller.updatePhishingLists();
     expect(
-      controller.test('ohpensea.io'),
+      await controller.test('ohpensea.io'),
     ).toMatchObject<EthPhishingDetectResult>({
       result: false,
       type: 'all',
@@ -307,76 +345,76 @@ describe('PhishingController', () => {
     const controller = new PhishingController();
     await controller.updatePhishingLists();
     expect(
-      controller.test('this-is-the-official-website-of-opensea.io'),
+      await controller.test('this-is-the-official-website-of-opensea.io'),
     ).toMatchObject<EthPhishingDetectResult>({
       result: false,
       type: 'all',
     });
   });
 
-  it('should bypass a given domain, and return a negative result', () => {
+  it('should bypass a given domain, and return a negative result', async () => {
     const controller = new PhishingController();
     const unsafeDomain = 'electrum.mx';
     assert.equal(
-      controller.test(unsafeDomain).result,
+      (await controller.test(unsafeDomain)).result,
       true,
       'Example unsafe domain seems to be safe',
     );
-    controller.bypass(unsafeDomain);
+    await controller.bypass(unsafeDomain);
     expect(
-      controller.test(unsafeDomain),
+      await controller.test(unsafeDomain),
     ).toMatchObject<EthPhishingDetectResult>({
       result: false,
       type: 'all',
     });
   });
 
-  it('should ignore second attempt to bypass a domain, and still return a negative result', () => {
+  it('should ignore second attempt to bypass a domain, and still return a negative result', async () => {
     const controller = new PhishingController();
     const unsafeDomain = 'electrum.mx';
     assert.equal(
-      controller.test(unsafeDomain).result,
+      (await controller.test(unsafeDomain)).result,
       true,
       'Example unsafe domain seems to be safe',
     );
-    controller.bypass(unsafeDomain);
-    controller.bypass(unsafeDomain);
+    await controller.bypass(unsafeDomain);
+    await controller.bypass(unsafeDomain);
     expect(
-      controller.test(unsafeDomain),
+      await controller.test(unsafeDomain),
     ).toMatchObject<EthPhishingDetectResult>({
       result: false,
       type: 'all',
     });
   });
 
-  it('should bypass a given unicode domain, and return a negative result', () => {
+  it('should bypass a given unicode domain, and return a negative result', async () => {
     const controller = new PhishingController();
     const unsafeDomain = 'myetherẉalletṭ.com';
     assert.equal(
-      controller.test(unsafeDomain).result,
+      (await controller.test(unsafeDomain)).result,
       true,
       'Example unsafe domain seems to be safe',
     );
-    controller.bypass(unsafeDomain);
+    await controller.bypass(unsafeDomain);
     expect(
-      controller.test(unsafeDomain),
+      await controller.test(unsafeDomain),
     ).toMatchObject<EthPhishingDetectResult>({
       result: false,
       type: 'all',
     });
   });
 
-  it('should bypass a given punycode domain, and return a negative result', () => {
+  it('should bypass a given punycode domain, and return a negative result', async () => {
     const controller = new PhishingController();
     const unsafeDomain = 'xn--myetherallet-4k5fwn.com';
     assert.equal(
-      controller.test(unsafeDomain).result,
+      (await controller.test(unsafeDomain)).result,
       true,
       'Example unsafe domain seems to be safe',
     );
-    controller.bypass(unsafeDomain);
+    await controller.bypass(unsafeDomain);
     expect(
-      controller.test(unsafeDomain),
+      await controller.test(unsafeDomain),
     ).toMatchObject<EthPhishingDetectResult>({
       result: false,
       type: 'all',

--- a/src/third-party/PhishingController.test.ts
+++ b/src/third-party/PhishingController.test.ts
@@ -30,20 +30,14 @@ describe('PhishingController', () => {
   });
 
   it('does not call updatePhishingList upon construction', async () => {
-    const mock = sinon.spy(
-      PhishingController.prototype,
-      'updatePhishingLists',
-    );
+    const mock = sinon.spy(PhishingController.prototype, 'updatePhishingLists');
     new PhishingController({});
     expect(mock.called).toBe(false);
     mock.restore();
   });
 
   it('fetches the first time test is used', async () => {
-    const mock = sinon.spy(
-      PhishingController.prototype,
-      'updatePhishingLists',
-    );
+    const mock = sinon.spy(PhishingController.prototype, 'updatePhishingLists');
     const controller = new PhishingController({});
     expect(mock.called).toBe(false);
     await controller.test('metamask.io');
@@ -52,10 +46,7 @@ describe('PhishingController', () => {
   });
 
   it('does not call fetch twice if the second call is inside of the refreshInterval', async () => {
-    const mock = sinon.spy(
-      PhishingController.prototype,
-      'updatePhishingLists',
-    );
+    const mock = sinon.spy(PhishingController.prototype, 'updatePhishingLists');
     const controller = new PhishingController({});
     expect(mock.callCount).toBe(0);
     await controller.test('metamask.io');
@@ -67,11 +58,8 @@ describe('PhishingController', () => {
 
   it('should call fetch twice if the second call is outside the refreshInterval', async () => {
     const clock = sinon.useFakeTimers(Date.now());
-    const mock = sinon.spy(
-      PhishingController.prototype,
-      'updatePhishingLists',
-    );
-    const controller = new PhishingController({refreshInterval: 1});
+    const mock = sinon.spy(PhishingController.prototype, 'updatePhishingLists');
+    const controller = new PhishingController({ refreshInterval: 1 });
     expect(mock.callCount).toBe(0);
     await controller.test('metamask.io');
     expect(mock.callCount).toBe(1);
@@ -83,10 +71,7 @@ describe('PhishingController', () => {
   });
 
   it('should be able to change the refreshInterval', async () => {
-    const mock = sinon.spy(
-      PhishingController.prototype,
-      'updatePhishingLists',
-    );
+    const mock = sinon.spy(PhishingController.prototype, 'updatePhishingLists');
     const controller = new PhishingController({});
     controller.setRefreshInterval(0);
 

--- a/src/third-party/PhishingController.ts
+++ b/src/third-party/PhishingController.ts
@@ -180,11 +180,8 @@ export class PhishingController extends BaseController<
    * Temporarily marks a given origin as approved.
    *
    * @param origin - The origin to mark as approved.
-   * @returns Promise<void> when completed adding the origin to the whitelist
    */
-  async bypass(origin: string) {
-    await this.fetchIfNecessary();
-
+  bypass(origin: string) {
     const punycodeOrigin = toASCII(origin);
     const { whitelist } = this.state;
     if (whitelist.indexOf(punycodeOrigin) !== -1) {

--- a/src/third-party/PhishingController.ts
+++ b/src/third-party/PhishingController.ts
@@ -2,7 +2,6 @@ import { toASCII } from 'punycode/';
 import DEFAULT_PHISHING_RESPONSE from 'eth-phishing-detect/src/config.json';
 import PhishingDetector from 'eth-phishing-detect/src/detector';
 import { BaseController, BaseConfig, BaseState } from '../BaseController';
-import { safelyExecute } from '../util';
 
 /**
  * @type EthPhishingResponse

--- a/src/third-party/PhishingController.ts
+++ b/src/third-party/PhishingController.ts
@@ -140,7 +140,7 @@ export class PhishingController extends BaseController<
   /**
    * Set the interval at which the phishing list will be refetched. Fetching will only occur on the next call to test/bypass. For immediate update to the phishing list, call updatePhishingLists directly.
    *
-   * @param interval - the new interval, in ms
+   * @param interval - the new interval, in ms.
    */
   setRefreshInterval(interval: number) {
     this.configure({ refreshInterval: interval }, false, false);

--- a/src/third-party/PhishingController.ts
+++ b/src/third-party/PhishingController.ts
@@ -95,7 +95,7 @@ export class PhishingController extends BaseController<
 
   private detector: any;
 
-  public lastFetched = 0;
+  private lastFetched = 0;
 
   /**
    * Name of this controller used during composition
@@ -140,7 +140,6 @@ export class PhishingController extends BaseController<
 
   /**
    * Set the interval at which the phishing list will be refetched. Fetching will only occur on the next call to test/bypass. For immediate update to the phishing list, call updatePhishingLists directly.
-   * last this.lastFetched.
    *
    * @param interval - the new interval, in ms
    */
@@ -153,16 +152,13 @@ export class PhishingController extends BaseController<
    *
    * @returns Promise<void> when finished fetching phishing lists or when fetching in not necessary.
    */
-  private async fetchIfNecessary(): Promise<boolean> {
+  private async fetchIfNecessary(): Promise<void> {
     const outOfDate =
       Date.now() - this.lastFetched >= this.config.refreshInterval;
 
-    if (this.lastFetched === 0 || outOfDate) {
-      await safelyExecute(() => this.updatePhishingLists());
-      this.lastFetched = Date.now();
-      return true;
+    if (outOfDate) {
+      await this.updatePhishingLists();
     }
-    return false;
   }
 
   /**
@@ -202,7 +198,6 @@ export class PhishingController extends BaseController<
    * Updates lists of approved and unapproved website origins.
    */
   async updatePhishingLists() {
-    this.lastFetched = Date.now();
     if (this.disabled) {
       return;
     }
@@ -251,6 +246,8 @@ export class PhishingController extends BaseController<
     this.update({
       phishing: configs,
     });
+
+    this.lastFetched = Date.now();
   }
 
   private async queryConfig<ResponseType>(


### PR DESCRIPTION
**PR Title**

problems:
1. Constructor starts polling, which is async. Starting async actions in a contructor makes testing hard.
2. `test` depends on `state.whitelist` which is set async via `poll` > `updatePhishingLists`. It is a sync function, which creates race conditions.

solution:
1. make test, have it update the phishing list if necessary
2. remove polling

**Description**

- BREAKING:

  - `phishingController.test` now returns a `Promise<EthPhishingDetectResult>`
  - instead of calling poll with a new interval to change the interval, use `phishingController.setRefreshInterval` or `phishingController.configure({ refreshInterval: 123 })` (configure will be deprecated when we switch to using BaseController V2)

- FIXED:

  - race conditions in Phishing controller tests

**Checklist**

- [ x ] Tests are included if applicable
- [ x ] Any added code is fully documented

**Issue**

Resolves #???
