### PR TITLE
Fix issues with empty responses in ERC20Standard

### DIFF
--- a/src/assets/Standards/ERC20Standard.ts
+++ b/src/assets/Standards/ERC20Standard.ts
@@ -78,7 +78,7 @@ export class ERC20Standard {
 
         const abiCoder = new AbiCoder();
 
-        // Parse as string
+        // Parse as string - treat empty string as failure
         try {
           const decoded = abiCoder.decode(['string'], result)[0];
           if (decoded?.length > 0) {
@@ -89,7 +89,7 @@ export class ERC20Standard {
           // Ignore error
         }
 
-        // Parse as bytes
+        // Parse as bytes - treat empty string as failure
         try {
           const utf8 = toUtf8(result);
           if (utf8.length > 0) {

--- a/src/assets/Standards/ERC20Standard.ts
+++ b/src/assets/Standards/ERC20Standard.ts
@@ -47,7 +47,13 @@ export class ERC20Standard {
           reject(error);
           return;
         }
-        resolve(result.toString());
+
+        const resultString = result.toString();
+        if (resultString.length > 0 && resultString !== '0') {
+          resolve(resultString);
+        }
+
+        reject(new Error('Failed to parse token decimals'));
       });
     });
   }
@@ -74,7 +80,7 @@ export class ERC20Standard {
         // Parse as string
         try {
           const decoded = abiCoder.decode(['string'], result)[0];
-          if (decoded) {
+          if (decoded?.length > 0) {
             resolve(decoded);
             return;
           }
@@ -85,8 +91,10 @@ export class ERC20Standard {
         // Parse as bytes
         try {
           const utf8 = toUtf8(result);
-          resolve(utf8);
-          return;
+          if (utf8.length > 0) {
+            resolve(utf8);
+            return;
+          }
         } catch {
           // Ignore error
         }

--- a/src/assets/Standards/ERC20Standard.ts
+++ b/src/assets/Standards/ERC20Standard.ts
@@ -49,6 +49,7 @@ export class ERC20Standard {
         }
 
         const resultString = result.toString();
+        // We treat empty string or 0 as invalid
         if (resultString.length > 0 && resultString !== '0') {
           resolve(resultString);
         }


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->


**Description**
This PR fixes some issues with ERC20Standard and proxy contracts. Some proxy contracts return `0x` instead of reverting when an unknown method signature is used. This PR adds requirements for `symbol()` and `decimals()` to be non-empty.

_Itemize the changes you have made into the categories below_

- FIXED:

  - Fix issues with empty responses in ERC20 standard

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented

**Issue**

Fixes https://github.com/MetaMask/metamask-extension/issues/16076
