### PR TITLE
bump @metamask/eth-sig-util to latest

### DIFF
--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -32,6 +32,7 @@
     "@keystonehq/metamask-airgapped-keyring": "^0.6.1",
     "@metamask/base-controller": "workspace:^",
     "@metamask/controller-utils": "workspace:^",
+    "@metamask/eth-sig-util": "^5.0.2",
     "@metamask/message-manager": "workspace:^",
     "@metamask/preferences-controller": "workspace:^",
     "async-mutex": "^0.2.6",

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -37,7 +37,6 @@
     "@metamask/preferences-controller": "workspace:^",
     "async-mutex": "^0.2.6",
     "eth-keyring-controller": "^7.0.2",
-    "eth-sig-util": "^3.0.0",
     "ethereumjs-util": "^7.0.10",
     "ethereumjs-wallet": "^1.0.1"
   },

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -475,7 +475,7 @@ describe('KeyringController', () => {
           wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
         },
       },
-      primaryType: 'Mail',
+      primaryType: 'Mail' as const,
       types: {
         EIP712Domain: [
           { name: 'name', type: 'string' },
@@ -500,7 +500,7 @@ describe('KeyringController', () => {
       SignTypedDataVersion.V3,
     );
     const recovered = recoverTypedSignature({
-      data: msgParams as any,
+      data: msgParams,
       signature,
       version: SignTypedDataVersion.V3,
     });
@@ -535,7 +535,7 @@ describe('KeyringController', () => {
           },
         ],
       },
-      primaryType: 'Mail',
+      primaryType: 'Mail' as const,
       types: {
         EIP712Domain: [
           { name: 'name', type: 'string' },
@@ -565,7 +565,7 @@ describe('KeyringController', () => {
       SignTypedDataVersion.V4,
     );
     const recovered = recoverTypedSignature({
-      data: msgParams as any,
+      data: msgParams,
       signature,
       version: SignTypedDataVersion.V4,
     });

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -3,7 +3,6 @@ import {
   recoverPersonalSignature,
   recoverTypedSignature,
   SignTypedDataVersion,
-  TypedDataV1,
 } from '@metamask/eth-sig-util';
 import * as sinon from 'sinon';
 import Common from '@ethereumjs/common';
@@ -451,7 +450,7 @@ describe('KeyringController', () => {
     );
     const recovered = recoverTypedSignature({
       data: typedMsgParams,
-      signature: signature as string,
+      signature,
       version: SignTypedDataVersion.V1,
     });
     expect(account).toBe(recovered);
@@ -502,7 +501,7 @@ describe('KeyringController', () => {
     );
     const recovered = recoverTypedSignature({
       data: msgParams as any,
-      signature: signature as string,
+      signature,
       version: SignTypedDataVersion.V3,
     });
     expect(account).toBe(recovered);
@@ -567,7 +566,7 @@ describe('KeyringController', () => {
     );
     const recovered = recoverTypedSignature({
       data: msgParams as any,
-      signature: signature as string,
+      signature,
       version: SignTypedDataVersion.V4,
     });
     expect(account).toBe(recovered);
@@ -886,8 +885,8 @@ describe('KeyringController', () => {
         SignTypedDataVersion.V1,
       );
       const recovered = recoverTypedSignature({
-        data: typedMsgParams as TypedDataV1,
-        signature: signature as string,
+        data: typedMsgParams,
+        signature,
         version: SignTypedDataVersion.V1,
       });
       expect(account.toLowerCase()).toBe(recovered.toLowerCase());
@@ -918,7 +917,7 @@ describe('KeyringController', () => {
       );
       const recovered = recoverTypedSignature({
         data: JSON.parse(msg),
-        signature: signature as string,
+        signature,
         version: SignTypedDataVersion.V3,
       });
       expect(account.toLowerCase()).toBe(recovered);
@@ -946,7 +945,7 @@ describe('KeyringController', () => {
       );
       const recovered = recoverTypedSignature({
         data: JSON.parse(msg),
-        signature: signature as string,
+        signature,
         version: SignTypedDataVersion.V4,
       });
       expect(account.toLowerCase()).toBe(recovered);

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -2,9 +2,9 @@ import { bufferToHex } from 'ethereumjs-util';
 import {
   recoverPersonalSignature,
   recoverTypedSignature,
-  recoverTypedSignature_v4,
-  recoverTypedSignatureLegacy,
-} from 'eth-sig-util';
+  SignTypedDataVersion,
+  TypedDataV1,
+} from '@metamask/eth-sig-util';
 import * as sinon from 'sinon';
 import Common from '@ethereumjs/common';
 import { TransactionFactory } from '@ethereumjs/tx';
@@ -20,7 +20,6 @@ import {
   KeyringConfig,
   KeyringController,
   KeyringTypes,
-  SignTypedDataVersion,
 } from './KeyringController';
 
 jest.mock('uuid', () => {
@@ -379,7 +378,7 @@ describe('KeyringController', () => {
       data,
       from: account,
     });
-    const recovered = recoverPersonalSignature({ data, sig: signature });
+    const recovered = recoverPersonalSignature({ data, signature });
     expect(account).toBe(recovered);
   });
 
@@ -393,7 +392,7 @@ describe('KeyringController', () => {
       data: '',
       from: account,
     });
-    const recovered = recoverPersonalSignature({ data: '', sig: signature });
+    const recovered = recoverPersonalSignature({ data: '', signature });
     expect(account).toBe(recovered);
   });
 
@@ -450,9 +449,10 @@ describe('KeyringController', () => {
       { data: typedMsgParams, from: account },
       SignTypedDataVersion.V1,
     );
-    const recovered = recoverTypedSignatureLegacy({
+    const recovered = recoverTypedSignature({
       data: typedMsgParams,
-      sig: signature as string,
+      signature: signature as string,
+      version: SignTypedDataVersion.V1,
     });
     expect(account).toBe(recovered);
   });
@@ -502,7 +502,8 @@ describe('KeyringController', () => {
     );
     const recovered = recoverTypedSignature({
       data: msgParams as any,
-      sig: signature as string,
+      signature: signature as string,
+      version: SignTypedDataVersion.V3,
     });
     expect(account).toBe(recovered);
   });
@@ -564,9 +565,10 @@ describe('KeyringController', () => {
       { data: JSON.stringify(msgParams), from: account },
       SignTypedDataVersion.V4,
     );
-    const recovered = recoverTypedSignature_v4({
+    const recovered = recoverTypedSignature({
       data: msgParams as any,
-      sig: signature as string,
+      signature: signature as string,
+      version: SignTypedDataVersion.V4,
     });
     expect(account).toBe(recovered);
   });
@@ -850,7 +852,7 @@ describe('KeyringController', () => {
         data,
         from: account,
       });
-      const recovered = recoverPersonalSignature({ data, sig: signature });
+      const recovered = recoverPersonalSignature({ data, signature });
       expect(account.toLowerCase()).toBe(recovered.toLowerCase());
     });
 
@@ -883,9 +885,10 @@ describe('KeyringController', () => {
         { data: typedMsgParams, from: account },
         SignTypedDataVersion.V1,
       );
-      const recovered = recoverTypedSignatureLegacy({
-        data: typedMsgParams,
-        sig: signature as string,
+      const recovered = recoverTypedSignature({
+        data: typedMsgParams as TypedDataV1,
+        signature: signature as string,
+        version: SignTypedDataVersion.V1,
       });
       expect(account.toLowerCase()).toBe(recovered.toLowerCase());
     });
@@ -915,7 +918,8 @@ describe('KeyringController', () => {
       );
       const recovered = recoverTypedSignature({
         data: JSON.parse(msg),
-        sig: signature as string,
+        signature: signature as string,
+        version: SignTypedDataVersion.V3,
       });
       expect(account.toLowerCase()).toBe(recovered);
     });
@@ -940,9 +944,10 @@ describe('KeyringController', () => {
         { data: msg, from: account },
         SignTypedDataVersion.V4,
       );
-      const recovered = recoverTypedSignature_v4({
+      const recovered = recoverTypedSignature({
         data: JSON.parse(msg),
-        sig: signature as string,
+        signature: signature as string,
+        version: SignTypedDataVersion.V4,
       });
       expect(account.toLowerCase()).toBe(recovered);
     });

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -8,9 +8,7 @@ import {
 import {
   normalize as normalizeAddress,
   signTypedData,
-  signTypedData_v4,
-  signTypedDataLegacy,
-} from 'eth-sig-util';
+} from '@metamask/eth-sig-util';
 import Wallet, { thirdparty as importers } from 'ethereumjs-wallet';
 import Keyring from 'eth-keyring-controller';
 import { Mutex } from 'async-mutex';
@@ -481,17 +479,22 @@ export class KeyringController extends BaseController<
       const privateKeyBuffer = toBuffer(addHexPrefix(privateKey));
       switch (version) {
         case SignTypedDataVersion.V1:
-          // signTypedDataLegacy will throw if the data is invalid.
-          return signTypedDataLegacy(privateKeyBuffer, {
+          return signTypedData({
+            privateKey: privateKeyBuffer,
             data: messageParams.data as any,
+            version: SignTypedDataVersion.V1,
           });
         case SignTypedDataVersion.V3:
-          return signTypedData(privateKeyBuffer, {
+          return signTypedData({
+            privateKey: privateKeyBuffer,
             data: JSON.parse(messageParams.data as string),
+            version: SignTypedDataVersion.V3,
           });
         case SignTypedDataVersion.V4:
-          return signTypedData_v4(privateKeyBuffer, {
+          return signTypedData({
+            privateKey: privateKeyBuffer,
             data: JSON.parse(messageParams.data as string),
+            version: SignTypedDataVersion.V4,
           });
         default:
           throw new Error(`Unexpected signTypedMessage version: '${version}'`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1747,7 +1747,6 @@ __metadata:
     async-mutex: ^0.2.6
     deepmerge: ^4.2.2
     eth-keyring-controller: ^7.0.2
-    eth-sig-util: ^3.0.0
     ethereumjs-util: ^7.0.10
     ethereumjs-wallet: ^1.0.1
     jest: ^26.4.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -1684,6 +1684,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/eth-sig-util@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "@metamask/eth-sig-util@npm:5.0.2"
+  dependencies:
+    "@ethereumjs/util": ^8.0.0
+    bn.js: ^4.11.8
+    ethereum-cryptography: ^1.1.2
+    ethjs-util: ^0.1.6
+    tweetnacl: ^1.0.3
+    tweetnacl-util: ^0.15.1
+  checksum: 1fbf1a0f5e654058f0219c9018dbebadf53036c9c3b47c8faf1cac54816532bb18996821736f526ac4e3d579afcaf502af4ad07e88158a50f015141858b08a90
+  languageName: node
+  linkType: hard
+
 "@metamask/gas-fee-controller@workspace:packages/gas-fee-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/gas-fee-controller@workspace:packages/gas-fee-controller"
@@ -1726,6 +1740,7 @@ __metadata:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:^"
     "@metamask/controller-utils": "workspace:^"
+    "@metamask/eth-sig-util": ^5.0.2
     "@metamask/message-manager": "workspace:^"
     "@metamask/preferences-controller": "workspace:^"
     "@types/jest": ^26.0.22


### PR DESCRIPTION
- CHANGED:

  - Upgrades `eth-sig-util` (now `@metmask/eth-sig-util`) from v3.0.0 to v5.0.2. This upgrade contains several updates, including:
      - consolidates the recoverTypedSignature, recoverTypedSignature_v4, recoverTypedSignatureLegacy functions into one that switch on a new version argument. 
      - reduces dependency burden, removing `secp256k1` and `keccak` via as dependencies by upgrading from `ethereumjs-util@6.2.1` to its latest version `@ethereumjs/util@8.0.0` which uses lighter `noble` implementations for crypto functionality. Replaces `keccak` hashing with `keccak256` from `ethereum-cryptography/keccak`

