### PR TITLE
Add slack-github-action

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           # metamask-dev channel-id
           channel-id: 'G1L7H42BT'
-          slack-message: "A deployment is awaiting review and deployment at: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/"
+          slack-message: 'A deployment is awaiting review and deployment at: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -65,6 +65,20 @@ jobs:
         env:
           SKIP_PREPACK: true
 
+  publish-npm-slack-announce:
+    runs-on: ubuntu-latest
+    needs: publish-npm-dry-run
+    steps:
+      - name: Post to a Slack channel
+        id: slack
+        uses: slackapi/slack-github-action@v1.22.0
+        with:
+          # metamask-dev channel-id
+          channel-id: 'G1L7H42BT'
+          slack-message: "A deployment is awaiting review and deployment at: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
   publish-npm:
     environment: npm-publish
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will announce when a workflow run needs review/approval on Slack

TODO:

- [ ] <strike>add `slackapi/slack-github-action@v1.22.0` to org list of approved GitHub Actions</strike>
- [ ] <strike>add `secrets.SLACK_BOT_TOKEN` to repository (who do I talk to about this?)</strike>
- [x] consider maybe adding this as a config option to `action-npm-publish` so we don't have to paste this block everywhere?

re: https://github.com/MetaMask/action-npm-publish/issues/6