### PR TITLE
Refactor NetworkController to BaseControllerV2

### DIFF
--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -15,6 +15,7 @@ import { PreferencesController } from './user/PreferencesController';
 import {
   NetworkController,
   NetworkControllerMessenger,
+  NetworkControllerStateChangeEvent,
   NetworksChainId,
 } from './network/NetworkController';
 import { AssetsContractController } from './assets/AssetsContractController';
@@ -88,7 +89,10 @@ class BarController extends BaseController<never, BarControllerState> {
 }
 
 const setupControllers = () => {
-  const mainMessenger: any = new ControllerMessenger();
+  const mainMessenger = new ControllerMessenger<
+    never,
+    NetworkControllerStateChangeEvent
+  >();
   const messenger: NetworkControllerMessenger = mainMessenger.getRestricted({
     name: 'NetworkController',
     allowedEvents: ['NetworkController:stateChange'],

--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -88,7 +88,7 @@ class BarController extends BaseController<never, BarControllerState> {
 }
 
 const setupControllers = () => {
-  const mainMessenger = new ControllerMessenger();
+  const mainMessenger: any = new ControllerMessenger();
   const messenger: NetworkControllerMessenger = mainMessenger.getRestricted({
     name: 'NetworkController',
     allowedEvents: ['NetworkController:stateChange'],
@@ -97,7 +97,7 @@ const setupControllers = () => {
 
   const composableMessenger = mainMessenger.getRestricted({
     name: 'ComposableController',
-    allowedEvents: [],
+    allowedEvents: ['NetworkController:stateChange'],
     allowedActions: [],
   });
 

--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -14,6 +14,7 @@ import {
 import { PreferencesController } from './user/PreferencesController';
 import {
   NetworkController,
+  NetworkControllerMessenger,
   NetworksChainId,
 } from './network/NetworkController';
 import { AssetsContractController } from './assets/AssetsContractController';
@@ -87,6 +88,25 @@ class BarController extends BaseController<never, BarControllerState> {
 }
 
 describe('ComposableController', () => {
+  let networkMessenger: NetworkControllerMessenger;
+  let messenger: any;
+
+  beforeEach(() => {
+    const _messenger = new ControllerMessenger();
+
+    networkMessenger = _messenger.getRestricted({
+      name: 'NetworkController',
+      allowedEvents: ['NetworkController:stateChange'],
+      allowedActions: [],
+    });
+
+    messenger = _messenger.getRestricted<string, any, any>({
+      name: 'ComposableController',
+      allowedEvents: ['NetworkController:stateChange'],
+      allowedActions: [],
+    });
+  });
+
   afterEach(() => {
     sinon.restore();
   });
@@ -94,18 +114,20 @@ describe('ComposableController', () => {
   describe('BaseController', () => {
     it('should compose controller state', () => {
       const preferencesController = new PreferencesController();
-      const networkController = new NetworkController();
+      const networkController = new NetworkController({
+        messenger: networkMessenger,
+      });
       const assetContractController = new AssetsContractController({
         onPreferencesStateChange: (listener) =>
           preferencesController.subscribe(listener),
         onNetworkStateChange: (listener) =>
-          networkController.subscribe(listener),
+          messenger.subscribe('NetworkController:stateChange', listener),
       });
       const collectiblesController = new CollectiblesController({
         onPreferencesStateChange: (listener) =>
           preferencesController.subscribe(listener),
         onNetworkStateChange: (listener) =>
-          networkController.subscribe(listener),
+          messenger.subscribe('NetworkController:stateChange', listener),
         getERC721AssetName: assetContractController.getERC721AssetName.bind(
           assetContractController,
         ),
@@ -130,17 +152,21 @@ describe('ComposableController', () => {
         onPreferencesStateChange: (listener) =>
           preferencesController.subscribe(listener),
         onNetworkStateChange: (listener) =>
-          networkController.subscribe(listener),
+          messenger.subscribe('NetworkController:stateChange', listener),
       });
-      const controller = new ComposableController([
-        new AddressBookController(),
-        collectiblesController,
-        assetContractController,
-        new EnsController(),
-        networkController,
-        preferencesController,
-        tokensController,
-      ]);
+      const controller = new ComposableController(
+        [
+          new AddressBookController(),
+          collectiblesController,
+          assetContractController,
+          new EnsController(),
+          networkController,
+          preferencesController,
+          tokensController,
+        ],
+        messenger,
+      );
+
       expect(controller.state).toStrictEqual({
         AddressBookController: { addressBook: {} },
         AssetsContractController: {},
@@ -183,18 +209,20 @@ describe('ComposableController', () => {
 
     it('should compose flat controller state', () => {
       const preferencesController = new PreferencesController();
-      const networkController = new NetworkController();
+      const networkController = new NetworkController({
+        messenger: networkMessenger,
+      });
       const assetContractController = new AssetsContractController({
         onPreferencesStateChange: (listener) =>
           preferencesController.subscribe(listener),
         onNetworkStateChange: (listener) =>
-          networkController.subscribe(listener),
+          messenger.subscribe('NetworkController:stateChange', listener),
       });
       const collectiblesController = new CollectiblesController({
         onPreferencesStateChange: (listener) =>
           preferencesController.subscribe(listener),
         onNetworkStateChange: (listener) =>
-          networkController.subscribe(listener),
+          messenger.subscribe('NetworkController:stateChange', listener),
         getERC721AssetName: assetContractController.getERC721AssetName.bind(
           assetContractController,
         ),
@@ -219,17 +247,20 @@ describe('ComposableController', () => {
         onPreferencesStateChange: (listener) =>
           preferencesController.subscribe(listener),
         onNetworkStateChange: (listener) =>
-          networkController.subscribe(listener),
+          messenger.subscribe('NetworkController:stateChange', listener),
       });
-      const controller = new ComposableController([
-        new AddressBookController(),
-        collectiblesController,
-        assetContractController,
-        new EnsController(),
-        networkController,
-        preferencesController,
-        tokensController,
-      ]);
+      const controller = new ComposableController(
+        [
+          new AddressBookController(),
+          collectiblesController,
+          assetContractController,
+          new EnsController(),
+          networkController,
+          preferencesController,
+          tokensController,
+        ],
+        messenger,
+      );
       expect(controller.flatState).toStrictEqual({
         addressBook: {},
         allCollectibleContracts: {},

--- a/src/ComposableController.test.ts
+++ b/src/ComposableController.test.ts
@@ -4,7 +4,10 @@ import { TokensController } from './assets/TokensController';
 import { CollectiblesController } from './assets/CollectiblesController';
 import { AddressBookController } from './user/AddressBookController';
 import { EnsController } from './third-party/EnsController';
-import { ComposableController } from './ComposableController';
+import {
+  ComposableController,
+  ComposableControllerRestrictedMessenger,
+} from './ComposableController';
 import { BaseController, BaseState } from './BaseController';
 import { BaseController as BaseControllerV2 } from './BaseControllerV2';
 import {
@@ -93,17 +96,19 @@ const setupControllers = () => {
     never,
     NetworkControllerStateChangeEvent
   >();
+
   const messenger: NetworkControllerMessenger = mainMessenger.getRestricted({
     name: 'NetworkController',
     allowedEvents: ['NetworkController:stateChange'],
     allowedActions: [],
   });
 
-  const composableMessenger = mainMessenger.getRestricted({
-    name: 'ComposableController',
-    allowedEvents: ['NetworkController:stateChange'],
-    allowedActions: [],
-  });
+  const composableMessenger: ComposableControllerRestrictedMessenger =
+    mainMessenger.getRestricted({
+      name: 'ComposableController',
+      allowedEvents: ['NetworkController:stateChange'],
+      allowedActions: [],
+    });
 
   const networkController = new NetworkController({
     messenger,

--- a/src/ComposableController.ts
+++ b/src/ComposableController.ts
@@ -15,19 +15,16 @@ export type ControllerList = (
   | { name: string; state: Record<string, unknown> }
 )[];
 
+export type ComposableControllerRestrictedMessenger =
+  RestrictedControllerMessenger<'ComposableController', never, any, never, any>;
+
 /**
  * Controller that can be used to compose multiple controllers together
  */
 export class ComposableController extends BaseController<never, any> {
   private controllers: ControllerList = [];
 
-  private messagingSystem?: RestrictedControllerMessenger<
-    'ComposableController',
-    never,
-    any,
-    never,
-    any
-  >;
+  private messagingSystem?: ComposableControllerRestrictedMessenger;
 
   /**
    * Name of this controller used during composition
@@ -42,13 +39,7 @@ export class ComposableController extends BaseController<never, any> {
    */
   constructor(
     controllers: ControllerList,
-    messenger?: RestrictedControllerMessenger<
-      'ComposableController',
-      never,
-      any,
-      never,
-      any
-    >,
+    messenger?: ComposableControllerRestrictedMessenger,
   ) {
     super(
       undefined,

--- a/src/assets/AssetsContractController.test.ts
+++ b/src/assets/AssetsContractController.test.ts
@@ -2,7 +2,11 @@ import HttpProvider from 'ethjs-provider-http';
 import { IPFS_DEFAULT_GATEWAY_URL } from '../constants';
 import { SupportedTokenDetectionNetworks } from '../util';
 import { PreferencesController } from '../user/PreferencesController';
-import { NetworkController } from '../network/NetworkController';
+import {
+  NetworkController,
+  NetworkControllerMessenger,
+} from '../network/NetworkController';
+import { ControllerMessenger } from '../ControllerMessenger';
 import {
   AssetsContractController,
   MISSING_PROVIDER_ERROR,
@@ -25,13 +29,23 @@ describe('AssetsContractController', () => {
   let assetsContract: AssetsContractController;
   let preferences: PreferencesController;
   let network: NetworkController;
+  let messenger: NetworkControllerMessenger;
 
   beforeEach(() => {
+    messenger = new ControllerMessenger().getRestricted({
+      name: 'NetworkController',
+      allowedEvents: ['NetworkController:stateChange'],
+      allowedActions: [],
+    });
+
+    network = new NetworkController({
+      messenger,
+    });
     preferences = new PreferencesController();
-    network = new NetworkController();
     assetsContract = new AssetsContractController({
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        messenger.subscribe('NetworkController:stateChange', listener),
     });
   });
 

--- a/src/assets/AssetsContractController.test.ts
+++ b/src/assets/AssetsContractController.test.ts
@@ -25,39 +25,40 @@ const ERC1155_ID =
 
 const TEST_ACCOUNT_PUBLIC_ADDRESS =
   '0x5a3CA5cD63807Ce5e4d7841AB32Ce6B6d9BbBa2D';
-describe('AssetsContractController', () => {
-  let assetsContract: AssetsContractController;
-  let preferences: PreferencesController;
-  let network: NetworkController;
-  let messenger: NetworkControllerMessenger;
 
-  beforeEach(() => {
-    messenger = new ControllerMessenger().getRestricted({
+const setupControllers = () => {
+  const messenger: NetworkControllerMessenger =
+    new ControllerMessenger().getRestricted({
       name: 'NetworkController',
       allowedEvents: ['NetworkController:stateChange'],
       allowedActions: [],
     });
-
-    network = new NetworkController({
-      messenger,
-    });
-    preferences = new PreferencesController();
-    assetsContract = new AssetsContractController({
-      onPreferencesStateChange: (listener) => preferences.subscribe(listener),
-      onNetworkStateChange: (listener) =>
-        messenger.subscribe('NetworkController:stateChange', listener),
-    });
+  const network = new NetworkController({
+    messenger,
+  });
+  const preferences = new PreferencesController();
+  const assetsContract = new AssetsContractController({
+    onPreferencesStateChange: (listener) => preferences.subscribe(listener),
+    onNetworkStateChange: (listener) =>
+      messenger.subscribe('NetworkController:stateChange', listener),
   });
 
+  return { messenger, network, preferences, assetsContract };
+};
+
+describe('AssetsContractController', () => {
   it('should set default config', () => {
+    const { assetsContract, messenger } = setupControllers();
     expect(assetsContract.config).toStrictEqual({
       chainId: SupportedTokenDetectionNetworks.mainnet,
       ipfsGateway: IPFS_DEFAULT_GATEWAY_URL,
       provider: undefined,
     });
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should update the ipfsGateWay config value when this value is changed in the preferences controller', () => {
+    const { assetsContract, messenger, preferences } = setupControllers();
     expect(assetsContract.config).toStrictEqual({
       chainId: SupportedTokenDetectionNetworks.mainnet,
       ipfsGateway: IPFS_DEFAULT_GATEWAY_URL,
@@ -70,15 +71,20 @@ describe('AssetsContractController', () => {
       chainId: SupportedTokenDetectionNetworks.mainnet,
       provider: undefined,
     });
+
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should throw when provider property is accessed', () => {
+    const { assetsContract, messenger } = setupControllers();
     expect(() => console.log(assetsContract.provider)).toThrow(
       'Property only used for setting',
     );
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should throw missing provider error when getting ERC-20 token balance when missing provider', async () => {
+    const { assetsContract, messenger } = setupControllers();
     assetsContract.configure({ provider: undefined });
     await expect(
       assetsContract.getERC20BalanceOf(
@@ -86,16 +92,20 @@ describe('AssetsContractController', () => {
         TEST_ACCOUNT_PUBLIC_ADDRESS,
       ),
     ).rejects.toThrow(MISSING_PROVIDER_ERROR);
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should throw missing provider error when getting ERC-20 token decimal when missing provider', async () => {
+    const { assetsContract, messenger } = setupControllers();
     assetsContract.configure({ provider: undefined });
     await expect(
       assetsContract.getERC20TokenDecimals(ERC20_UNI_ADDRESS),
     ).rejects.toThrow(MISSING_PROVIDER_ERROR);
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should get balance of ERC-20 token contract correctly', async () => {
+    const { assetsContract, messenger } = setupControllers();
     assetsContract.configure({ provider: MAINNET_PROVIDER });
     const UNIBalance = await assetsContract.getERC20BalanceOf(
       ERC20_UNI_ADDRESS,
@@ -107,9 +117,11 @@ describe('AssetsContractController', () => {
     );
     expect(UNIBalance.toNumber()).not.toStrictEqual(0);
     expect(UNINoBalance.toNumber()).toStrictEqual(0);
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should get ERC-721 collectible tokenId correctly', async () => {
+    const { assetsContract, messenger } = setupControllers();
     assetsContract.configure({ provider: MAINNET_PROVIDER });
     const tokenId = await assetsContract.getERC721CollectibleTokenId(
       ERC721_GODS_ADDRESS,
@@ -117,9 +129,11 @@ describe('AssetsContractController', () => {
       0,
     );
     expect(tokenId).not.toStrictEqual(0);
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should throw missing provider error when getting ERC-721 token standard and details when missing provider', async () => {
+    const { assetsContract, messenger } = setupControllers();
     assetsContract.configure({ provider: undefined });
     await expect(
       assetsContract.getTokenStandardAndDetails(
@@ -127,9 +141,11 @@ describe('AssetsContractController', () => {
         TEST_ACCOUNT_PUBLIC_ADDRESS,
       ),
     ).rejects.toThrow(MISSING_PROVIDER_ERROR);
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should throw contract standard error when getting ERC-20 token standard and details when provided with invalid ERC-20 address', async () => {
+    const { assetsContract, messenger } = setupControllers();
     assetsContract.configure({ provider: MAINNET_PROVIDER });
     const error = 'Unable to determine contract standard';
     await expect(
@@ -138,45 +154,55 @@ describe('AssetsContractController', () => {
         TEST_ACCOUNT_PUBLIC_ADDRESS,
       ),
     ).rejects.toThrow(error);
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should get ERC-721 token standard and details', async () => {
+    const { assetsContract, messenger } = setupControllers();
     assetsContract.configure({ provider: MAINNET_PROVIDER });
     const standardAndDetails = await assetsContract.getTokenStandardAndDetails(
       ERC721_GODS_ADDRESS,
       TEST_ACCOUNT_PUBLIC_ADDRESS,
     );
     expect(standardAndDetails.standard).toStrictEqual('ERC721');
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should get ERC-1155 token standard and details', async () => {
+    const { assetsContract, messenger } = setupControllers();
     assetsContract.configure({ provider: MAINNET_PROVIDER });
     const standardAndDetails = await assetsContract.getTokenStandardAndDetails(
       ERC1155_ADDRESS,
       TEST_ACCOUNT_PUBLIC_ADDRESS,
     );
     expect(standardAndDetails.standard).toStrictEqual('ERC1155');
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should get ERC-20 token standard and details', async () => {
+    const { assetsContract, messenger } = setupControllers();
     assetsContract.configure({ provider: MAINNET_PROVIDER });
     const standardAndDetails = await assetsContract.getTokenStandardAndDetails(
       ERC20_UNI_ADDRESS,
       TEST_ACCOUNT_PUBLIC_ADDRESS,
     );
     expect(standardAndDetails.standard).toStrictEqual('ERC20');
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should get ERC-721 collectible tokenURI correctly', async () => {
+    const { assetsContract, messenger } = setupControllers();
     assetsContract.configure({ provider: MAINNET_PROVIDER });
     const tokenId = await assetsContract.getERC721TokenURI(
       ERC721_GODS_ADDRESS,
       '0',
     );
     expect(tokenId).toStrictEqual('https://api.godsunchained.com/card/0');
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should throw an error when address given is not an ERC-721 collectible', async () => {
+    const { assetsContract, messenger } = setupControllers();
     assetsContract.configure({ provider: MAINNET_PROVIDER });
     const result = async () => {
       await assetsContract.getERC721TokenURI(
@@ -187,61 +213,77 @@ describe('AssetsContractController', () => {
 
     const error = 'Contract does not support ERC721 metadata interface.';
     await expect(result).rejects.toThrow(error);
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should get ERC-721 collectible name', async () => {
+    const { assetsContract, messenger } = setupControllers();
     assetsContract.configure({ provider: MAINNET_PROVIDER });
     const name = await assetsContract.getERC721AssetName(ERC721_GODS_ADDRESS);
     expect(name).toStrictEqual('Gods Unchained');
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should get ERC-721 collectible symbol', async () => {
+    const { assetsContract, messenger } = setupControllers();
     assetsContract.configure({ provider: MAINNET_PROVIDER });
     const symbol = await assetsContract.getERC721AssetSymbol(
       ERC721_GODS_ADDRESS,
     );
     expect(symbol).toStrictEqual('GODS');
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should throw missing provider error when getting ERC-721 collectible symbol when missing provider', async () => {
+    const { assetsContract, messenger } = setupControllers();
     await expect(
       assetsContract.getERC721AssetSymbol(ERC721_GODS_ADDRESS),
     ).rejects.toThrow(MISSING_PROVIDER_ERROR);
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should get ERC-20 token decimals', async () => {
+    const { assetsContract, messenger } = setupControllers();
     assetsContract.configure({ provider: MAINNET_PROVIDER });
     const decimals = await assetsContract.getERC20TokenDecimals(
       ERC20_DAI_ADDRESS,
     );
     expect(Number(decimals)).toStrictEqual(18);
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should get ERC-721 collectible ownership', async () => {
+    const { assetsContract, messenger } = setupControllers();
     assetsContract.configure({ provider: MAINNET_PROVIDER });
     const tokenId = await assetsContract.getERC721OwnerOf(
       ERC721_GODS_ADDRESS,
       '148332',
     );
     expect(tokenId).not.toStrictEqual('');
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should throw missing provider error when getting ERC-721 collectible ownership', async () => {
+    const { assetsContract, messenger } = setupControllers();
     await expect(
       assetsContract.getERC721OwnerOf(ERC721_GODS_ADDRESS, '148332'),
     ).rejects.toThrow(MISSING_PROVIDER_ERROR);
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should get balance of ERC-20 token in a single call on network with token detection support', async () => {
+    const { assetsContract, messenger } = setupControllers();
     assetsContract.configure({ provider: MAINNET_PROVIDER });
     const balances = await assetsContract.getBalancesInSingleCall(
       ERC20_DAI_ADDRESS,
       [ERC20_DAI_ADDRESS],
     );
     expect(balances[ERC20_DAI_ADDRESS]).not.toBeUndefined();
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should not have balance in a single call after switching to network without token detection support', async () => {
+    const { assetsContract, messenger, network } = setupControllers();
     assetsContract.configure({
       provider: MAINNET_PROVIDER,
     });
@@ -259,9 +301,11 @@ describe('AssetsContractController', () => {
       [ERC20_DAI_ADDRESS],
     );
     expect(noBalances).toStrictEqual({});
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should throw missing provider error when transfering single ERC-1155 when missing provider', async () => {
+    const { assetsContract, messenger } = setupControllers();
     assetsContract.configure({ provider: undefined });
     await expect(
       assetsContract.transferSingleERC1155(
@@ -272,9 +316,11 @@ describe('AssetsContractController', () => {
         '1',
       ),
     ).rejects.toThrow(MISSING_PROVIDER_ERROR);
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should get the balance of a ERC-1155 collectible for a given address', async () => {
+    const { assetsContract, messenger } = setupControllers();
     assetsContract.configure({ provider: MAINNET_PROVIDER });
     const balance = await assetsContract.getERC1155BalanceOf(
       TEST_ACCOUNT_PUBLIC_ADDRESS,
@@ -282,9 +328,11 @@ describe('AssetsContractController', () => {
       ERC1155_ID,
     );
     expect(Number(balance)).toBeGreaterThan(0);
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should throw missing provider error when getting the balance of a ERC-1155 collectible when missing provider', async () => {
+    const { assetsContract, messenger } = setupControllers();
     await expect(
       assetsContract.getERC1155BalanceOf(
         TEST_ACCOUNT_PUBLIC_ADDRESS,
@@ -292,9 +340,11 @@ describe('AssetsContractController', () => {
         ERC1155_ID,
       ),
     ).rejects.toThrow(MISSING_PROVIDER_ERROR);
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should get the URI of a ERC-1155 collectible', async () => {
+    const { assetsContract, messenger } = setupControllers();
     assetsContract.configure({ provider: MAINNET_PROVIDER });
     const expectedUri = `https://api.opensea.io/api/v1/metadata/${ERC1155_ADDRESS}/0x{id}`;
     const uri = await assetsContract.getERC1155TokenURI(
@@ -302,5 +352,6 @@ describe('AssetsContractController', () => {
       ERC1155_ID,
     );
     expect(uri.toLowerCase()).toStrictEqual(expectedUri);
+    messenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 });

--- a/src/assets/CollectibleDetectionController.test.ts
+++ b/src/assets/CollectibleDetectionController.test.ts
@@ -1,8 +1,12 @@
 import sinon from 'sinon';
 import nock from 'nock';
-import { NetworkController } from '../network/NetworkController';
+import {
+  NetworkController,
+  NetworkControllerMessenger,
+} from '../network/NetworkController';
 import { PreferencesController } from '../user/PreferencesController';
 import { OPENSEA_PROXY_URL } from '../constants';
+import { ControllerMessenger } from '../ControllerMessenger';
 import { CollectiblesController } from './CollectiblesController';
 import { AssetsContractController } from './AssetsContractController';
 import { CollectibleDetectionController } from './CollectibleDetectionController';
@@ -14,9 +18,9 @@ const ROPSTEN = 'ropsten';
 describe('CollectibleDetectionController', () => {
   let collectibleDetection: CollectibleDetectionController;
   let preferences: PreferencesController;
-  let network: NetworkController;
   let collectiblesController: CollectiblesController;
   let assetsContract: AssetsContractController;
+  let messenger: NetworkControllerMessenger;
 
   const getOpenSeaApiKeyStub = jest.fn();
   beforeAll(() => {
@@ -28,16 +32,27 @@ describe('CollectibleDetectionController', () => {
   });
 
   beforeEach(async () => {
+    messenger = new ControllerMessenger().getRestricted({
+      name: 'NetworkController',
+      allowedEvents: ['NetworkController:stateChange'],
+      allowedActions: [],
+    });
+
+    new NetworkController({
+      messenger,
+      infuraProjectId: 'potato',
+    });
     preferences = new PreferencesController();
-    network = new NetworkController();
     assetsContract = new AssetsContractController({
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        messenger.subscribe('NetworkController:stateChange', listener),
     });
 
     collectiblesController = new CollectiblesController({
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        messenger.subscribe('NetworkController:stateChange', listener),
       getERC721AssetName:
         assetsContract.getERC721AssetName.bind(assetsContract),
       getERC721AssetSymbol:
@@ -55,7 +70,8 @@ describe('CollectibleDetectionController', () => {
       onCollectiblesStateChange: (listener) =>
         collectiblesController.subscribe(listener),
       onPreferencesStateChange: (listener) => preferences.subscribe(listener),
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        messenger.subscribe('NetworkController:stateChange', listener),
       getOpenSeaApiKey: getOpenSeaApiKeyStub,
       addCollectible: collectiblesController.addCollectible.bind(
         collectiblesController,
@@ -226,7 +242,8 @@ describe('CollectibleDetectionController', () => {
               collectiblesController.subscribe(listener),
             onPreferencesStateChange: (listener) =>
               preferences.subscribe(listener),
-            onNetworkStateChange: (listener) => network.subscribe(listener),
+            onNetworkStateChange: (listener) =>
+              messenger.subscribe('NetworkController:stateChange', listener),
             getOpenSeaApiKey: () => collectiblesController.openSeaApiKey,
             addCollectible: collectiblesController.addCollectible.bind(
               collectiblesController,
@@ -264,7 +281,8 @@ describe('CollectibleDetectionController', () => {
             collectiblesController.subscribe(listener),
           onPreferencesStateChange: (listener) =>
             preferences.subscribe(listener),
-          onNetworkStateChange: (listener) => network.subscribe(listener),
+          onNetworkStateChange: (listener) =>
+            messenger.subscribe('NetworkController:stateChange', listener),
           getOpenSeaApiKey: () => collectiblesController.openSeaApiKey,
           addCollectible: collectiblesController.addCollectible.bind(
             collectiblesController,

--- a/src/assets/TokenBalancesController.test.ts
+++ b/src/assets/TokenBalancesController.test.ts
@@ -22,8 +22,6 @@ const stubCreateEthers = (ctrl: TokensController, res: boolean) => {
   });
 };
 
-const INFURA_PROJECT_ID = 'ad3a368836ff4596becc3be8e2f137ac';
-
 describe('TokenBalancesController', () => {
   const getToken = (
     tokenBalances: TokenBalancesController,
@@ -133,7 +131,7 @@ describe('TokenBalancesController', () => {
 
       new NetworkController({
         messenger,
-        infuraProjectId: INFURA_PROJECT_ID,
+        infuraProjectId: 'potato',
       });
       preferences = new PreferencesController();
     });

--- a/src/assets/TokenDetectionController.test.ts
+++ b/src/assets/TokenDetectionController.test.ts
@@ -83,13 +83,20 @@ const sampleTokenB: Token = {
   aggregators: formattedSampleAggregators,
 };
 
-type MainControllerMessenger = ControllerMessenger<GetTokenListState, TokenListStateChange | NetworkControllerProviderChangeEvent | NetworkControllerStateChangeEvent>;
+type MainControllerMessenger = ControllerMessenger<
+  GetTokenListState,
+  | TokenListStateChange
+  | NetworkControllerProviderChangeEvent
+  | NetworkControllerStateChangeEvent
+>;
 
 const getControllerMessenger = (): MainControllerMessenger => {
   return new ControllerMessenger();
 };
 
-const setupNetworkController = (controllerMessenger: MainControllerMessenger) => {
+const setupNetworkController = (
+  controllerMessenger: MainControllerMessenger,
+) => {
   const networkMessenger = controllerMessenger.getRestricted({
     name: 'NetworkController',
     allowedEvents: [
@@ -107,13 +114,15 @@ const setupNetworkController = (controllerMessenger: MainControllerMessenger) =>
   return { network, networkMessenger };
 };
 
-const setupTokenListController = (controllerMessenger: MainControllerMessenger) =>{
+const setupTokenListController = (
+  controllerMessenger: MainControllerMessenger,
+) => {
   const tokenListMessenger = controllerMessenger.getRestricted({
     name: 'TokenListController',
     allowedActions: [],
     allowedEvents: [
       'TokenListController:stateChange',
-      'NetworkController:providerChange'
+      'NetworkController:providerChange',
     ],
   });
 
@@ -124,7 +133,7 @@ const setupTokenListController = (controllerMessenger: MainControllerMessenger) 
   });
 
   return { tokenList, tokenListMessenger };
-}
+};
 
 describe('TokenDetectionController', () => {
   let tokenDetection: TokenDetectionController;
@@ -172,7 +181,10 @@ describe('TokenDetectionController', () => {
       onNetworkStateChange: (listener) =>
         networkMessenger.subscribe('NetworkController:stateChange', listener),
       onTokenListStateChange: (listener) =>
-        tokenListSetup.tokenListMessenger.subscribe(`TokenListController:stateChange`, listener),
+        tokenListSetup.tokenListMessenger.subscribe(
+          `TokenListController:stateChange`,
+          listener,
+        ),
       getBalancesInSingleCall:
         getBalancesInSingleCall as unknown as AssetsContractController['getBalancesInSingleCall'],
       addDetectedTokens:
@@ -193,7 +205,9 @@ describe('TokenDetectionController', () => {
     sinon.restore();
     tokenDetection.stop();
     tokenList.destroy();
-    controllerMessenger.clearEventSubscriptions('NetworkController:stateChange');
+    controllerMessenger.clearEventSubscriptions(
+      'NetworkController:stateChange',
+    );
   });
 
   it('should set default config', () => {

--- a/src/assets/TokenListController.test.ts
+++ b/src/assets/TokenListController.test.ts
@@ -4,6 +4,7 @@ import { TOKEN_END_POINT_API } from '../apis/token-service';
 import { ControllerMessenger } from '../ControllerMessenger';
 import {
   NetworkController,
+  NetworkControllerMessenger,
   NetworksChainId,
 } from '../network/NetworkController';
 import {
@@ -493,13 +494,24 @@ function getRestrictedMessenger() {
 
 describe('TokenListController', () => {
   let network: NetworkController;
+  let networkMessenger: NetworkControllerMessenger;
   beforeEach(() => {
-    network = new NetworkController();
+    networkMessenger = new ControllerMessenger().getRestricted({
+      name: 'NetworkController',
+      allowedEvents: ['NetworkController:stateChange'],
+      allowedActions: [],
+    });
+
+    network = new NetworkController({
+      messenger: networkMessenger,
+      infuraProjectId: '123',
+    });
   });
 
   afterEach(() => {
     nock.cleanAll();
     sinon.restore();
+    networkMessenger.clearEventSubscriptions('NetworkController:stateChange');
   });
 
   it('should set default state', async () => {
@@ -507,7 +519,8 @@ describe('TokenListController', () => {
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        networkMessenger.subscribe('NetworkController:stateChange', listener),
       messenger,
     });
 
@@ -525,7 +538,8 @@ describe('TokenListController', () => {
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        networkMessenger.subscribe('NetworkController:stateChange', listener),
       messenger,
       state: existingState,
     });
@@ -566,11 +580,12 @@ describe('TokenListController', () => {
     controller.destroy();
   });
 
-  it('should set initiate without preventPollingOnNetworkRestart', async () => {
+  it('should initiate without preventPollingOnNetworkRestart', async () => {
     const messenger = getRestrictedMessenger();
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        networkMessenger.subscribe('NetworkController:stateChange', listener),
       messenger,
     });
 
@@ -588,7 +603,8 @@ describe('TokenListController', () => {
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        networkMessenger.subscribe('NetworkController:stateChange', listener),
       interval: 100,
       messenger,
     });
@@ -609,7 +625,8 @@ describe('TokenListController', () => {
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        networkMessenger.subscribe('NetworkController:stateChange', listener),
       interval: 100,
       messenger,
     });
@@ -634,7 +651,8 @@ describe('TokenListController', () => {
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        networkMessenger.subscribe('NetworkController:stateChange', listener),
       interval: 100,
       messenger,
     });
@@ -661,7 +679,8 @@ describe('TokenListController', () => {
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        networkMessenger.subscribe('NetworkController:stateChange', listener),
       interval: 100,
       messenger,
     });
@@ -691,7 +710,8 @@ describe('TokenListController', () => {
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        networkMessenger.subscribe('NetworkController:stateChange', listener),
       interval: 100,
       messenger,
     });
@@ -715,7 +735,8 @@ describe('TokenListController', () => {
     const controller = new TokenListController({
       chainId: NetworksChainId.localhost,
       preventPollingOnNetworkRestart: false,
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        networkMessenger.subscribe('NetworkController:stateChange', listener),
       interval: 100,
       messenger,
     });
@@ -738,7 +759,8 @@ describe('TokenListController', () => {
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        networkMessenger.subscribe('NetworkController:stateChange', listener),
       messenger,
     });
     await controller.start();
@@ -775,7 +797,8 @@ describe('TokenListController', () => {
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        networkMessenger.subscribe('NetworkController:stateChange', listener),
       messenger,
       interval: 100,
     });
@@ -798,7 +821,8 @@ describe('TokenListController', () => {
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        networkMessenger.subscribe('NetworkController:stateChange', listener),
       messenger,
       state: existingState,
     });
@@ -825,7 +849,8 @@ describe('TokenListController', () => {
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        networkMessenger.subscribe('NetworkController:stateChange', listener),
       messenger,
     });
     await controller.start();
@@ -867,7 +892,8 @@ describe('TokenListController', () => {
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        networkMessenger.subscribe('NetworkController:stateChange', listener),
       messenger,
     });
     await controller.start();
@@ -890,7 +916,8 @@ describe('TokenListController', () => {
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        networkMessenger.subscribe('NetworkController:stateChange', listener),
       messenger,
       state: outdatedExistingState,
     });
@@ -917,7 +944,8 @@ describe('TokenListController', () => {
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        networkMessenger.subscribe('NetworkController:stateChange', listener),
       messenger,
       state: expiredCacheExistingState,
     });
@@ -951,7 +979,8 @@ describe('TokenListController', () => {
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        networkMessenger.subscribe('NetworkController:stateChange', listener),
       messenger,
       state: existingState,
       interval: 100,
@@ -968,12 +997,8 @@ describe('TokenListController', () => {
       sampleTwoChainState.tokensChainsCache[NetworksChainId.mainnet].data,
     );
 
-    network.update({
-      provider: {
-        type: 'ropsten',
-        chainId: NetworksChainId.ropsten,
-      },
-    });
+    network.setProviderType('ropsten');
+
     await new Promise<void>((resolve) => setTimeout(() => resolve(), 10));
     expect(controller.state.tokenList).toStrictEqual({});
     expect(
@@ -982,12 +1007,8 @@ describe('TokenListController', () => {
       sampleTwoChainState.tokensChainsCache[NetworksChainId.mainnet].data,
     );
 
-    network.update({
-      provider: {
-        type: 'rpc',
-        chainId: '56',
-      },
-    });
+    network.setRpcTarget('http://localhost', '56');
+
     await new Promise<void>((resolve) => setTimeout(() => resolve(), 10));
     expect(controller.state.tokenList).toStrictEqual(
       sampleTwoChainState.tokenList,
@@ -1011,7 +1032,8 @@ describe('TokenListController', () => {
     const controller = new TokenListController({
       chainId: NetworksChainId.mainnet,
       preventPollingOnNetworkRestart: false,
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        networkMessenger.subscribe('NetworkController:stateChange', listener),
       messenger,
       state: existingState,
     });
@@ -1037,17 +1059,13 @@ describe('TokenListController', () => {
     const controller = new TokenListController({
       chainId: NetworksChainId.ropsten,
       preventPollingOnNetworkRestart: true,
-      onNetworkStateChange: (listener) => network.subscribe(listener),
+      onNetworkStateChange: (listener) =>
+        networkMessenger.subscribe('NetworkController:stateChange', listener),
       messenger,
       interval: 100,
     });
     await controller.start();
-    network.update({
-      provider: {
-        type: 'mainnet',
-        chainId: NetworksChainId.mainnet,
-      },
-    });
+    network.setProviderType('mainnet');
 
     expect(controller.state).toStrictEqual({
       tokenList: {},
@@ -1082,12 +1100,7 @@ describe('TokenListController', () => {
         resolve();
       });
 
-      network.update({
-        provider: {
-          type: 'rpc',
-          chainId: '56',
-        },
-      });
+      network.setRpcTarget('http://localhost', '56');
     });
   });
 });

--- a/src/assets/TokenListController.test.ts
+++ b/src/assets/TokenListController.test.ts
@@ -471,18 +471,21 @@ const expiredCacheExistingState: TokenListState = {
   preventPollingOnNetworkRestart: false,
 };
 
-type MainControllerMessenger = ControllerMessenger<GetTokenListState, TokenListStateChange | NetworkControllerProviderChangeEvent>;
+type MainControllerMessenger = ControllerMessenger<
+  GetTokenListState,
+  TokenListStateChange | NetworkControllerProviderChangeEvent
+>;
 
 const getControllerMessenger = (): MainControllerMessenger => {
   return new ControllerMessenger();
 };
 
-const setupNetworkController = (controllerMessenger: MainControllerMessenger) => {
+const setupNetworkController = (
+  controllerMessenger: MainControllerMessenger,
+) => {
   const networkMessenger = controllerMessenger.getRestricted({
     name: 'NetworkController',
-    allowedEvents: [
-      'NetworkController:providerChange',
-    ],
+    allowedEvents: ['NetworkController:providerChange'],
     allowedActions: [],
   });
 
@@ -494,23 +497,20 @@ const setupNetworkController = (controllerMessenger: MainControllerMessenger) =>
   return { network, networkMessenger };
 };
 
-/**
- * Get a TokenListController restricted controller messenger.
- *
- * @returns A restricted controller messenger for the TokenListController.
- */
-function getRestrictedMessenger(controllerMessenger: MainControllerMessenger) {
+const getRestrictedMessenger = (
+  controllerMessenger: MainControllerMessenger,
+) => {
   const messenger = controllerMessenger.getRestricted({
     name,
     allowedActions: [],
     allowedEvents: [
       'TokenListController:stateChange',
-      'NetworkController:providerChange'
+      'NetworkController:providerChange',
     ],
   });
 
   return messenger;
-}
+};
 
 describe('TokenListController', () => {
   afterEach(() => {
@@ -535,7 +535,9 @@ describe('TokenListController', () => {
     });
 
     controller.destroy();
-    controllerMessenger.clearEventSubscriptions('NetworkController:providerChange');
+    controllerMessenger.clearEventSubscriptions(
+      'NetworkController:providerChange',
+    );
   });
 
   it('should initialize with initial state', () => {
@@ -583,7 +585,9 @@ describe('TokenListController', () => {
     });
 
     controller.destroy();
-    controllerMessenger.clearEventSubscriptions('NetworkController:providerChange');
+    controllerMessenger.clearEventSubscriptions(
+      'NetworkController:providerChange',
+    );
   });
 
   it('should initiate without preventPollingOnNetworkRestart', async () => {
@@ -602,7 +606,9 @@ describe('TokenListController', () => {
     });
 
     controller.destroy();
-    controllerMessenger.clearEventSubscriptions('NetworkController:providerChange');
+    controllerMessenger.clearEventSubscriptions(
+      'NetworkController:providerChange',
+    );
   });
 
   it('should not poll before being started', async () => {
@@ -620,7 +626,9 @@ describe('TokenListController', () => {
     expect(controller.state.tokenList).toStrictEqual({});
 
     controller.destroy();
-    controllerMessenger.clearEventSubscriptions('NetworkController:providerChange');
+    controllerMessenger.clearEventSubscriptions(
+      'NetworkController:providerChange',
+    );
   });
 
   it('should poll and update rate in the right interval', async () => {
@@ -647,7 +655,9 @@ describe('TokenListController', () => {
     expect(tokenListMock.calledTwice).toBe(true);
 
     controller.destroy();
-    controllerMessenger.clearEventSubscriptions('NetworkController:providerChange');
+    controllerMessenger.clearEventSubscriptions(
+      'NetworkController:providerChange',
+    );
   });
 
   it('should not poll after being stopped', async () => {
@@ -676,7 +686,9 @@ describe('TokenListController', () => {
     expect(tokenListMock.calledTwice).toBe(false);
 
     controller.destroy();
-    controllerMessenger.clearEventSubscriptions('NetworkController:providerChange');
+    controllerMessenger.clearEventSubscriptions(
+      'NetworkController:providerChange',
+    );
   });
 
   it('should poll correctly after being started, stopped, and started again', async () => {
@@ -709,7 +721,9 @@ describe('TokenListController', () => {
     await new Promise<void>((resolve) => setTimeout(() => resolve(), 150));
     expect(tokenListMock.calledThrice).toBe(true);
     controller.destroy();
-    controllerMessenger.clearEventSubscriptions('NetworkController:providerChange');
+    controllerMessenger.clearEventSubscriptions(
+      'NetworkController:providerChange',
+    );
   });
 
   it('should call fetchTokenList on network that supports token detection', async () => {
@@ -733,7 +747,9 @@ describe('TokenListController', () => {
     // called once upon initial start
     expect(tokenListMock.called).toBe(true);
     controller.destroy();
-    controllerMessenger.clearEventSubscriptions('NetworkController:providerChange');
+    controllerMessenger.clearEventSubscriptions(
+      'NetworkController:providerChange',
+    );
   });
 
   it('should not call fetchTokenList on network that does not support token detection', async () => {
@@ -759,7 +775,9 @@ describe('TokenListController', () => {
 
     controller.destroy();
     tokenListMock.restore();
-    controllerMessenger.clearEventSubscriptions('NetworkController:providerChange');
+    controllerMessenger.clearEventSubscriptions(
+      'NetworkController:providerChange',
+    );
   });
 
   it('should update token list from api', async () => {
@@ -794,7 +812,9 @@ describe('TokenListController', () => {
         .timestamp,
     );
     controller.destroy();
-    controllerMessenger.clearEventSubscriptions('NetworkController:providerChange');
+    controllerMessenger.clearEventSubscriptions(
+      'NetworkController:providerChange',
+    );
   });
 
   it('should update the cache before threshold time if the current data is undefined', async () => {
@@ -829,7 +849,9 @@ describe('TokenListController', () => {
       sampleSingleChainState.tokensChainsCache['1'].data,
     );
     controller.destroy();
-    controllerMessenger.clearEventSubscriptions('NetworkController:providerChange');
+    controllerMessenger.clearEventSubscriptions(
+      'NetworkController:providerChange',
+    );
   });
 
   it('should update token list from cache before reaching the threshold time', async () => {
@@ -854,7 +876,9 @@ describe('TokenListController', () => {
       sampleSingleChainState.tokensChainsCache[NetworksChainId.mainnet].data,
     );
     controller.destroy();
-    controllerMessenger.clearEventSubscriptions('NetworkController:providerChange');
+    controllerMessenger.clearEventSubscriptions(
+      'NetworkController:providerChange',
+    );
   });
 
   it('should update token list after removing data with duplicate symbols', async () => {
@@ -899,7 +923,9 @@ describe('TokenListController', () => {
       controller.state.tokensChainsCache[NetworksChainId.mainnet].data,
     ).toStrictEqual(sampleWithDuplicateSymbolsTokensChainsCache);
     controller.destroy();
-    controllerMessenger.clearEventSubscriptions('NetworkController:providerChange');
+    controllerMessenger.clearEventSubscriptions(
+      'NetworkController:providerChange',
+    );
   });
 
   it('should update token list after removing data less than 3 occurrences', async () => {
@@ -925,7 +951,9 @@ describe('TokenListController', () => {
       controller.state.tokensChainsCache[NetworksChainId.mainnet].data,
     ).toStrictEqual(sampleWith3OrMoreOccurrences);
     controller.destroy();
-    controllerMessenger.clearEventSubscriptions('NetworkController:providerChange');
+    controllerMessenger.clearEventSubscriptions(
+      'NetworkController:providerChange',
+    );
   });
 
   it('should update token list when the token property changes', async () => {
@@ -955,7 +983,9 @@ describe('TokenListController', () => {
       sampleSingleChainState.tokensChainsCache[NetworksChainId.mainnet].data,
     );
     controller.destroy();
-    controllerMessenger.clearEventSubscriptions('NetworkController:providerChange');
+    controllerMessenger.clearEventSubscriptions(
+      'NetworkController:providerChange',
+    );
   });
 
   it('should update the cache when the timestamp expires', async () => {
@@ -988,7 +1018,9 @@ describe('TokenListController', () => {
       sampleSingleChainState.tokensChainsCache[NetworksChainId.mainnet].data,
     );
     controller.destroy();
-    controllerMessenger.clearEventSubscriptions('NetworkController:providerChange');
+    controllerMessenger.clearEventSubscriptions(
+      'NetworkController:providerChange',
+    );
   });
 
   it('should update token list when the chainId change', async () => {
@@ -1052,7 +1084,9 @@ describe('TokenListController', () => {
     );
 
     controller.destroy();
-    controllerMessenger.clearEventSubscriptions('NetworkController:providerChange');
+    controllerMessenger.clearEventSubscriptions(
+      'NetworkController:providerChange',
+    );
   });
 
   it('should clear the tokenList and tokensChainsCache', async () => {
@@ -1072,7 +1106,9 @@ describe('TokenListController', () => {
     expect(controller.state.tokensChainsCache).toStrictEqual({});
 
     controller.destroy();
-    controllerMessenger.clearEventSubscriptions('NetworkController:providerChange');
+    controllerMessenger.clearEventSubscriptions(
+      'NetworkController:providerChange',
+    );
   });
 
   it('should update preventPollingOnNetworkRestart and restart the polling on network restart', async () => {
@@ -1127,7 +1163,9 @@ describe('TokenListController', () => {
         );
         messenger.clearEventSubscriptions('TokenListController:stateChange');
         controller.destroy();
-        controllerMessenger.clearEventSubscriptions('NetworkController:providerChange');
+        controllerMessenger.clearEventSubscriptions(
+          'NetworkController:providerChange',
+        );
         resolve();
       });
 

--- a/src/assets/TokenListController.test.ts
+++ b/src/assets/TokenListController.test.ts
@@ -4,7 +4,6 @@ import { TOKEN_END_POINT_API } from '../apis/token-service';
 import { ControllerMessenger } from '../ControllerMessenger';
 import {
   NetworkController,
-  NetworkControllerMessenger,
   NetworkControllerProviderChangeEvent,
   NetworksChainId,
 } from '../network/NetworkController';

--- a/src/assets/TokenRatesController.test.ts
+++ b/src/assets/TokenRatesController.test.ts
@@ -17,8 +17,8 @@ const COINGECKO_ASSETS_PATH = '/asset_platforms';
 const COINGECKO_SUPPORTED_CURRENCIES = '/simple/supported_vs_currencies';
 const ADDRESS = '0x01';
 
-let messenger: NetworkControllerMessenger;
 describe('TokenRatesController', () => {
+  let messenger: NetworkControllerMessenger;
   beforeEach(() => {
     nock(COINGECKO_API)
       .get(COINGECKO_ASSETS_PATH)

--- a/src/gas/GasFeeController.test.ts
+++ b/src/gas/GasFeeController.test.ts
@@ -3,8 +3,8 @@ import { mocked } from 'ts-jest/utils';
 import { ControllerMessenger } from '../ControllerMessenger';
 import {
   NetworkController,
-  NetworkControllerGetEthQuery,
-  NetworkControllerGetProviderConfig,
+  NetworkControllerGetEthQueryAction,
+  NetworkControllerGetProviderConfigAction,
   NetworkControllerProviderChangeEvent,
 } from '../network/NetworkController';
 import {
@@ -30,8 +30,8 @@ const name = 'GasFeeController';
 
 type MainControllerMessenger = ControllerMessenger<
   | GetGasFeeState
-  | NetworkControllerGetProviderConfig
-  | NetworkControllerGetEthQuery,
+  | NetworkControllerGetProviderConfigAction
+  | NetworkControllerGetEthQueryAction,
   GasFeeStateChange | NetworkControllerProviderChangeEvent
 >;
 

--- a/src/gas/GasFeeController.test.ts
+++ b/src/gas/GasFeeController.test.ts
@@ -2,6 +2,12 @@ import sinon, { SinonFakeTimers } from 'sinon';
 import { mocked } from 'ts-jest/utils';
 import { ControllerMessenger } from '../ControllerMessenger';
 import {
+  NetworkController,
+  NetworkControllerGetEthQuery,
+  NetworkControllerGetProviderConfig,
+  NetworkControllerProviderChangeEvent,
+} from '../network/NetworkController';
+import {
   GAS_ESTIMATE_TYPES,
   GasFeeController,
   GasFeeState,
@@ -22,25 +28,51 @@ const mockedDetermineGasFeeCalculations = mocked(
 
 const name = 'GasFeeController';
 
-/**
- * Constructs a restricted controller messenger.
- *
- * @returns A restricted controller messenger.
- */
-function getRestrictedMessenger() {
-  const controllerMessenger = new ControllerMessenger<
-    GetGasFeeState,
-    GasFeeStateChange
-  >();
-  const messenger = controllerMessenger.getRestricted<
-    typeof name,
-    never,
-    never
-  >({
-    name,
+type MainControllerMessenger = ControllerMessenger<
+  | GetGasFeeState
+  | NetworkControllerGetProviderConfig
+  | NetworkControllerGetEthQuery,
+  GasFeeStateChange | NetworkControllerProviderChangeEvent
+>;
+
+const getControllerMessenger = (): MainControllerMessenger => {
+  return new ControllerMessenger();
+};
+
+const setupNetworkController = (
+  controllerMessenger: MainControllerMessenger,
+) => {
+  const networkMessenger = controllerMessenger.getRestricted({
+    name: 'NetworkController',
+    allowedEvents: ['NetworkController:providerChange'],
+    allowedActions: [
+      'NetworkController:getProviderConfig',
+      'NetworkController:getEthQuery',
+    ],
   });
+
+  const network = new NetworkController({
+    messenger: networkMessenger,
+    infuraProjectId: '123',
+  });
+
+  return { network, networkMessenger };
+};
+
+const getRestrictedMessenger = (
+  controllerMessenger: MainControllerMessenger,
+) => {
+  const messenger = controllerMessenger.getRestricted({
+    name,
+    allowedActions: [
+      'NetworkController:getProviderConfig',
+      'NetworkController:getEthQuery',
+    ],
+    allowedEvents: ['NetworkController:providerChange'],
+  });
+
   return messenger;
-}
+};
 
 /**
  * Builds mock gas fee state that would typically be generated for an EIP-1559-compatible network.
@@ -160,7 +192,6 @@ describe('GasFeeController', () => {
    * @param options.clientId - Sets clientId on the GasFeeController.
    */
   function setupGasFeeController({
-    getChainId = jest.fn().mockReturnValue('0x1'),
     getIsEIP1559Compatible = jest.fn().mockResolvedValue(true),
     getCurrentNetworkLegacyGasAPICompatibility = jest
       .fn()
@@ -176,11 +207,11 @@ describe('GasFeeController', () => {
     EIP1559APIEndpoint?: string;
     clientId?: string;
   } = {}) {
+    const controllerMessenger = getControllerMessenger();
+    setupNetworkController(controllerMessenger);
+    const messenger = getRestrictedMessenger(controllerMessenger);
     gasFeeController = new GasFeeController({
-      messenger: getRestrictedMessenger(),
-      getProvider: jest.fn(),
-      getChainId,
-      onNetworkStateChange: jest.fn(),
+      messenger,
       getCurrentNetworkLegacyGasAPICompatibility,
       getCurrentNetworkEIP1559Compatibility: getIsEIP1559Compatible, // change this for networkController.state.properties.isEIP1559Compatible ???
       legacyAPIEndpoint,

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -1,14 +1,14 @@
 import type { Patch } from 'immer';
 
-import EthQuery from 'eth-query';
 import { v1 as random } from 'uuid';
 import { isHexString } from 'ethereumjs-util';
 import { BaseController } from '../BaseControllerV2';
 import { safelyExecute } from '../util';
 import type { RestrictedControllerMessenger } from '../ControllerMessenger';
 import type {
-  NetworkController,
-  NetworkState,
+  NetworkControllerGetEthQuery,
+  NetworkControllerGetProviderConfig,
+  NetworkControllerProviderChangeEvent,
 } from '../network/NetworkController';
 import {
   fetchGasEstimates,
@@ -102,7 +102,6 @@ export type LegacyGasPriceEstimate = {
  * @property suggestedMaxPriorityFeePerGas - A suggested "tip", a GWEI hex number
  * @property suggestedMaxFeePerGas - A suggested max fee, the most a user will pay. a GWEI hex number
  */
-
 export type Eip1559GasFee = {
   minWaitTimeEstimate: number; // a time duration in milliseconds
   maxWaitTimeEstimate: number; // a time duration in milliseconds
@@ -121,7 +120,6 @@ export type Eip1559GasFee = {
  * @property networkCongestion - A normalized number that can be used to gauge the congestion
  * level of the network, with 0 meaning not congested and 1 meaning extremely congested
  */
-
 export type GasFeeEstimates = SourcedGasFeeEstimates | FallbackGasFeeEstimates;
 
 type SourcedGasFeeEstimates = {
@@ -211,10 +209,13 @@ export type GetGasFeeState = {
 
 type GasFeeMessenger = RestrictedControllerMessenger<
   typeof name,
-  GetGasFeeState,
-  GasFeeStateChange,
-  never,
-  never
+  | GetGasFeeState
+  | NetworkControllerGetProviderConfig
+  | NetworkControllerGetEthQuery,
+  GasFeeStateChange | NetworkControllerProviderChangeEvent,
+  | NetworkControllerGetProviderConfig['type']
+  | NetworkControllerGetEthQuery['type'],
+  NetworkControllerProviderChangeEvent['type']
 >;
 
 const defaultState: GasFeeState = {
@@ -222,6 +223,8 @@ const defaultState: GasFeeState = {
   estimatedGasFeeTimeBounds: {},
   gasEstimateType: GAS_ESTIMATE_TYPES.NONE,
 };
+
+export type ChainID = `0x${string}` | `${number}` | number;
 
 /**
  * Controller that retrieves gas fee estimate data and polls for updated data on a set interval
@@ -247,8 +250,6 @@ export class GasFeeController extends BaseController<
 
   private getCurrentAccountEIP1559Compatibility;
 
-  private getChainId;
-
   private currentChainId;
 
   private ethQuery: any;
@@ -268,10 +269,6 @@ export class GasFeeController extends BaseController<
    * current network is compatible with the legacy gas price API.
    * @param options.getCurrentAccountEIP1559Compatibility - Determines whether or not the current
    * account is EIP-1559 compatible.
-   * @param options.getChainId - Returns the current chain ID.
-   * @param options.getProvider - Returns a network provider for the current network.
-   * @param options.onNetworkStateChange - A function for registering an event handler for the
-   * network state change event.
    * @param options.legacyAPIEndpoint - The legacy gas price API URL. This option is primarily for
    * testing purposes.
    * @param options.EIP1559APIEndpoint - The EIP-1559 gas price API URL. This option is primarily
@@ -285,10 +282,7 @@ export class GasFeeController extends BaseController<
     state,
     getCurrentNetworkEIP1559Compatibility,
     getCurrentAccountEIP1559Compatibility,
-    getChainId,
     getCurrentNetworkLegacyGasAPICompatibility,
-    getProvider,
-    onNetworkStateChange,
     legacyAPIEndpoint = LEGACY_GAS_PRICES_API_URL,
     EIP1559APIEndpoint = GAS_FEE_API,
     clientId,
@@ -299,9 +293,6 @@ export class GasFeeController extends BaseController<
     getCurrentNetworkEIP1559Compatibility: () => Promise<boolean>;
     getCurrentNetworkLegacyGasAPICompatibility: () => boolean;
     getCurrentAccountEIP1559Compatibility?: () => boolean;
-    getChainId: () => `0x${string}` | `${number}` | number;
-    getProvider: () => NetworkController['provider'];
-    onNetworkStateChange: (listener: (state: NetworkState) => void) => void;
     legacyAPIEndpoint?: string;
     EIP1559APIEndpoint?: string;
     clientId?: string;
@@ -324,20 +315,25 @@ export class GasFeeController extends BaseController<
       getCurrentAccountEIP1559Compatibility;
     this.EIP1559APIEndpoint = EIP1559APIEndpoint;
     this.legacyAPIEndpoint = legacyAPIEndpoint;
-    this.getChainId = getChainId;
-    this.currentChainId = this.getChainId();
-    const provider = getProvider();
-    this.ethQuery = new EthQuery(provider);
+    const providerConfig = this.messagingSystem.call(
+      'NetworkController:getProviderConfig',
+    );
+    this.currentChainId = providerConfig.chainId;
+    this.ethQuery = this.messagingSystem.call('NetworkController:getEthQuery');
     this.clientId = clientId;
-    onNetworkStateChange(async () => {
-      const newProvider = getProvider();
-      const newChainId = this.getChainId();
-      this.ethQuery = new EthQuery(newProvider);
-      if (this.currentChainId !== newChainId) {
-        this.currentChainId = newChainId;
-        await this.resetPolling();
-      }
-    });
+    this.messagingSystem.subscribe(
+      'NetworkController:providerChange',
+      async (provider) => {
+        this.ethQuery = this.messagingSystem.call(
+          'NetworkController:getEthQuery',
+        );
+
+        if (this.currentChainId !== provider.chainId) {
+          this.currentChainId = provider.chainId;
+          await this.resetPolling();
+        }
+      },
+    );
   }
 
   async resetPolling() {
@@ -386,9 +382,15 @@ export class GasFeeController extends BaseController<
     const isLegacyGasAPICompatible =
       this.getCurrentNetworkLegacyGasAPICompatibility();
 
-    let chainId = this.getChainId();
-    if (typeof chainId === 'string' && isHexString(chainId)) {
-      chainId = parseInt(chainId, 16);
+    let chainId: number;
+    if (typeof this.currentChainId === 'string') {
+      if (isHexString(this.currentChainId)) {
+        chainId = parseInt(this.currentChainId, 16);
+      } else {
+        chainId = parseInt(this.currentChainId, 10);
+      }
+    } else {
+      chainId = this.currentChainId;
     }
 
     try {

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -6,8 +6,8 @@ import { BaseController } from '../BaseControllerV2';
 import { safelyExecute } from '../util';
 import type { RestrictedControllerMessenger } from '../ControllerMessenger';
 import type {
-  NetworkControllerGetEthQuery,
-  NetworkControllerGetProviderConfig,
+  NetworkControllerGetEthQueryAction,
+  NetworkControllerGetProviderConfigAction,
   NetworkControllerProviderChangeEvent,
 } from '../network/NetworkController';
 import {
@@ -210,11 +210,11 @@ export type GetGasFeeState = {
 type GasFeeMessenger = RestrictedControllerMessenger<
   typeof name,
   | GetGasFeeState
-  | NetworkControllerGetProviderConfig
-  | NetworkControllerGetEthQuery,
+  | NetworkControllerGetProviderConfigAction
+  | NetworkControllerGetEthQueryAction,
   GasFeeStateChange | NetworkControllerProviderChangeEvent,
-  | NetworkControllerGetProviderConfig['type']
-  | NetworkControllerGetEthQuery['type'],
+  | NetworkControllerGetProviderConfigAction['type']
+  | NetworkControllerGetEthQueryAction['type'],
   NetworkControllerProviderChangeEvent['type']
 >;
 

--- a/src/network/NetworkController.test.ts
+++ b/src/network/NetworkController.test.ts
@@ -12,10 +12,9 @@ import {
 
 const RPC_TARGET = 'http://foo';
 
-const checkNetwork = (
+const setupController = (
   pType: NetworkType,
   messenger: NetworkControllerMessenger,
-  expectIsCustomNetwork = false,
 ) => {
   const networkControllerOpts: NetworkControllerOptions = {
     infuraProjectId: 'foo',
@@ -31,8 +30,7 @@ const checkNetwork = (
   };
   const controller = new NetworkController(networkControllerOpts);
   controller.providerConfig = {} as ProviderConfig;
-  expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
-  expect(controller.state.isCustomNetwork).toBe(expectIsCustomNetwork);
+  return controller;
 };
 
 describe('NetworkController', () => {
@@ -81,7 +79,11 @@ describe('NetworkController', () => {
     ['kovan', 'rinkeby', 'ropsten', 'mainnet', 'localhost'] as NetworkType[]
   ).forEach((n) => {
     it(`should create a provider instance for ${n} infura network`, () => {
-      checkNetwork(n, messenger);
+      const networkController = setupController(n, messenger);
+      expect(networkController.provider instanceof Web3ProviderEngine).toBe(
+        true,
+      );
+      expect(networkController.state.isCustomNetwork).toBe(false);
     });
   });
 

--- a/src/network/NetworkController.test.ts
+++ b/src/network/NetworkController.test.ts
@@ -89,7 +89,7 @@ describe('NetworkController', () => {
         provider: {
           rpcTarget: RPC_TARGET,
           type: 'rpc',
-          chainId: '10'
+          chainId: '10',
         },
         properties: { isEIP1559Compatible: false },
       },

--- a/src/network/NetworkController.test.ts
+++ b/src/network/NetworkController.test.ts
@@ -12,6 +12,29 @@ import {
 
 const RPC_TARGET = 'http://foo';
 
+const checkNetwork = (
+  pType: NetworkType,
+  messenger: NetworkControllerMessenger,
+  expectIsCustomNetwork = false,
+) => {
+  const networkControllerOpts: NetworkControllerOptions = {
+    infuraProjectId: 'foo',
+    state: {
+      network: '0',
+      provider: {
+        type: pType,
+        chainId: NetworksChainId[pType],
+      },
+      properties: { isEIP1559Compatible: false },
+    },
+    messenger,
+  };
+  const controller = new NetworkController(networkControllerOpts);
+  controller.providerConfig = {} as ProviderConfig;
+  expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
+  expect(controller.state.isCustomNetwork).toBe(expectIsCustomNetwork);
+};
+
 describe('NetworkController', () => {
   let messenger: NetworkControllerMessenger;
 
@@ -54,30 +77,11 @@ describe('NetworkController', () => {
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
   });
 
-  const checkNetwork = (pType: NetworkType, expectIsCustomNetwork = false) => {
-    const networkControllerOpts: NetworkControllerOptions = {
-      infuraProjectId: 'foo',
-      state: {
-        network: '0',
-        provider: {
-          type: pType,
-          chainId: NetworksChainId[pType],
-        },
-        properties: { isEIP1559Compatible: false },
-      },
-      messenger,
-    };
-    const controller = new NetworkController(networkControllerOpts);
-    controller.providerConfig = {} as ProviderConfig;
-    expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
-    expect(controller.state.isCustomNetwork).toBe(expectIsCustomNetwork);
-  };
-
   (
     ['kovan', 'rinkeby', 'ropsten', 'mainnet', 'localhost'] as NetworkType[]
   ).forEach((n) => {
     it(`should create a provider instance for ${n} infura network`, () => {
-      checkNetwork(n);
+      checkNetwork(n, messenger);
     });
   });
 

--- a/src/network/NetworkController.test.ts
+++ b/src/network/NetworkController.test.ts
@@ -1,21 +1,38 @@
 import sinon from 'sinon';
 import Web3ProviderEngine from 'web3-provider-engine';
+import { ControllerMessenger } from '../ControllerMessenger';
 import {
   NetworkController,
+  NetworkControllerMessenger,
+  NetworkControllerOptions,
   NetworksChainId,
-  ProviderConfig,
   NetworkType,
+  ProviderConfig,
 } from './NetworkController';
 
 const RPC_TARGET = 'http://foo';
 
 describe('NetworkController', () => {
+  let messenger: NetworkControllerMessenger;
+
+  beforeEach(() => {
+    messenger = new ControllerMessenger().getRestricted({
+      name: 'NetworkController',
+      allowedEvents: ['NetworkController:providerChange'],
+      allowedActions: [],
+    });
+  });
+
   afterEach(() => {
     sinon.restore();
   });
 
   it('should set default state', () => {
-    const controller = new NetworkController();
+    const controller = new NetworkController({
+      messenger,
+      infuraProjectId: 'potate',
+    });
+
     expect(controller.state).toStrictEqual({
       network: 'loading',
       isCustomNetwork: false,
@@ -27,133 +44,101 @@ describe('NetworkController', () => {
     });
   });
 
-  it('should throw when providerConfig property is accessed', () => {
-    const controller = new NetworkController();
-    expect(() => console.log(controller.providerConfig)).toThrow(
-      'Property only used for setting',
-    );
-  });
-
   it('should create a provider instance for default infura network', () => {
-    const testConfig = {
+    const networkControllerOpts = {
       infuraProjectId: 'foo',
+      messenger,
     };
-    const controller = new NetworkController(testConfig);
-    controller.providerConfig = {} as ProviderConfig;
+    const controller = new NetworkController(networkControllerOpts);
     controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
   });
 
-  it('should create a provider instance for kovan infura network', () => {
-    const testConfig = {
+  const checkNetwork = (pType: NetworkType, expectIsCustomNetwork = false) => {
+    const networkControllerOpts: NetworkControllerOptions = {
       infuraProjectId: 'foo',
+      state: {
+        network: '0',
+        provider: {
+          type: pType,
+          chainId: NetworksChainId[pType],
+        },
+        properties: { isEIP1559Compatible: false },
+      },
+      messenger,
     };
-    const controller = new NetworkController(testConfig, {
-      network: '0',
-      provider: { type: 'kovan', chainId: NetworksChainId.kovan },
-    });
+    const controller = new NetworkController(networkControllerOpts);
     controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
-    expect(controller.state.isCustomNetwork).toBe(false);
-  });
+    expect(controller.state.isCustomNetwork).toBe(expectIsCustomNetwork);
+  };
 
-  it('should create a provider instance for rinkeby infura network', () => {
-    const testConfig = {
-      infuraProjectId: 'foo',
-    };
-    const controller = new NetworkController(testConfig, {
-      network: '0',
-      provider: { type: 'rinkeby', chainId: NetworksChainId.rinkeby },
+  (
+    ['kovan', 'rinkeby', 'ropsten', 'mainnet', 'localhost'] as NetworkType[]
+  ).forEach((n) => {
+    it(`should create a provider instance for ${n} infura network`, () => {
+      checkNetwork(n);
     });
-    controller.providerConfig = {} as ProviderConfig;
-    expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
-    expect(controller.state.isCustomNetwork).toBe(false);
   });
 
   it('should create a provider instance for optimism network', () => {
-    const testConfig = {
+    const networkControllerOpts: NetworkControllerOptions = {
       infuraProjectId: 'foo',
-    };
-    const controller = new NetworkController(testConfig, {
-      network: '10',
-      provider: {
-        rpcTarget: RPC_TARGET,
-        type: 'rpc',
-        chainId: '10',
+      state: {
+        network: '0',
+        provider: {
+          rpcTarget: RPC_TARGET,
+          type: 'rpc',
+          chainId: '10'
+        },
+        properties: { isEIP1559Compatible: false },
       },
-    });
+      messenger,
+    };
+    const controller = new NetworkController(networkControllerOpts);
     controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
     expect(controller.state.isCustomNetwork).toBe(true);
   });
 
-  it('should create a provider instance for ropsten infura network', () => {
-    const testConfig = {
-      infuraProjectId: 'foo',
-    };
-    const controller = new NetworkController(testConfig, {
-      network: '0',
-      provider: { type: 'ropsten', chainId: NetworksChainId.ropsten },
-    });
-    controller.providerConfig = {} as ProviderConfig;
-    expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
-    expect(controller.state.isCustomNetwork).toBe(false);
-  });
-
-  it('should create a provider instance for mainnet infura network', () => {
-    const testConfig = {
-      infuraProjectId: 'foo',
-    };
-    const controller = new NetworkController(testConfig, {
-      network: '0',
-      provider: { type: 'mainnet', chainId: NetworksChainId.mainnet },
-    });
-    controller.providerConfig = {} as ProviderConfig;
-    expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
-    expect(controller.state.isCustomNetwork).toBe(false);
-  });
-
-  it('should create a provider instance for local network', () => {
-    const controller = new NetworkController(undefined, {
-      network: '0',
-      provider: { type: 'localhost', chainId: NetworksChainId.rpc },
-    });
-    controller.providerConfig = {} as ProviderConfig;
-    expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
-    expect(controller.state.isCustomNetwork).toBe(false);
-  });
-
   it('should create a provider instance for rpc network', () => {
-    const controller = new NetworkController(undefined, {
-      network: '0',
-      provider: {
-        rpcTarget: RPC_TARGET,
-        type: 'rpc',
-        chainId: NetworksChainId.mainnet,
+    const networkControllerOpts: NetworkControllerOptions = {
+      infuraProjectId: 'foo',
+      state: {
+        network: '0',
+        provider: {
+          rpcTarget: RPC_TARGET,
+          type: 'rpc',
+          chainId: NetworksChainId.mainnet,
+        },
       },
-    });
+      messenger,
+    };
+    const controller = new NetworkController(networkControllerOpts);
     controller.providerConfig = {} as ProviderConfig;
     expect(controller.provider instanceof Web3ProviderEngine).toBe(true);
     expect(controller.state.isCustomNetwork).toBe(false);
   });
 
   it('should set new RPC target', () => {
-    const controller = new NetworkController();
+    const controller = new NetworkController({ messenger });
     controller.setRpcTarget(RPC_TARGET, NetworksChainId.rpc);
     expect(controller.state.provider.rpcTarget).toBe(RPC_TARGET);
     expect(controller.state.isCustomNetwork).toBe(false);
   });
 
   it('should set new provider type', () => {
-    const controller = new NetworkController();
+    const controller = new NetworkController({ messenger });
     controller.setProviderType('localhost');
     expect(controller.state.provider.type).toBe('localhost');
     expect(controller.state.isCustomNetwork).toBe(false);
   });
 
   it('should set new testnet provider type', () => {
-    const controller = new NetworkController();
-    controller.config.infuraProjectId = '0x0000';
+    const controller = new NetworkController({
+      messenger,
+      infuraProjectId: '123',
+    });
     controller.setProviderType('rinkeby' as NetworkType);
     expect(controller.state.provider.type).toBe('rinkeby');
     expect(controller.state.provider.ticker).toBe('RinkebyETH');
@@ -161,8 +146,10 @@ describe('NetworkController', () => {
   });
 
   it('should set mainnet provider type', () => {
-    const controller = new NetworkController();
-    controller.config.infuraProjectId = '0x0000';
+    const controller = new NetworkController({
+      messenger,
+      infuraProjectId: '123',
+    });
     controller.setProviderType('mainnet' as NetworkType);
     expect(controller.state.provider.type).toBe('mainnet');
     expect(controller.state.provider.ticker).toBe('ETH');
@@ -170,18 +157,19 @@ describe('NetworkController', () => {
   });
 
   it('should throw when setting an unrecognized provider type', () => {
-    const controller = new NetworkController();
+    const controller = new NetworkController({ messenger });
     expect(() => controller.setProviderType('junk' as NetworkType)).toThrow(
       "Unrecognized network type: 'junk'",
     );
   });
 
   it('should verify the network on an error', async () => {
-    const testConfig = {
-      infuraProjectId: 'foo',
-    };
-    const controller = new NetworkController(testConfig, {
-      network: 'loading',
+    const controller = new NetworkController({
+      messenger,
+      infuraProjectId: '123',
+      state: {
+        network: 'loading',
+      },
     });
     controller.providerConfig = {} as ProviderConfig;
     controller.lookupNetwork = sinon.stub();
@@ -190,18 +178,24 @@ describe('NetworkController', () => {
   });
 
   it('should look up the network', async () => {
+    const testConfig = {
+      // This test needs a real project ID as it makes a test
+      // `eth_version` call; https://github.com/MetaMask/controllers/issues/1
+      infuraProjectId: '341eacb578dd44a1a049cbc5f6fd4035',
+      messenger,
+    };
+    const event = 'NetworkController:providerChange';
+    const controller = new NetworkController(testConfig);
+
     await new Promise((resolve) => {
-      const testConfig = {
-        // This test needs a real project ID as it makes a test
-        // `eth_version` call; https://github.com/MetaMask/controllers/issues/1
-        infuraProjectId: '341eacb578dd44a1a049cbc5f6fd4035',
-      };
-      const controller = new NetworkController(testConfig);
-      controller.providerConfig = {} as ProviderConfig;
-      setTimeout(() => {
+      const handleProviderChange = () => {
         expect(controller.state.network !== 'loading').toBe(true);
+        messenger.unsubscribe(event, handleProviderChange);
         resolve('');
-      }, 4500);
+      };
+      messenger.subscribe(event, handleProviderChange);
+
+      controller.providerConfig = {} as ProviderConfig;
     });
   });
 });

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -134,7 +134,7 @@ export class NetworkController extends BaseController<
 
   private internalProviderConfig: ProviderConfig = {} as ProviderConfig;
 
-  private _infuraProjectId: string | undefined;
+  private infuraProjectId: string | undefined;
 
   private mutex = new Mutex();
 
@@ -162,7 +162,7 @@ export class NetworkController extends BaseController<
       messenger,
       state: { ...defaultState, ...state },
     });
-    this._infuraProjectId = infuraProjectId;
+    this.infuraProjectId = infuraProjectId;
     this.messagingSystem.registerActionHandler(
       `${this.name}:getProviderConfig`,
       () => {
@@ -228,7 +228,7 @@ export class NetworkController extends BaseController<
   private setupInfuraProvider(type: NetworkType) {
     const infuraProvider = createInfuraProvider({
       network: type,
-      projectId: this._infuraProjectId,
+      projectId: this.infuraProjectId,
     });
     const infuraSubprovider = new Subprovider(infuraProvider);
     const config = {

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -91,19 +91,19 @@ export type NetworkControllerProviderChangeEvent = {
   payload: [ProviderConfig];
 };
 
-export type NetworkControllerGetProviderConfig = {
+export type NetworkControllerGetProviderConfigAction = {
   type: `NetworkController:getProviderConfig`;
   handler: () => ProviderConfig;
 };
 
-export type NetworkControllerGetEthQuery = {
+export type NetworkControllerGetEthQueryAction = {
   type: `NetworkController:getEthQuery`;
   handler: () => EthQuery;
 };
 
 export type NetworkControllerMessenger = RestrictedControllerMessenger<
   typeof name,
-  NetworkControllerGetProviderConfig | NetworkControllerGetEthQuery,
+  NetworkControllerGetProviderConfigAction | NetworkControllerGetEthQueryAction,
   NetworkControllerStateChangeEvent | NetworkControllerProviderChangeEvent,
   string,
   string

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -79,6 +79,8 @@ const LOCALHOST_RPC_URL = 'http://localhost:8545';
 
 const name = 'NetworkController';
 
+export type EthQuery = any;
+
 export type NetworkControllerStateChangeEvent = {
   type: `NetworkController:stateChange`;
   payload: [NetworkState, Patch[]];
@@ -86,7 +88,7 @@ export type NetworkControllerStateChangeEvent = {
 
 export type NetworkControllerProviderChangeEvent = {
   type: `NetworkController:providerChange`;
-  payload: [ProviderConfig]; // 'any' is actually 'new NetworkController().provider'
+  payload: [ProviderConfig];
 };
 
 export type NetworkControllerGetProviderConfig = {
@@ -96,7 +98,7 @@ export type NetworkControllerGetProviderConfig = {
 
 export type NetworkControllerGetEthQuery = {
   type: `NetworkController:getEthQuery`;
-  handler: () => any; // EthQuery;
+  handler: () => EthQuery;
 };
 
 export type NetworkControllerMessenger = RestrictedControllerMessenger<
@@ -128,7 +130,7 @@ export class NetworkController extends BaseController<
   NetworkState,
   NetworkControllerMessenger
 > {
-  private ethQuery: any;
+  private ethQuery: EthQuery;
 
   private internalProviderConfig: ProviderConfig = {} as ProviderConfig;
 
@@ -183,7 +185,7 @@ export class NetworkController extends BaseController<
     ticker?: string,
     nickname?: string,
   ) {
-    this.update((state: NetworkState) => {
+    this.update((state) => {
       state.isCustomNetwork = this.getIsCustomNetwork(chainId);
     });
 
@@ -209,7 +211,7 @@ export class NetworkController extends BaseController<
   }
 
   private refreshNetwork() {
-    this.update((state: NetworkState) => {
+    this.update((state) => {
       state.network = 'loading';
       state.properties = {};
     });
@@ -328,7 +330,7 @@ export class NetworkController extends BaseController<
           return;
         }
 
-        this.update((state: NetworkState) => {
+        this.update((state) => {
           state.network = error ? /* istanbul ignore next*/ 'loading' : network;
         });
 
@@ -355,7 +357,7 @@ export class NetworkController extends BaseController<
         ? TESTNET_NETWORK_TYPE_TO_TICKER_SYMBOL[type]
         : 'ETH';
 
-    this.update((state: NetworkState) => {
+    this.update((state) => {
       state.provider.type = type;
       state.provider.ticker = ticker;
       state.provider.chainId = NetworksChainId[type];
@@ -377,7 +379,7 @@ export class NetworkController extends BaseController<
     ticker?: string,
     nickname?: string,
   ) {
-    this.update((state: NetworkState) => {
+    this.update((state) => {
       state.provider.type = RPC;
       state.provider.rpcTarget = rpcTarget;
       state.provider.chainId = chainId;
@@ -404,7 +406,7 @@ export class NetworkController extends BaseController<
               const isEIP1559Compatible =
                 typeof block.baseFeePerGas !== 'undefined';
               if (properties.isEIP1559Compatible !== isEIP1559Compatible) {
-                this.update((state: NetworkState) => {
+                this.update((state) => {
                   if (state.properties === undefined) {
                     state.properties = {};
                   }

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -70,9 +70,9 @@ export type NetworkProperties = {
  */
 export type NetworkState = {
   network: string;
-  isCustomNetwork?: boolean;
+  isCustomNetwork: boolean;
   provider: ProviderConfig;
-  properties?: NetworkProperties;
+  properties: NetworkProperties;
 };
 
 const LOCALHOST_RPC_URL = 'http://localhost:8545';
@@ -407,9 +407,6 @@ export class NetworkController extends BaseController<
                 typeof block.baseFeePerGas !== 'undefined';
               if (properties.isEIP1559Compatible !== isEIP1559Compatible) {
                 this.update((state) => {
-                  if (state.properties === undefined) {
-                    state.properties = {};
-                  }
                   state.properties.isEIP1559Compatible = isEIP1559Compatible;
                 });
               }

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -86,7 +86,7 @@ export type NetworkControllerStateChangeEvent = {
 
 export type NetworkControllerProviderChangeEvent = {
   type: `NetworkController:providerChange`;
-  payload: [any]; // 'any' is actually 'new NetworkController().provider'
+  payload: [ProviderConfig]; // 'any' is actually 'new NetworkController().provider'
 };
 
 export type NetworkControllerMessenger = RestrictedControllerMessenger<
@@ -301,16 +301,16 @@ export class NetworkController extends BaseController<
     this.ethQuery.sendAsync(
       { method: 'net_version' },
       (error: Error, network: string) => {
+        if (this.state.network === network) { return; }
         this.update((state: any) => {
           state.network = error ? /* istanbul ignore next*/ 'loading' : network;
         });
 
-        if (!error) {
-          this.messagingSystem.publish(
-            `${this.name}:providerChange`,
-            this.provider,
-          );
-        }
+        this.messagingSystem.publish(
+          `NetworkController:providerChange`,
+          this.state.provider,
+        );
+
         releaseLock();
       },
     );

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -3,12 +3,14 @@ import Subprovider from 'web3-provider-engine/subproviders/provider';
 import createInfuraProvider from 'eth-json-rpc-infura/src/createProvider';
 import createMetamaskProvider from 'web3-provider-engine/zero';
 import { Mutex } from 'async-mutex';
-import { BaseController, BaseConfig, BaseState } from '../BaseController';
+import type { Patch } from 'immer';
+import { BaseController } from '../BaseControllerV2';
 import {
   MAINNET,
   RPC,
   TESTNET_NETWORK_TYPE_TO_TICKER_SYMBOL,
 } from '../constants';
+import { RestrictedControllerMessenger } from '../ControllerMessenger';
 
 /**
  * Human-readable network name
@@ -42,33 +44,21 @@ export enum NetworksChainId {
  * @property ticker - Currency ticker.
  * @property nickname - Personalized network name.
  */
-export interface ProviderConfig {
+export type ProviderConfig = {
   rpcTarget?: string;
   type: NetworkType;
   chainId: string;
   ticker?: string;
   nickname?: string;
-}
+};
 
-export interface Block {
+export type Block = {
   baseFeePerGas?: string;
-}
+};
 
-export interface NetworkProperties {
+export type NetworkProperties = {
   isEIP1559Compatible?: boolean;
-}
-
-/**
- * @type NetworkConfig
- *
- * Network controller configuration
- * @property infuraProjectId - an Infura project ID
- * @property providerConfig - web3-provider-engine configuration
- */
-export interface NetworkConfig extends BaseConfig {
-  infuraProjectId?: string;
-  providerConfig: ProviderConfig;
-}
+};
 
 /**
  * @type NetworkState
@@ -78,27 +68,90 @@ export interface NetworkConfig extends BaseConfig {
  * @property isCustomNetwork - Identifies if the network is a custom network
  * @property provider - RPC URL and network name provider settings
  */
-export interface NetworkState extends BaseState {
+export type NetworkState = {
   network: string;
-  isCustomNetwork: boolean;
+  isCustomNetwork?: boolean;
   provider: ProviderConfig;
-  properties: NetworkProperties;
-}
+  properties?: NetworkProperties;
+};
 
 const LOCALHOST_RPC_URL = 'http://localhost:8545';
+
+const name = 'NetworkController';
+
+export type NetworkControllerStateChangeEvent = {
+  type: `NetworkController:stateChange`;
+  payload: [NetworkState, Patch[]];
+};
+
+export type NetworkControllerProviderChangeEvent = {
+  type: `NetworkController:providerChange`;
+  payload: [any]; // 'any' is actually 'new NetworkController().provider'
+};
+
+export type NetworkControllerMessenger = RestrictedControllerMessenger<
+  typeof name,
+  any,
+  NetworkControllerStateChangeEvent | NetworkControllerProviderChangeEvent,
+  string,
+  string
+>;
+
+export type NetworkControllerOptions = {
+  messenger: NetworkControllerMessenger;
+  infuraProjectId?: string;
+  state?: Partial<NetworkState>;
+};
+
+const defaultState: NetworkState = {
+  network: 'loading',
+  isCustomNetwork: false,
+  provider: { type: MAINNET, chainId: NetworksChainId.mainnet },
+  properties: { isEIP1559Compatible: false },
+};
 
 /**
  * Controller that creates and manages an Ethereum network provider
  */
 export class NetworkController extends BaseController<
-  NetworkConfig,
-  NetworkState
+  typeof name,
+  NetworkState,
+  NetworkControllerMessenger
 > {
   private ethQuery: any;
 
   private internalProviderConfig: ProviderConfig = {} as ProviderConfig;
 
+  private _infuraProjectId: string | undefined;
+
   private mutex = new Mutex();
+
+  constructor({ messenger, state, infuraProjectId }: NetworkControllerOptions) {
+    super({
+      name,
+      metadata: {
+        network: {
+          persist: true,
+          anonymous: false,
+        },
+        isCustomNetwork: {
+          persist: true,
+          anonymous: false,
+        },
+        properties: {
+          persist: true,
+          anonymous: false,
+        },
+        provider: {
+          persist: true,
+          anonymous: false,
+        },
+      },
+      messenger,
+      state: { ...defaultState, ...state },
+    });
+    this._infuraProjectId = infuraProjectId;
+  }
 
   private initializeProvider(
     type: NetworkType,
@@ -107,7 +160,10 @@ export class NetworkController extends BaseController<
     ticker?: string,
     nickname?: string,
   ) {
-    this.update({ isCustomNetwork: this.getIsCustomNetwork(chainId) });
+    this.update((state: any) => {
+      state.isCustomNetwork = this.getIsCustomNetwork(chainId);
+    });
+
     switch (type) {
       case 'kovan':
       case MAINNET:
@@ -126,10 +182,14 @@ export class NetworkController extends BaseController<
       default:
         throw new Error(`Unrecognized network type: '${type}'`);
     }
+    this.getEIP1559Compatibility();
   }
 
   private refreshNetwork() {
-    this.update({ network: 'loading', properties: {} });
+    this.update((state: any) => {
+      state.network = 'loading';
+      state.properties = {};
+    });
     const { rpcTarget, type, chainId, ticker } = this.state.provider;
     this.initializeProvider(type, rpcTarget, chainId, ticker);
     this.lookupNetwork();
@@ -143,7 +203,7 @@ export class NetworkController extends BaseController<
   private setupInfuraProvider(type: NetworkType) {
     const infuraProvider = createInfuraProvider({
       network: type,
-      projectId: this.config.infuraProjectId,
+      projectId: this._infuraProjectId,
     });
     const infuraSubprovider = new Subprovider(infuraProvider);
     const config = {
@@ -206,32 +266,9 @@ export class NetworkController extends BaseController<
   }
 
   /**
-   * Name of this controller used during composition
-   */
-  override name = 'NetworkController';
-
-  /**
    * Ethereum provider object for the current network
    */
   provider: any;
-
-  /**
-   * Creates a NetworkController instance.
-   *
-   * @param config - Initial options used to configure this controller.
-   * @param state - Initial state to set on this controller.
-   */
-  constructor(config?: Partial<NetworkConfig>, state?: Partial<NetworkState>) {
-    super(config, state);
-    this.defaultState = {
-      network: 'loading',
-      isCustomNetwork: false,
-      provider: { type: MAINNET, chainId: NetworksChainId.mainnet },
-      properties: { isEIP1559Compatible: false },
-    };
-    this.initialize();
-    this.getEIP1559Compatibility();
-  }
 
   /**
    * Sets a new configuration for web3-provider-engine.
@@ -264,9 +301,16 @@ export class NetworkController extends BaseController<
     this.ethQuery.sendAsync(
       { method: 'net_version' },
       (error: Error, network: string) => {
-        this.update({
-          network: error ? /* istanbul ignore next*/ 'loading' : network,
+        this.update((state: any) => {
+          state.network = error ? /* istanbul ignore next*/ 'loading' : network;
         });
+
+        if (!error) {
+          this.messagingSystem.publish(
+            `${this.name}:providerChange`,
+            this.provider,
+          );
+        }
         releaseLock();
       },
     );
@@ -278,9 +322,6 @@ export class NetworkController extends BaseController<
    * @param type - Human readable network name.
    */
   setProviderType(type: NetworkType) {
-    const { rpcTarget, chainId, nickname, ...providerState } =
-      this.state.provider;
-
     // If testnet the ticker symbol should use a testnet prefix
     const ticker =
       type in TESTNET_NETWORK_TYPE_TO_TICKER_SYMBOL &&
@@ -288,15 +329,10 @@ export class NetworkController extends BaseController<
         ? TESTNET_NETWORK_TYPE_TO_TICKER_SYMBOL[type]
         : 'ETH';
 
-    this.update({
-      provider: {
-        ...providerState,
-        ...{
-          type,
-          ticker,
-          chainId: NetworksChainId[type],
-        },
-      },
+    this.update((state: any) => {
+      state.provider.type = type;
+      state.provider.ticker = ticker;
+      state.provider.chainId = NetworksChainId[type];
     });
     this.refreshNetwork();
   }
@@ -315,11 +351,12 @@ export class NetworkController extends BaseController<
     ticker?: string,
     nickname?: string,
   ) {
-    this.update({
-      provider: {
-        ...this.state.provider,
-        ...{ type: RPC, ticker, rpcTarget, chainId, nickname },
-      },
+    this.update((state: any) => {
+      state.provider.type = RPC;
+      state.provider.rpcTarget = rpcTarget;
+      state.provider.chainId = chainId;
+      state.provider.ticker = ticker;
+      state.provider.nickname = nickname;
     });
     this.refreshNetwork();
   }
@@ -341,10 +378,8 @@ export class NetworkController extends BaseController<
               const isEIP1559Compatible =
                 typeof block.baseFeePerGas !== 'undefined';
               if (properties.isEIP1559Compatible !== isEIP1559Compatible) {
-                this.update({
-                  properties: {
-                    isEIP1559Compatible,
-                  },
+                this.update((state: any) => {
+                  state.properties.isEIP1559Compatible = isEIP1559Compatible;
                 });
               }
               resolve(isEIP1559Compatible);

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -183,7 +183,7 @@ export class NetworkController extends BaseController<
     ticker?: string,
     nickname?: string,
   ) {
-    this.update((state: any) => {
+    this.update((state: NetworkState) => {
       state.isCustomNetwork = this.getIsCustomNetwork(chainId);
     });
 
@@ -209,7 +209,7 @@ export class NetworkController extends BaseController<
   }
 
   private refreshNetwork() {
-    this.update((state: any) => {
+    this.update((state: NetworkState) => {
       state.network = 'loading';
       state.properties = {};
     });
@@ -328,7 +328,7 @@ export class NetworkController extends BaseController<
           return;
         }
 
-        this.update((state: any) => {
+        this.update((state: NetworkState) => {
           state.network = error ? /* istanbul ignore next*/ 'loading' : network;
         });
 
@@ -355,7 +355,7 @@ export class NetworkController extends BaseController<
         ? TESTNET_NETWORK_TYPE_TO_TICKER_SYMBOL[type]
         : 'ETH';
 
-    this.update((state: any) => {
+    this.update((state: NetworkState) => {
       state.provider.type = type;
       state.provider.ticker = ticker;
       state.provider.chainId = NetworksChainId[type];
@@ -377,7 +377,7 @@ export class NetworkController extends BaseController<
     ticker?: string,
     nickname?: string,
   ) {
-    this.update((state: any) => {
+    this.update((state: NetworkState) => {
       state.provider.type = RPC;
       state.provider.rpcTarget = rpcTarget;
       state.provider.chainId = chainId;
@@ -404,7 +404,10 @@ export class NetworkController extends BaseController<
               const isEIP1559Compatible =
                 typeof block.baseFeePerGas !== 'undefined';
               if (properties.isEIP1559Compatible !== isEIP1559Compatible) {
-                this.update((state: any) => {
+                this.update((state: NetworkState) => {
+                  if (state.properties === undefined) {
+                    state.properties = {};
+                  }
                   state.properties.isEIP1559Compatible = isEIP1559Compatible;
                 });
               }


### PR DESCRIPTION
**NetworkController update to extend from BaseControllerV2**

swaps out the base controller, implements messenger, fixes all the tests associated

**Description**

- BREAKING:

  - NetworkController constructor now takes a `ControllerMessenger`
  - subscriptions should be made on the messenger, not the controller
  - listen for providerChange if you want to receive updates once lookupNetwork has completed 

- CHANGED:

  - NetworkController uses BaseControllerV2

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented

**Issue**

#902 
