### PR TITLE
Making functions idempotent by not conditionally throwing exceptions

### DIFF
--- a/src/approval/ApprovalController.test.ts
+++ b/src/approval/ApprovalController.test.ts
@@ -464,10 +464,8 @@ describe('approval controller', () => {
       expect(deleteSpy.callCount).toStrictEqual(numDeletions);
     });
 
-    it('throws on unknown id', () => {
-      expect(() => approvalController.accept('foo')).toThrow(
-        getIdNotFoundError('foo'),
-      );
+    it('does not throws on unknown id', () => {
+      expect(() => approvalController.accept('foo')).not.toThrow();
       expect(deleteSpy.callCount).toStrictEqual(numDeletions);
     });
   });
@@ -520,10 +518,10 @@ describe('approval controller', () => {
       expect(deleteSpy.callCount).toStrictEqual(numDeletions);
     });
 
-    it('throws on unknown id', () => {
-      expect(() => approvalController.reject('foo', new Error('bar'))).toThrow(
-        getIdNotFoundError('foo'),
-      );
+    it('does not throws on unknown id', () => {
+      expect(() =>
+        approvalController.reject('foo', new Error('bar')),
+      ).not.toThrow();
       expect(deleteSpy.callCount).toStrictEqual(numDeletions);
     });
   });

--- a/src/approval/ApprovalController.test.ts
+++ b/src/approval/ApprovalController.test.ts
@@ -464,7 +464,7 @@ describe('approval controller', () => {
       expect(deleteSpy.callCount).toStrictEqual(numDeletions);
     });
 
-    it('does not throws on unknown id', () => {
+    it('does not throw on unknown id', () => {
       expect(() => approvalController.accept('foo')).not.toThrow();
       expect(deleteSpy.callCount).toStrictEqual(numDeletions);
     });
@@ -518,7 +518,7 @@ describe('approval controller', () => {
       expect(deleteSpy.callCount).toStrictEqual(numDeletions);
     });
 
-    it('does not throws on unknown id', () => {
+    it('does not throw on unknown id', () => {
       expect(() =>
         approvalController.reject('foo', new Error('bar')),
       ).not.toThrow();

--- a/src/approval/ApprovalController.test.ts
+++ b/src/approval/ApprovalController.test.ts
@@ -463,7 +463,26 @@ describe('approval controller', () => {
       expect(result).toStrictEqual('success1');
       expect(deleteSpy.callCount).toStrictEqual(numDeletions);
     });
+  });
 
+  describe('resolve (idempotent tests)', () => {
+    let approvalController: ApprovalController;
+    let numDeletions: number;
+    let deleteSpy: sinon.SinonSpy;
+
+    beforeEach(() => {
+      approvalController = new ApprovalController({
+        messenger: getRestrictedMessenger(),
+        showApprovalRequest: sinon.spy(),
+      });
+      // TODO: Stop using private methods in tests
+      deleteSpy = sinon.spy(approvalController as any, '_delete');
+      numDeletions = 0;
+    });
+
+    // If already is already resolved the method should not throw error
+    // This is to make the method idempotent and multiple calls with same parameters will
+    // leave controller in same state and function will not throw error.
     it('does not throw on unknown id', () => {
       expect(() => approvalController.accept('foo')).not.toThrow();
       expect(deleteSpy.callCount).toStrictEqual(numDeletions);
@@ -517,7 +536,26 @@ describe('approval controller', () => {
       await expect(rejectionPromise1).rejects.toThrow('failure1');
       expect(deleteSpy.callCount).toStrictEqual(numDeletions);
     });
+  });
 
+  describe('reject (idempotent tests)', () => {
+    let approvalController: ApprovalController;
+    let numDeletions: number;
+    let deleteSpy: sinon.SinonSpy;
+
+    beforeEach(() => {
+      approvalController = new ApprovalController({
+        messenger: getRestrictedMessenger(),
+        showApprovalRequest: sinon.spy(),
+      });
+      // TODO: Stop using private methods in tests
+      deleteSpy = sinon.spy(approvalController as any, '_delete');
+      numDeletions = 0;
+    });
+
+    // If already is already rejected the method should not throw error
+    // This is to make the method idempotent and multiple calls with same parameters will
+    // leave controller in same state and function will not throw error.
     it('does not throw on unknown id', () => {
       expect(() =>
         approvalController.reject('foo', new Error('bar')),

--- a/src/approval/ApprovalController.test.ts
+++ b/src/approval/ApprovalController.test.ts
@@ -705,16 +705,6 @@ function getOriginTypeCollisionError(origin: string, type = TYPE) {
 }
 
 /**
- * Get an "ID not found" error.
- *
- * @param id - The ID that was not found.
- * @returns An "ID not found" error.
- */
-function getIdNotFoundError(id: string) {
-  return getError(`Approval request with id '${id}' not found.`);
-}
-
-/**
  * Get an error.
  *
  * @param message - The error message.

--- a/src/approval/ApprovalController.ts
+++ b/src/approval/ApprovalController.ts
@@ -386,7 +386,7 @@ export class ApprovalController extends BaseController<
    * @param value - The value to resolve the approval promise with.
    */
   accept(id: string, value?: unknown): void {
-    this._deleteApprovalAndGetCallbacks(id).resolve(value);
+    this._deleteApprovalAndGetCallbacks(id)?.resolve(value);
   }
 
   /**
@@ -397,7 +397,7 @@ export class ApprovalController extends BaseController<
    * @param error - The error to reject the approval promise with.
    */
   reject(id: string, error: unknown): void {
-    this._deleteApprovalAndGetCallbacks(id).reject(error);
+    this._deleteApprovalAndGetCallbacks(id)?.reject(error);
   }
 
   /**
@@ -565,10 +565,12 @@ export class ApprovalController extends BaseController<
    * @param id - The id of the approval request.
    * @returns The promise callbacks associated with the approval request.
    */
-  private _deleteApprovalAndGetCallbacks(id: string): ApprovalCallbacks {
+  private _deleteApprovalAndGetCallbacks(
+    id: string,
+  ): ApprovalCallbacks | undefined {
     const callbacks = this._approvals.get(id);
     if (!callbacks) {
-      throw new Error(`Approval request with id '${id}' not found.`);
+      return undefined;
     }
 
     this._delete(id);

--- a/src/permissions/PermissionController.test.ts
+++ b/src/permissions/PermissionController.test.ts
@@ -3920,6 +3920,7 @@ describe('PermissionController', () => {
         },
       });
 
+      // Method is called only once
       expect(callActionSpy).toHaveBeenCalledTimes(1);
       expect(callActionSpy).toHaveBeenNthCalledWith(
         1,
@@ -4031,6 +4032,7 @@ describe('PermissionController', () => {
 
       await controller.rejectPermissionsRequest(id);
 
+      // Method is called only once
       expect(callActionSpy).toHaveBeenCalledTimes(1);
       expect(callActionSpy).toHaveBeenNthCalledWith(
         1,

--- a/src/permissions/PermissionController.test.ts
+++ b/src/permissions/PermissionController.test.ts
@@ -1000,19 +1000,14 @@ describe('PermissionController', () => {
       ).toThrow(new errors.UnrecognizedSubjectError('metamask.io'));
     });
 
-    it('throws an error if the requested subject does not have the specified permission', () => {
+    it('does not throws an error if the requested subject does not have the specified permission', () => {
       const controller = getDefaultPermissionControllerWithState();
       expect(() =>
         controller.revokePermission(
           'metamask.io',
           PermissionNames.wallet_getSecretObject,
         ),
-      ).toThrow(
-        new errors.PermissionDoesNotExistError(
-          'metamask.io',
-          PermissionNames.wallet_getSecretObject,
-        ),
-      );
+      ).not.toThrow();
     });
   });
 

--- a/src/permissions/PermissionController.test.ts
+++ b/src/permissions/PermissionController.test.ts
@@ -1000,7 +1000,7 @@ describe('PermissionController', () => {
       ).toThrow(new errors.UnrecognizedSubjectError('metamask.io'));
     });
 
-    it('does not throws an error if the requested subject does not have the specified permission', () => {
+    it('does not throw an error if the requested subject does not have the specified permission', () => {
       const controller = getDefaultPermissionControllerWithState();
       expect(() =>
         controller.revokePermission(
@@ -1119,7 +1119,7 @@ describe('PermissionController', () => {
       ).toThrow(new errors.UnrecognizedSubjectError('foo'));
     });
 
-    it('does not throws an error if the requested subject does not have the specified permission', () => {
+    it('does not throw an error if the requested subject does not have the specified permission', () => {
       const controller = getDefaultPermissionControllerWithState();
       expect(() =>
         controller.revokePermissions({

--- a/src/permissions/PermissionController.test.ts
+++ b/src/permissions/PermissionController.test.ts
@@ -1124,18 +1124,13 @@ describe('PermissionController', () => {
       ).toThrow(new errors.UnrecognizedSubjectError('foo'));
     });
 
-    it('throws an error if the requested subject does not have the specified permission', () => {
+    it('does not throws an error if the requested subject does not have the specified permission', () => {
       const controller = getDefaultPermissionControllerWithState();
       expect(() =>
         controller.revokePermissions({
           'metamask.io': [PermissionNames.wallet_getSecretObject],
         }),
-      ).toThrow(
-        new errors.PermissionDoesNotExistError(
-          'metamask.io',
-          PermissionNames.wallet_getSecretObject,
-        ),
-      );
+      ).not.toThrow();
     });
   });
 
@@ -3911,7 +3906,7 @@ describe('PermissionController', () => {
       );
     });
 
-    it('throws if the request does not exist', async () => {
+    it('does not call ApprovalController:acceptRequest if the request does not exist', async () => {
       const options = getPermissionControllerOptions();
       const { messenger } = options;
       const origin = 'metamask.io';
@@ -3923,15 +3918,12 @@ describe('PermissionController', () => {
 
       const controller = getDefaultPermissionController(options);
 
-      await expect(
-        async () =>
-          await controller.acceptPermissionsRequest({
-            metadata: { id, origin },
-            permissions: {
-              [PermissionNames.wallet_getSecretArray]: {},
-            },
-          }),
-      ).rejects.toThrow(new errors.PermissionsRequestNotFoundError(id));
+      await controller.acceptPermissionsRequest({
+        metadata: { id, origin },
+        permissions: {
+          [PermissionNames.wallet_getSecretArray]: {},
+        },
+      });
 
       expect(callActionSpy).toHaveBeenCalledTimes(1);
       expect(callActionSpy).toHaveBeenNthCalledWith(
@@ -4031,7 +4023,7 @@ describe('PermissionController', () => {
       );
     });
 
-    it('throws if the request does not exist', async () => {
+    it('does not call ApprovalController:rejectRequest if the request does not exist', async () => {
       const options = getPermissionControllerOptions();
       const { messenger } = options;
       const id = 'foobar';
@@ -4042,9 +4034,7 @@ describe('PermissionController', () => {
 
       const controller = getDefaultPermissionController(options);
 
-      await expect(
-        async () => await controller.rejectPermissionsRequest(id),
-      ).rejects.toThrow(new errors.PermissionsRequestNotFoundError(id));
+      await controller.rejectPermissionsRequest(id);
 
       expect(callActionSpy).toHaveBeenCalledTimes(1);
       expect(callActionSpy).toHaveBeenNthCalledWith(

--- a/src/permissions/PermissionController.ts
+++ b/src/permissions/PermissionController.ts
@@ -48,7 +48,6 @@ import {
   InvalidSubjectIdentifierError,
   methodNotFound,
   PermissionDoesNotExistError,
-  PermissionsRequestNotFoundError,
   unauthorized,
   UnrecognizedCaveatTypeError,
   UnrecognizedSubjectError,

--- a/src/permissions/PermissionController.ts
+++ b/src/permissions/PermissionController.ts
@@ -974,7 +974,7 @@ export class PermissionController<
         subjectsAndPermissions[origin].forEach((target) => {
           const { permissions } = draftState.subjects[origin];
           if (!hasProperty(permissions as Record<string, unknown>, target)) {
-            throw new PermissionDoesNotExistError(origin, target);
+            return;
           }
 
           this.deletePermission(draftState.subjects, origin, target);
@@ -2040,7 +2040,7 @@ export class PermissionController<
     const { id } = request.metadata;
 
     if (!this.hasApprovalRequest({ id })) {
-      throw new PermissionsRequestNotFoundError(id);
+      return;
     }
 
     if (Object.keys(request.permissions).length === 0) {
@@ -2075,7 +2075,7 @@ export class PermissionController<
    */
   async rejectPermissionsRequest(id: string): Promise<void> {
     if (!this.hasApprovalRequest({ id })) {
-      throw new PermissionsRequestNotFoundError(id);
+      return;
     }
 
     this._rejectPermissionsRequest(id, userRejectedRequest());


### PR DESCRIPTION
A requirement in MV3 is to make method calls idempotent, that is repeatedly calling method with same input parameters should give same result.

At a few places second call could have thrown error, the PR fixes those.