### PR TITLE
Improve PhishingController tests

### DIFF
--- a/src/third-party/PhishingController.test.ts
+++ b/src/third-party/PhishingController.test.ts
@@ -195,7 +195,7 @@ describe('PhishingController', () => {
     ]);
   });
 
-  it('should not update infura rate if disabled', async () => {
+  it('should not update phishing configuration if disabled', async () => {
     const controller = new PhishingController({ disabled: true });
     await controller.updatePhishingLists();
 

--- a/src/third-party/PhishingController.test.ts
+++ b/src/third-party/PhishingController.test.ts
@@ -1,127 +1,226 @@
 import { strict as assert } from 'assert';
 import sinon from 'sinon';
 import nock from 'nock';
-import {
-  EthPhishingDetectResult,
-  PhishingController,
-} from './PhishingController';
+import DEFAULT_PHISHING_RESPONSE from 'eth-phishing-detect/src/config.json';
+import { PhishingController } from './PhishingController';
+
+const defaultRefreshInterval = 3600000;
 
 describe('PhishingController', () => {
+  beforeAll(() => {
+    nock.disableNetConnect();
+  });
+
+  afterAll(() => {
+    nock.enableNetConnect();
+  });
+
   afterEach(() => {
     nock.cleanAll();
     sinon.restore();
   });
 
-  it('should set default state', () => {
+  it('should set default state to the package phishing configuration', () => {
     const controller = new PhishingController();
-    controller.state.phishing.forEach((i) => {
-      expect(i).toHaveProperty('allowlist');
-      expect(i).toHaveProperty('blocklist');
-      expect(i).toHaveProperty('fuzzylist');
-      expect(i).toHaveProperty('tolerance');
-      expect(i).toHaveProperty('name');
-      expect(i).toHaveProperty('version');
+    expect(controller.state.phishing).toStrictEqual([
+      {
+        allowlist: DEFAULT_PHISHING_RESPONSE.whitelist,
+        blocklist: DEFAULT_PHISHING_RESPONSE.blacklist,
+        fuzzylist: DEFAULT_PHISHING_RESPONSE.fuzzylist,
+        tolerance: DEFAULT_PHISHING_RESPONSE.tolerance,
+        name: `MetaMask`,
+        version: DEFAULT_PHISHING_RESPONSE.version,
+      },
+    ]);
+  });
+
+  it('should default to an empty whitelist', () => {
+    const controller = new PhishingController();
+    expect(controller.state.whitelist).toStrictEqual([]);
+  });
+
+  it('should use default refresh interval', () => {
+    const controller = new PhishingController();
+    expect(controller.config).toStrictEqual({
+      refreshInterval: defaultRefreshInterval,
     });
   });
 
-  it('should set default config', () => {
-    const controller = new PhishingController();
-    expect(controller.config).toStrictEqual({ refreshInterval: 3600000 });
-  });
-
   it('does not call updatePhishingList upon construction', async () => {
-    const mock = sinon.spy(PhishingController.prototype, 'updatePhishingLists');
+    const nockScope = nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(200, {
+        blacklist: [],
+        fuzzylist: [],
+        tolerance: 0,
+        whitelist: [],
+        version: 0,
+      })
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(200, []);
+
     new PhishingController({});
-    expect(mock.called).toBe(false);
-    mock.restore();
+
+    expect(nockScope.isDone()).toBe(false);
   });
 
   it('fetches the first time test is used', async () => {
-    const mock = sinon.spy(PhishingController.prototype, 'updatePhishingLists');
+    const nockScope = nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(200, {
+        blacklist: [],
+        fuzzylist: [],
+        tolerance: 0,
+        whitelist: [],
+        version: 0,
+      })
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(200, []);
+
     const controller = new PhishingController({});
-    expect(mock.called).toBe(false);
     await controller.test('metamask.io');
-    expect(mock.called).toBe(true);
-    mock.restore();
+
+    expect(nockScope.isDone()).toBe(true);
   });
 
   it('does not call fetch twice if the second call is inside of the refreshInterval', async () => {
-    const mock = sinon.spy(PhishingController.prototype, 'updatePhishingLists');
+    const nockScope = nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(200, {
+        blacklist: [],
+        fuzzylist: [],
+        tolerance: 0,
+        whitelist: [],
+        version: 0,
+      })
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(200, []);
+
     const controller = new PhishingController({});
-    expect(mock.callCount).toBe(0);
     await controller.test('metamask.io');
-    expect(mock.callCount).toBe(1);
-    await controller.test('metamask.io');
-    expect(mock.callCount).toBe(1);
-    mock.restore();
+
+    expect(nockScope.isDone()).toBe(true);
+    // The nock handlers were not created with `persist()`, so they will only
+    // be used once. The next `fetch` will throw, so this expectation shows
+    // that no `fetch` has occurred.
+    expect(await controller.test('metamask.io')).toStrictEqual({
+      result: false,
+      type: 'all',
+    });
   });
 
   it('should call fetch twice if the second call is outside the refreshInterval', async () => {
     const clock = sinon.useFakeTimers(Date.now());
-    const mock = sinon.spy(PhishingController.prototype, 'updatePhishingLists');
-    const controller = new PhishingController({ refreshInterval: 1 });
-    expect(mock.callCount).toBe(0);
+    const nockScope = nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .times(2)
+      .reply(200, {
+        blacklist: [],
+        fuzzylist: [],
+        tolerance: 0,
+        whitelist: [],
+        version: 0,
+      })
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .times(2)
+      .reply(200, []);
+
+    const controller = new PhishingController();
     await controller.test('metamask.io');
-    expect(mock.callCount).toBe(1);
-    await clock.tickAsync(2);
+    await clock.tickAsync(defaultRefreshInterval);
     await controller.test('metamask.io');
-    expect(mock.callCount).toBe(2);
-    clock.restore();
-    mock.restore();
+
+    expect(nockScope.isDone()).toBe(true);
   });
 
   it('should be able to change the refreshInterval', async () => {
-    const mock = sinon.spy(PhishingController.prototype, 'updatePhishingLists');
-    const controller = new PhishingController({});
+    const nockScope = nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .times(3)
+      .reply(200, {
+        blacklist: [],
+        fuzzylist: [],
+        tolerance: 0,
+        whitelist: [],
+        version: 0,
+      })
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .times(3)
+      .reply(200, []);
+
+    const controller = new PhishingController({ refreshInterval: 1 });
     controller.setRefreshInterval(0);
-
     await controller.test('metamask.io');
     await controller.test('metamask.io');
     await controller.test('metamask.io');
 
-    expect(mock.callCount).toBe(3);
-    mock.restore();
+    expect(nockScope.isDone()).toBe(true);
   });
 
   it('should update lists', async () => {
+    const mockPhishingBlocklist = ['https://example-blocked-website.com'];
+    const phishfortHotlist = ['https://another-example-blocked-website.com'];
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(200, {
+        blacklist: mockPhishingBlocklist,
+        fuzzylist: [],
+        tolerance: 0,
+        whitelist: [],
+        version: 0,
+      })
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(200, phishfortHotlist);
+
     const controller = new PhishingController();
-    controller.update({}, true);
     await controller.updatePhishingLists();
-    controller.state.phishing.forEach((config) => {
-      expect(config).toHaveProperty('allowlist');
-      expect(config).toHaveProperty('blocklist');
-      expect(config).toHaveProperty('fuzzylist');
-      expect(config).toHaveProperty('tolerance');
-      expect(config).toHaveProperty('name');
-      expect(config).toHaveProperty('version');
-    });
+
+    expect(controller.state.phishing).toStrictEqual([
+      {
+        allowlist: [],
+        blocklist: mockPhishingBlocklist,
+        fuzzylist: [],
+        tolerance: 0,
+        name: 'MetaMask',
+        version: 0,
+      },
+      {
+        allowlist: [],
+        blocklist: phishfortHotlist,
+        fuzzylist: [],
+        tolerance: 0,
+        name: 'PhishFort',
+        version: 1,
+      },
+    ]);
   });
 
   it('should not update infura rate if disabled', async () => {
     const controller = new PhishingController({ disabled: true });
-    controller.update({}, true);
     await controller.updatePhishingLists();
-    expect(controller.state.phishing).toBeUndefined();
-  });
 
-  it('should not update rates if disabled', async () => {
-    nock('https://cdn.jsdelivr.net')
-      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
-      .replyWithError('Network error')
-      .persist();
-    const controller = new PhishingController({
-      disabled: true,
-      refreshInterval: 10,
-    });
-
-    expect(async () => await controller.updatePhishingLists()).not.toThrow();
+    expect(controller.state.phishing).toStrictEqual([
+      {
+        allowlist: DEFAULT_PHISHING_RESPONSE.whitelist,
+        blocklist: DEFAULT_PHISHING_RESPONSE.blacklist,
+        fuzzylist: DEFAULT_PHISHING_RESPONSE.fuzzylist,
+        tolerance: DEFAULT_PHISHING_RESPONSE.tolerance,
+        name: `MetaMask`,
+        version: DEFAULT_PHISHING_RESPONSE.version,
+      },
+    ]);
   });
 
   it('should return negative result for safe domain from default config', async () => {
+    // Return API failure to ensure default config is not overwritten
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(500)
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(500);
+
     const controller = new PhishingController();
-    expect(
-      await controller.test('metamask.io'),
-    ).toMatchObject<EthPhishingDetectResult>({
+    expect(await controller.test('metamask.io')).toMatchObject({
       result: false,
       type: 'allowlist',
       name: 'MetaMask',
@@ -129,30 +228,45 @@ describe('PhishingController', () => {
   });
 
   it('should return negative result for safe unicode domain from default config', async () => {
+    // Return API failure to ensure default config is not overwritten
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(500)
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(500);
+
     const controller = new PhishingController();
-    expect(
-      await controller.test('i❤.ws'),
-    ).toMatchObject<EthPhishingDetectResult>({
+    expect(await controller.test('i❤.ws')).toMatchObject({
       result: false,
       type: 'all',
     });
   });
 
   it('should return negative result for safe punycode domain from default config', async () => {
+    // Return API failure to ensure default config is not overwritten
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(500)
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(500);
+
     const controller = new PhishingController();
-    expect(
-      await controller.test('xn--i-7iq.ws'),
-    ).toMatchObject<EthPhishingDetectResult>({
+    expect(await controller.test('xn--i-7iq.ws')).toMatchObject({
       result: false,
       type: 'all',
     });
   });
 
   it('should return positive result for unsafe domain from default config', async () => {
+    // Return API failure to ensure default config is not overwritten
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(500)
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(500);
+
     const controller = new PhishingController();
-    expect(
-      await controller.test('etnerscan.io'),
-    ).toMatchObject<EthPhishingDetectResult>({
+    expect(await controller.test('etnerscan.io')).toMatchObject({
       result: true,
       type: 'blocklist',
       name: 'MetaMask',
@@ -160,10 +274,15 @@ describe('PhishingController', () => {
   });
 
   it('should return positive result for unsafe unicode domain from default config', async () => {
+    // Return API failure to ensure default config is not overwritten
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(500)
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(500);
+
     const controller = new PhishingController();
-    expect(
-      await controller.test('myetherẉalletṭ.com'),
-    ).toMatchObject<EthPhishingDetectResult>({
+    expect(await controller.test('myetherẉalletṭ.com')).toMatchObject({
       result: true,
       type: 'blocklist',
       name: 'MetaMask',
@@ -171,10 +290,15 @@ describe('PhishingController', () => {
   });
 
   it('should return positive result for unsafe punycode domain from default config', async () => {
+    // Return API failure to ensure default config is not overwritten
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(500)
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(500);
+
     const controller = new PhishingController();
-    expect(
-      await controller.test('xn--myetherallet-4k5fwn.com'),
-    ).toMatchObject<EthPhishingDetectResult>({
+    expect(await controller.test('xn--myetherallet-4k5fwn.com')).toMatchObject({
       result: true,
       type: 'blocklist',
       name: `MetaMask`,
@@ -182,11 +306,21 @@ describe('PhishingController', () => {
   });
 
   it('should return negative result for safe domain from MetaMask config', async () => {
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(200, {
+        blacklist: [],
+        fuzzylist: [],
+        tolerance: 0,
+        whitelist: ['metamask.io'],
+        version: 0,
+      })
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(200, []);
+
     const controller = new PhishingController();
     await controller.updatePhishingLists();
-    expect(
-      await controller.test('metamask.io'),
-    ).toMatchObject<EthPhishingDetectResult>({
+    expect(await controller.test('metamask.io')).toMatchObject({
       result: false,
       type: 'allowlist',
       name: 'MetaMask',
@@ -194,33 +328,63 @@ describe('PhishingController', () => {
   });
 
   it('should return negative result for safe unicode domain from MetaMask config', async () => {
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(200, {
+        blacklist: [],
+        fuzzylist: [],
+        tolerance: 0,
+        whitelist: [],
+        version: 0,
+      })
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(200, []);
+
     const controller = new PhishingController();
     await controller.updatePhishingLists();
-    expect(
-      await controller.test('i❤.ws'),
-    ).toMatchObject<EthPhishingDetectResult>({
+    expect(await controller.test('i❤.ws')).toMatchObject({
       result: false,
       type: 'all',
     });
   });
 
   it('should return negative result for safe punycode domain from MetaMask config', async () => {
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(200, {
+        blacklist: [],
+        fuzzylist: [],
+        tolerance: 0,
+        whitelist: [],
+        version: 0,
+      })
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(200, []);
+
     const controller = new PhishingController();
     await controller.updatePhishingLists();
-    expect(
-      await controller.test('xn--i-7iq.ws'),
-    ).toMatchObject<EthPhishingDetectResult>({
+    expect(await controller.test('xn--i-7iq.ws')).toMatchObject({
       result: false,
       type: 'all',
     });
   });
 
   it('should return positive result for unsafe domain from MetaMask config', async () => {
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(200, {
+        blacklist: ['etnerscan.io'],
+        fuzzylist: [],
+        tolerance: 0,
+        whitelist: [],
+        version: 0,
+      })
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(200, []);
+
     const controller = new PhishingController();
     await controller.updatePhishingLists();
-    expect(
-      await controller.test('etnerscan.io'),
-    ).toMatchObject<EthPhishingDetectResult>({
+    expect(await controller.test('etnerscan.io')).toMatchObject({
       result: true,
       type: 'blocklist',
       name: 'MetaMask',
@@ -228,11 +392,21 @@ describe('PhishingController', () => {
   });
 
   it('should return positive result for unsafe unicode domain from MetaMask config', async () => {
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(200, {
+        blacklist: ['xn--myetherallet-4k5fwn.com'],
+        fuzzylist: [],
+        tolerance: 0,
+        whitelist: [],
+        version: 0,
+      })
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(200, []);
+
     const controller = new PhishingController();
     await controller.updatePhishingLists();
-    expect(
-      await controller.test('myetherẉalletṭ.com'),
-    ).toMatchObject<EthPhishingDetectResult>({
+    expect(await controller.test('myetherẉalletṭ.com')).toMatchObject({
       result: true,
       type: 'blocklist',
       name: 'MetaMask',
@@ -240,26 +414,36 @@ describe('PhishingController', () => {
   });
 
   it('should return negative result for unsafe unicode domain if the MetaMask config returns 500', async () => {
-    nock('https://cdn.jsdelivr.net', { allowUnmocked: true })
+    nock('https://cdn.jsdelivr.net')
       .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
       .reply(500)
-      .persist();
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(200, []);
+
     const controller = new PhishingController();
     await controller.updatePhishingLists();
-    expect(
-      await controller.test('myetherẉalletṭ.com'),
-    ).toMatchObject<EthPhishingDetectResult>({
+    expect(await controller.test('myetherẉalletṭ.com')).toMatchObject({
       result: false,
       type: 'all',
     });
   });
 
   it('should return positive result for unsafe punycode domain from MetaMask config', async () => {
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(200, {
+        blacklist: ['xn--myetherallet-4k5fwn.com'],
+        fuzzylist: [],
+        tolerance: 0,
+        whitelist: [],
+        version: 0,
+      })
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(200, []);
+
     const controller = new PhishingController();
     await controller.updatePhishingLists();
-    expect(
-      await controller.test('xn--myetherallet-4k5fwn.com'),
-    ).toMatchObject<EthPhishingDetectResult>({
+    expect(await controller.test('xn--myetherallet-4k5fwn.com')).toMatchObject({
       result: true,
       type: 'blocklist',
       name: 'MetaMask',
@@ -267,11 +451,23 @@ describe('PhishingController', () => {
   });
 
   it('should return positive result for unsafe unicode domain from the PhishFort hotlist (blocklist)', async () => {
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(200, {
+        blacklist: [],
+        fuzzylist: [],
+        tolerance: 0,
+        whitelist: [],
+        version: 0,
+      })
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(200, ['e4d600ab9141b7a9859511c77e63b9b3.com']);
+
     const controller = new PhishingController();
     await controller.updatePhishingLists();
     expect(
       await controller.test('e4d600ab9141b7a9859511c77e63b9b3.com'),
-    ).toMatchObject<EthPhishingDetectResult>({
+    ).toMatchObject({
       result: true,
       type: 'blocklist',
       name: 'PhishFort',
@@ -279,26 +475,44 @@ describe('PhishingController', () => {
   });
 
   it('should return negative result for unsafe unicode domain if the PhishFort hotlist (blocklist) returns 500', async () => {
-    nock('https://cdn.jsdelivr.net', { allowUnmocked: true })
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(200, {
+        blacklist: [],
+        fuzzylist: [],
+        tolerance: 0,
+        whitelist: [],
+        version: 0,
+      })
       .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
-      .reply(500)
-      .persist();
+      .reply(500);
+
     const controller = new PhishingController();
     await controller.updatePhishingLists();
     expect(
       await controller.test('e4d600ab9141b7a9859511c77e63b9b3.com'),
-    ).toMatchObject<EthPhishingDetectResult>({
+    ).toMatchObject({
       result: false,
       type: 'all',
     });
   });
 
   it('should return negative result for safe fuzzylist domain from MetaMask config', async () => {
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(200, {
+        blacklist: [],
+        fuzzylist: [],
+        tolerance: 0,
+        whitelist: ['opensea.io'],
+        version: 0,
+      })
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(200, []);
+
     const controller = new PhishingController();
     await controller.updatePhishingLists();
-    expect(
-      await controller.test('opensea.io'),
-    ).toMatchObject<EthPhishingDetectResult>({
+    expect(await controller.test('opensea.io')).toMatchObject({
       result: false,
       type: 'allowlist',
       name: 'MetaMask',
@@ -306,11 +520,21 @@ describe('PhishingController', () => {
   });
 
   it('should return positive result for domain very close to fuzzylist from MetaMask config', async () => {
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(200, {
+        blacklist: [],
+        fuzzylist: ['opensea.io'],
+        tolerance: 2,
+        whitelist: ['opensea.io'],
+        version: 0,
+      })
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(200, []);
+
     const controller = new PhishingController();
     await controller.updatePhishingLists();
-    expect(
-      await controller.test('ohpensea.io'),
-    ).toMatchObject<EthPhishingDetectResult>({
+    expect(await controller.test('ohpensea.io')).toMatchObject({
       result: true,
       type: 'fuzzy',
       name: 'MetaMask',
@@ -318,33 +542,56 @@ describe('PhishingController', () => {
   });
 
   it('should return negative result for domain very close to fuzzylist if MetaMask config returns 500', async () => {
-    nock('https://cdn.jsdelivr.net', { allowUnmocked: true })
+    nock('https://cdn.jsdelivr.net')
       .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
       .reply(500)
-      .persist();
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(200, []);
 
     const controller = new PhishingController();
     await controller.updatePhishingLists();
-    expect(
-      await controller.test('ohpensea.io'),
-    ).toMatchObject<EthPhishingDetectResult>({
+    expect(await controller.test('ohpensea.io')).toMatchObject({
       result: false,
       type: 'all',
     });
   });
 
   it('should return negative result for domain not very close to fuzzylist from MetaMask config', async () => {
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(200, {
+        blacklist: [],
+        fuzzylist: ['opensea.io'],
+        tolerance: 2,
+        whitelist: ['opensea.io'],
+        version: 0,
+      })
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(200, []);
+
     const controller = new PhishingController();
     await controller.updatePhishingLists();
     expect(
       await controller.test('this-is-the-official-website-of-opensea.io'),
-    ).toMatchObject<EthPhishingDetectResult>({
+    ).toMatchObject({
       result: false,
       type: 'all',
     });
   });
 
   it('should bypass a given domain, and return a negative result', async () => {
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(200, {
+        blacklist: ['electrum.mx'],
+        fuzzylist: [],
+        tolerance: 2,
+        whitelist: [],
+        version: 0,
+      })
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(200, []);
+
     const controller = new PhishingController();
     const unsafeDomain = 'electrum.mx';
     assert.equal(
@@ -353,15 +600,25 @@ describe('PhishingController', () => {
       'Example unsafe domain seems to be safe',
     );
     controller.bypass(unsafeDomain);
-    expect(
-      await controller.test(unsafeDomain),
-    ).toMatchObject<EthPhishingDetectResult>({
+    expect(await controller.test(unsafeDomain)).toMatchObject({
       result: false,
       type: 'all',
     });
   });
 
   it('should ignore second attempt to bypass a domain, and still return a negative result', async () => {
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(200, {
+        blacklist: ['electrum.mx'],
+        fuzzylist: [],
+        tolerance: 2,
+        whitelist: [],
+        version: 0,
+      })
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(200, []);
+
     const controller = new PhishingController();
     const unsafeDomain = 'electrum.mx';
     assert.equal(
@@ -371,15 +628,25 @@ describe('PhishingController', () => {
     );
     controller.bypass(unsafeDomain);
     controller.bypass(unsafeDomain);
-    expect(
-      await controller.test(unsafeDomain),
-    ).toMatchObject<EthPhishingDetectResult>({
+    expect(await controller.test(unsafeDomain)).toMatchObject({
       result: false,
       type: 'all',
     });
   });
 
   it('should bypass a given unicode domain, and return a negative result', async () => {
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(200, {
+        blacklist: ['xn--myetherallet-4k5fwn.com'],
+        fuzzylist: [],
+        tolerance: 2,
+        whitelist: [],
+        version: 0,
+      })
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(200, []);
+
     const controller = new PhishingController();
     const unsafeDomain = 'myetherẉalletṭ.com';
     assert.equal(
@@ -388,15 +655,25 @@ describe('PhishingController', () => {
       'Example unsafe domain seems to be safe',
     );
     controller.bypass(unsafeDomain);
-    expect(
-      await controller.test(unsafeDomain),
-    ).toMatchObject<EthPhishingDetectResult>({
+    expect(await controller.test(unsafeDomain)).toMatchObject({
       result: false,
       type: 'all',
     });
   });
 
   it('should bypass a given punycode domain, and return a negative result', async () => {
+    nock('https://cdn.jsdelivr.net')
+      .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
+      .reply(200, {
+        blacklist: ['xn--myetherallet-4k5fwn.com'],
+        fuzzylist: [],
+        tolerance: 2,
+        whitelist: [],
+        version: 0,
+      })
+      .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
+      .reply(200, []);
+
     const controller = new PhishingController();
     const unsafeDomain = 'xn--myetherallet-4k5fwn.com';
     assert.equal(
@@ -405,42 +682,53 @@ describe('PhishingController', () => {
       'Example unsafe domain seems to be safe',
     );
     controller.bypass(unsafeDomain);
-    expect(
-      await controller.test(unsafeDomain),
-    ).toMatchObject<EthPhishingDetectResult>({
+    expect(await controller.test(unsafeDomain)).toMatchObject({
       result: false,
       type: 'all',
     });
   });
 
   it('should not update phishing lists if fetch returns 304', async () => {
-    nock('https://cdn.jsdelivr.net', { allowUnmocked: true })
+    nock('https://cdn.jsdelivr.net')
       .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
       .reply(304)
       .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
-      .reply(304)
-      .persist();
-    const controller = new PhishingController();
-    const oldState = controller.state.phishing;
+      .reply(304);
 
+    const controller = new PhishingController();
     await controller.updatePhishingLists();
 
-    expect(controller.state.phishing).toBe(oldState);
+    expect(controller.state.phishing).toStrictEqual([
+      {
+        allowlist: DEFAULT_PHISHING_RESPONSE.whitelist,
+        blocklist: DEFAULT_PHISHING_RESPONSE.blacklist,
+        fuzzylist: DEFAULT_PHISHING_RESPONSE.fuzzylist,
+        tolerance: DEFAULT_PHISHING_RESPONSE.tolerance,
+        name: `MetaMask`,
+        version: DEFAULT_PHISHING_RESPONSE.version,
+      },
+    ]);
   });
 
   it('should not update phishing lists if fetch returns 500', async () => {
-    nock('https://cdn.jsdelivr.net', { allowUnmocked: true })
+    nock('https://cdn.jsdelivr.net')
       .get('/gh/MetaMask/eth-phishing-detect@master/src/config.json')
       .reply(500)
       .get('/gh/phishfort/phishfort-lists@master/blacklists/hotlist.json')
-      .reply(500)
-      .persist();
+      .reply(500);
 
     const controller = new PhishingController();
-    const oldState = controller.state.phishing;
-
     await controller.updatePhishingLists();
 
-    expect(controller.state.phishing).toBe(oldState);
+    expect(controller.state.phishing).toStrictEqual([
+      {
+        allowlist: DEFAULT_PHISHING_RESPONSE.whitelist,
+        blocklist: DEFAULT_PHISHING_RESPONSE.blacklist,
+        fuzzylist: DEFAULT_PHISHING_RESPONSE.fuzzylist,
+        tolerance: DEFAULT_PHISHING_RESPONSE.tolerance,
+        name: `MetaMask`,
+        version: DEFAULT_PHISHING_RESPONSE.version,
+      },
+    ]);
   });
 });

--- a/src/third-party/PhishingController.ts
+++ b/src/third-party/PhishingController.ts
@@ -119,16 +119,12 @@ export class PhishingController extends BaseController<
     this.defaultState = {
       phishing: [
         {
-          allowlist: (DEFAULT_PHISHING_RESPONSE as EthPhishingResponse)
-            .whitelist,
-          blocklist: (DEFAULT_PHISHING_RESPONSE as EthPhishingResponse)
-            .blacklist,
-          fuzzylist: (DEFAULT_PHISHING_RESPONSE as EthPhishingResponse)
-            .fuzzylist,
-          tolerance: (DEFAULT_PHISHING_RESPONSE as EthPhishingResponse)
-            .tolerance,
+          allowlist: DEFAULT_PHISHING_RESPONSE.whitelist,
+          blocklist: DEFAULT_PHISHING_RESPONSE.blacklist,
+          fuzzylist: DEFAULT_PHISHING_RESPONSE.fuzzylist,
+          tolerance: DEFAULT_PHISHING_RESPONSE.tolerance,
           name: `MetaMask`,
-          version: (DEFAULT_PHISHING_RESPONSE as EthPhishingResponse).version,
+          version: DEFAULT_PHISHING_RESPONSE.version,
         },
       ],
       whitelist: [],


### PR DESCRIPTION
The PhishingController tests now use fetch mocks for all tests that use fetch. `nock` is used to disable any network unmocked network requests. This should make the test suite more reliable, as it won't be affected by intermittent network failures anymore. To some degree it makes the tests more readable as well by making it more clear what is happening, at the cost of making them more verbose.

A few other minor improvements have been made as well, such as removing redundant tests and removing unnecessary generic type parameters. An unnecessary cast has been removed from the PhishingController as well.

I was tempted to make many further improvements to the tests beyond here, to make them easier to read, more in-line with our conventions, and more comprehensive. But I stopped here so that the diff for this PR would still be easily readable. Further improvements can be made later.