### PR TITLE
Add Git hook to run linter before pushing

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ console.log(datamodel.flatState); // {infura: {...}, contractExchangeRates: [...
 - Install [Node.js](https://nodejs.org) version 14
   - If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm use` will automatically choose the right node version for you.
 - Install [Yarn v3](https://yarnpkg.com/getting-started/install)
-- Run `yarn setup` to install dependencies and run any required post-install scripts.
+- Run `yarn install` to install dependencies and run any required post-install scripts
 - (Optional) Run `yarn simple-git-hooks` to set up a Git hook that will ensure that all files pass the linter before you push a branch.
 
 ### Testing and Linting

--- a/README.md
+++ b/README.md
@@ -257,10 +257,10 @@ console.log(datamodel.flatState); // {infura: {...}, contractExchangeRates: [...
 
 ### Setup
 
-- Install [Node.js](https://nodejs.org) version 12
+- Install [Node.js](https://nodejs.org) version 14
   - If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm use` will automatically choose the right node version for you.
 - Install [Yarn v3](https://yarnpkg.com/getting-started/install)
-- Run `yarn install` to install dependencies and run any required post-install scripts
+- Run `yarn setup` to install dependencies, run any required post-install scripts, and set up a Git hook for ensuring that files pass the linter pre-push.
 
 ### Testing and Linting
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,8 @@ console.log(datamodel.flatState); // {infura: {...}, contractExchangeRates: [...
 - Install [Node.js](https://nodejs.org) version 14
   - If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm use` will automatically choose the right node version for you.
 - Install [Yarn v3](https://yarnpkg.com/getting-started/install)
-- Run `yarn setup` to install dependencies, run any required post-install scripts, and set up a Git hook for ensuring that files pass the linter pre-push.
+- Run `yarn setup` to install dependencies and run any required post-install scripts.
+- (Optional) Run `yarn simple-git-hooks` to set up a Git hook that will ensure that all files pass the linter before you push a branch.
 
 ### Testing and Linting
 

--- a/README.md
+++ b/README.md
@@ -257,11 +257,11 @@ console.log(datamodel.flatState); // {infura: {...}, contractExchangeRates: [...
 
 ### Setup
 
-- Install [Node.js](https://nodejs.org) version 14
+- Install [Node.js](https://nodejs.org) version 14.
   - If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm use` will automatically choose the right node version for you.
-- Install [Yarn v3](https://yarnpkg.com/getting-started/install)
-- Run `yarn install` to install dependencies and run any required post-install scripts
-- (Optional) Run `yarn simple-git-hooks` to set up a Git hook that will ensure that all files pass the linter before you push a branch.
+- Install [Yarn v3](https://yarnpkg.com/getting-started/install).
+- Run `yarn install` to install dependencies and run any required post-install scripts.
+- Run `yarn simple-git-hooks` to add a [Git hook](https://github.com/toplenboren/simple-git-hooks#what-is-a-git-hook) which will ensure that all files pass the linter before you push a branch.
 
 ### Testing and Linting
 

--- a/package.json
+++ b/package.json
@@ -126,10 +126,10 @@
   "lavamoat": {
     "allowScripts": {
       "@lavamoat/preinstall-always-fail": false,
-      "@keystonehq/bc-ur-registry-eth>hdkey>secp256k1": false,
+      "@keystonehq/bc-ur-registry-eth>hdkey>secp256k1": true,
       "babel-runtime>core-js": false,
       "eth-sig-util>ethereumjs-abi>ethereumjs-util>keccakjs>sha3": true,
-      "eth-sig-util>ethereumjs-util>keccak": false,
+      "eth-sig-util>ethereumjs-util>keccak": true,
       "eth-sig-util>ethereumjs-util>secp256k1": true,
       "ethereumjs-util>ethereum-cryptography>keccak": true,
       "ethereumjs-util>ethereum-cryptography>secp256k1": true,

--- a/package.json
+++ b/package.json
@@ -30,10 +30,13 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' '!.yarnrc.yml' --ignore-path .gitignore",
     "prepack": "./scripts/prepack.sh",
-    "setup": "yarn install",
+    "setup": "yarn install && yarn simple-git-hooks",
     "test": "jest",
     "test:debug": "yarn run --inspect-brk jest --runInBand",
     "test:watch": "jest --watch"
+  },
+  "simple-git-hooks": {
+    "pre-push": "yarn lint"
   },
   "dependencies": {
     "@ethereumjs/common": "^2.3.1",
@@ -105,6 +108,7 @@
     "prettier": "^2.6.2",
     "prettier-plugin-packagejson": "^2.2.17",
     "rimraf": "^3.0.2",
+    "simple-git-hooks": "^2.8.0",
     "sinon": "^9.2.4",
     "ts-jest": "^26.5.2",
     "typedoc": "^0.22.15",
@@ -126,9 +130,10 @@
       "babel-runtime>core-js": false,
       "eth-sig-util>ethereumjs-abi>ethereumjs-util>keccakjs>sha3": true,
       "eth-sig-util>ethereumjs-util>keccak": true,
-      "eth-sig-util>ethereumjs-util>secp256k1": true,
-      "ethereumjs-util>ethereum-cryptography>keccak": true,
-      "ethereumjs-util>ethereum-cryptography>secp256k1": true
+      "eth-sig-util>ethereumjs-util>secp256k1": false,
+      "ethereumjs-util>ethereum-cryptography>keccak": false,
+      "ethereumjs-util>ethereum-cryptography>secp256k1": false,
+      "simple-git-hooks": false
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -126,13 +126,13 @@
   "lavamoat": {
     "allowScripts": {
       "@lavamoat/preinstall-always-fail": false,
-      "@keystonehq/bc-ur-registry-eth>hdkey>secp256k1": true,
+      "@keystonehq/bc-ur-registry-eth>hdkey>secp256k1": false,
       "babel-runtime>core-js": false,
       "eth-sig-util>ethereumjs-abi>ethereumjs-util>keccakjs>sha3": true,
-      "eth-sig-util>ethereumjs-util>keccak": true,
-      "eth-sig-util>ethereumjs-util>secp256k1": false,
-      "ethereumjs-util>ethereum-cryptography>keccak": false,
-      "ethereumjs-util>ethereum-cryptography>secp256k1": false,
+      "eth-sig-util>ethereumjs-util>keccak": false,
+      "eth-sig-util>ethereumjs-util>secp256k1": true,
+      "ethereumjs-util>ethereum-cryptography>keccak": true,
+      "ethereumjs-util>ethereum-cryptography>secp256k1": true,
       "simple-git-hooks": false
     }
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' '!.yarnrc.yml' --ignore-path .gitignore",
     "prepack": "./scripts/prepack.sh",
-    "setup": "yarn install && yarn simple-git-hooks",
+    "setup": "yarn install",
     "test": "jest",
     "test:debug": "yarn run --inspect-brk jest --runInBand",
     "test:watch": "jest --watch"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1500,6 +1500,7 @@ __metadata:
     prettier-plugin-packagejson: ^2.2.17
     punycode: ^2.1.1
     rimraf: ^3.0.2
+    simple-git-hooks: ^2.8.0
     single-call-balance-checker-abi: ^1.0.0
     sinon: ^9.2.4
     ts-jest: ^26.5.2
@@ -10187,6 +10188,15 @@ __metadata:
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
   checksum: a2f098f247adc367dffc27845853e9959b9e88b01cb301658cfe4194352d8d2bb32e18467c786a7fe15f1d44b233ea35633d076d5e737870b7139949d1ab6318
+  languageName: node
+  linkType: hard
+
+"simple-git-hooks@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "simple-git-hooks@npm:2.8.0"
+  bin:
+    simple-git-hooks: cli.js
+  checksum: 2249177fd039c3841b6bc1ba63a8692a6aebf1820abe2cad0d41abfb7cec95e13de704efd3c60aff344919cc676ad87c492fa1c3a3cb391f6f6c28e5b66b7e26
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
It's far too common to create or update a pull request, receive an
approval, and then realize that you can't merge it because CI is saying
that you have linter violations. Ideally, you could always run the
linter before you push, but this step is easy to forget.

To solve this problem, this commit provides a way to install a Git hook
via `simple-git-hooks` which will run `yarn lint` pre-push. If there are
any linter violations, pushing will fail and you can run `yarn lint:fix`
to fix them (or fix them manually).

Note that a previous solution to this problem, submitted as a PR to the
extension repo, involved the use of `lint-staged` to run the linter
against staged files pre-commit. I've changed the workflow to pre-push
because ESLint, when supplied with TypeScript rules, can take a long
time to run (around 2-3 seconds in my testing). This is noticeable
enough to be annoying.

Also note that because the use of Git hooks is local to one's machine,
they must be installed in order to take advantage of automatic linting.
To do this, I've re-introduced `yarn setup`, which will run `yarn
simple-git-hooks`.