### PR TITLE
Make both callback and messaging system options for `TokenListController` & `GasFeeController` when listening to `NetworkController`

### DIFF
--- a/src/assets/TokenListController.test.ts
+++ b/src/assets/TokenListController.test.ts
@@ -654,7 +654,6 @@ describe('TokenListController', () => {
     });
     controller.start();
     await new Promise<void>((resolve) => setTimeout(() => resolve(), 150));
-    // expect(controller.state.tokenList).toStrictEqual(sampleMainnetTokenList)
     expect(controller.state.tokenList).toStrictEqual(
       sampleSingleChainState.tokenList,
     );

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -150,7 +150,8 @@ export class TokenListController extends BaseController<
   }
 
   /**
-   * Updates tokenList state and restart polling when updates are received through NetworkController subscription
+   * Updates state and restart polling when updates are received through NetworkController subscription.
+   *
    * @param providerConfig - the configuration for a provider containing critical network info.
    */
   async #onNetworkStateChangeCallback(providerConfig: ProviderConfig) {

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -117,7 +117,7 @@ export class TokenListController extends BaseController<
     chainId: string;
     preventPollingOnNetworkRestart?: boolean;
     onNetworkStateChange?: (
-      listener: (networkState: NetworkState) => void,
+      listener: (networkState: NetworkState | ProviderConfig) => void,
     ) => void;
     interval?: number;
     cacheRefreshThreshold?: number;
@@ -136,8 +136,23 @@ export class TokenListController extends BaseController<
     this.updatePreventPollingOnNetworkRestart(preventPollingOnNetworkRestart);
     this.abortController = new AbortController();
     if (onNetworkStateChange) {
-      onNetworkStateChange(async ({ provider }) => {
-        await this.#onNetworkStateChangeCallback(provider);
+      onNetworkStateChange(async (networkStateOrProviderConfig) => {
+        // for testing purposes, since in the extension this callback will receive an object typed as NetworkState
+        // but within repo we can only simulate as if the callback receives an object typed as ProviderConfig
+        if ('provider' in networkStateOrProviderConfig) {
+          console.log(
+            'networkStateOrProviderConfig',
+            networkStateOrProviderConfig,
+          );
+
+          await this.#onNetworkStateChangeCallback(
+            networkStateOrProviderConfig.provider,
+          );
+        } else {
+          await this.#onNetworkStateChangeCallback(
+            networkStateOrProviderConfig,
+          );
+        }
       });
     } else {
       this.messagingSystem.subscribe(

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -137,19 +137,19 @@ export class TokenListController extends BaseController<
     this.abortController = new AbortController();
     if (onNetworkStateChange) {
       onNetworkStateChange(async ({ provider }) => {
-        await this.onNetworkStateChangeCb(provider);
+        await this.onNetworkStateChangeCallback(provider);
       });
     } else {
       this.messagingSystem.subscribe(
         'NetworkController:providerChange',
         async (providerConfig) => {
-          await this.onNetworkStateChangeCb(providerConfig);
+          await this.onNetworkStateChangeCallback(providerConfig);
         },
       );
     }
   }
 
-  async onNetworkStateChangeCb(providerConfig: ProviderConfig) {
+  async onNetworkStateChangeCallback(providerConfig: ProviderConfig) {
     if (this.chainId !== providerConfig.chainId) {
       this.abortController.abort();
       this.abortController = new AbortController();

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -137,19 +137,23 @@ export class TokenListController extends BaseController<
     this.abortController = new AbortController();
     if (onNetworkStateChange) {
       onNetworkStateChange(async ({ provider }) => {
-        await this.onNetworkStateChangeCallback(provider);
+        await this.#onNetworkStateChangeCallback(provider);
       });
     } else {
       this.messagingSystem.subscribe(
         'NetworkController:providerChange',
         async (providerConfig) => {
-          await this.onNetworkStateChangeCallback(providerConfig);
+          await this.#onNetworkStateChangeCallback(providerConfig);
         },
       );
     }
   }
 
-  async onNetworkStateChangeCallback(providerConfig: ProviderConfig) {
+  /**
+   * Updates tokenList state and restart polling when updates are received through NetworkController subscription
+   * @param providerConfig - the configuration for a provider containing critical network info.
+   */
+  async #onNetworkStateChangeCallback(providerConfig: ProviderConfig) {
     if (this.chainId !== providerConfig.chainId) {
       this.abortController.abort();
       this.abortController = new AbortController();

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -5,7 +5,7 @@ import { BaseController } from '../BaseControllerV2';
 import type { RestrictedControllerMessenger } from '../ControllerMessenger';
 import { safelyExecute, isTokenListSupportedForNetwork } from '../util';
 import { fetchTokenList } from '../apis/token-service';
-import { NetworkControllerProviderChangeEvent } from '../network/NetworkController';
+import { NetworkState } from '../network/NetworkController';
 import { formatAggregatorNames, formatIconUrlWithProxy } from './assetsUtil';
 
 const DEFAULT_INTERVAL = 24 * 60 * 60 * 1000;
@@ -52,9 +52,9 @@ export type GetTokenListState = {
 type TokenListMessenger = RestrictedControllerMessenger<
   typeof name,
   GetTokenListState,
-  TokenListStateChange | NetworkControllerProviderChangeEvent,
+  TokenListStateChange,
   never,
-  TokenListStateChange['type'] | NetworkControllerProviderChangeEvent['type']
+  TokenListStateChange['type']
 >;
 
 const metadata = {
@@ -94,6 +94,7 @@ export class TokenListController extends BaseController<
    *
    * @param options - The controller options.
    * @param options.chainId - The chain ID of the current network.
+   * @param options.onNetworkStateChange - A function for registering an event handler for network state changes.
    * @param options.interval - The polling interval, in milliseconds.
    * @param options.cacheRefreshThreshold - The token cache expiry time, in milliseconds.
    * @param options.messenger - A restricted controller messenger.
@@ -103,6 +104,7 @@ export class TokenListController extends BaseController<
   constructor({
     chainId,
     preventPollingOnNetworkRestart = false,
+    onNetworkStateChange,
     interval = DEFAULT_INTERVAL,
     cacheRefreshThreshold = DEFAULT_THRESHOLD,
     messenger,
@@ -110,6 +112,9 @@ export class TokenListController extends BaseController<
   }: {
     chainId: string;
     preventPollingOnNetworkRestart?: boolean;
+    onNetworkStateChange: (
+      listener: (networkState: NetworkState) => void,
+    ) => void;
     interval?: number;
     cacheRefreshThreshold?: number;
     messenger: TokenListMessenger;
@@ -126,29 +131,25 @@ export class TokenListController extends BaseController<
     this.chainId = chainId;
     this.updatePreventPollingOnNetworkRestart(preventPollingOnNetworkRestart);
     this.abortController = new AbortController();
-    this.messagingSystem.subscribe(
-      'NetworkController:providerChange',
-      async (providerConfig) => {
-        if (this.chainId !== providerConfig.chainId) {
-          this.abortController.abort();
-          this.abortController = new AbortController();
-          this.chainId = providerConfig.chainId;
-          if (this.state.preventPollingOnNetworkRestart) {
-            this.clearingTokenListData();
-          } else {
-            // Ensure tokenList is referencing data from correct network
-            this.update(() => {
-              return {
-                ...this.state,
-                tokenList:
-                  this.state.tokensChainsCache[this.chainId]?.data || {},
-              };
-            });
-            await this.restart();
-          }
+    onNetworkStateChange(async (networkState) => {
+      if (this.chainId !== networkState.provider.chainId) {
+        this.abortController.abort();
+        this.abortController = new AbortController();
+        this.chainId = networkState.provider.chainId;
+        if (this.state.preventPollingOnNetworkRestart) {
+          this.clearingTokenListData();
+        } else {
+          // Ensure tokenList is referencing data from correct network
+          this.update(() => {
+            return {
+              ...this.state,
+              tokenList: this.state.tokensChainsCache[this.chainId]?.data || {},
+            };
+          });
+          await this.restart();
         }
-      },
-    );
+      }
+    });
   }
 
   /**

--- a/src/assets/TokenListController.ts
+++ b/src/assets/TokenListController.ts
@@ -137,14 +137,10 @@ export class TokenListController extends BaseController<
     this.abortController = new AbortController();
     if (onNetworkStateChange) {
       onNetworkStateChange(async (networkStateOrProviderConfig) => {
-        // for testing purposes, since in the extension this callback will receive an object typed as NetworkState
-        // but within repo we can only simulate as if the callback receives an object typed as ProviderConfig
+        // this check for "provider" is for testing purposes, since in the extension this callback will receive
+        // an object typed as NetworkState but within repo we can only simulate as if the callback receives an
+        // object typed as ProviderConfig
         if ('provider' in networkStateOrProviderConfig) {
-          console.log(
-            'networkStateOrProviderConfig',
-            networkStateOrProviderConfig,
-          );
-
           await this.#onNetworkStateChangeCallback(
             networkStateOrProviderConfig.provider,
           );

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -305,8 +305,8 @@ export class GasFeeController extends BaseController<
     getCurrentNetworkEIP1559Compatibility: () => Promise<boolean>;
     getCurrentNetworkLegacyGasAPICompatibility: () => boolean;
     getCurrentAccountEIP1559Compatibility?: () => boolean;
-    getChainId: () => `0x${string}` | `${number}` | number;
-    getProvider: () => NetworkController['provider'];
+    getChainId?: () => `0x${string}` | `${number}` | number;
+    getProvider?: () => NetworkController['provider'];
     onNetworkStateChange?: (listener: (state: NetworkState) => void) => void;
     legacyAPIEndpoint?: string;
     EIP1559APIEndpoint?: string;

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -1,5 +1,6 @@
 import type { Patch } from 'immer';
 
+import EthQuery from 'eth-query';
 import { v1 as random } from 'uuid';
 import { isHexString } from 'ethereumjs-util';
 import { BaseController } from '../BaseControllerV2';
@@ -9,6 +10,8 @@ import type {
   NetworkControllerGetEthQueryAction,
   NetworkControllerGetProviderConfigAction,
   NetworkControllerProviderChangeEvent,
+  NetworkController,
+  NetworkState,
 } from '../network/NetworkController';
 import {
   fetchGasEstimates,
@@ -250,6 +253,8 @@ export class GasFeeController extends BaseController<
 
   private getCurrentAccountEIP1559Compatibility;
 
+  private getChainId;
+
   private currentChainId;
 
   private ethQuery: any;
@@ -269,6 +274,10 @@ export class GasFeeController extends BaseController<
    * current network is compatible with the legacy gas price API.
    * @param options.getCurrentAccountEIP1559Compatibility - Determines whether or not the current
    * account is EIP-1559 compatible.
+   * @param options.getChainId - Returns the current chain ID.
+   * @param options.getProvider - Returns a network provider for the current network.
+   * @param options.onNetworkStateChange - A function for registering an event handler for the
+   * network state change event.
    * @param options.legacyAPIEndpoint - The legacy gas price API URL. This option is primarily for
    * testing purposes.
    * @param options.EIP1559APIEndpoint - The EIP-1559 gas price API URL. This option is primarily
@@ -282,7 +291,10 @@ export class GasFeeController extends BaseController<
     state,
     getCurrentNetworkEIP1559Compatibility,
     getCurrentAccountEIP1559Compatibility,
+    getChainId,
     getCurrentNetworkLegacyGasAPICompatibility,
+    getProvider,
+    onNetworkStateChange,
     legacyAPIEndpoint = LEGACY_GAS_PRICES_API_URL,
     EIP1559APIEndpoint = GAS_FEE_API,
     clientId,
@@ -293,6 +305,9 @@ export class GasFeeController extends BaseController<
     getCurrentNetworkEIP1559Compatibility: () => Promise<boolean>;
     getCurrentNetworkLegacyGasAPICompatibility: () => boolean;
     getCurrentAccountEIP1559Compatibility?: () => boolean;
+    getChainId: () => `0x${string}` | `${number}` | number;
+    getProvider: () => NetworkController['provider'];
+    onNetworkStateChange?: (listener: (state: NetworkState) => void) => void;
     legacyAPIEndpoint?: string;
     EIP1559APIEndpoint?: string;
     clientId?: string;
@@ -315,25 +330,41 @@ export class GasFeeController extends BaseController<
       getCurrentAccountEIP1559Compatibility;
     this.EIP1559APIEndpoint = EIP1559APIEndpoint;
     this.legacyAPIEndpoint = legacyAPIEndpoint;
-    const providerConfig = this.messagingSystem.call(
-      'NetworkController:getProviderConfig',
-    );
-    this.currentChainId = providerConfig.chainId;
-    this.ethQuery = this.messagingSystem.call('NetworkController:getEthQuery');
     this.clientId = clientId;
-    this.messagingSystem.subscribe(
-      'NetworkController:providerChange',
-      async (provider) => {
-        this.ethQuery = this.messagingSystem.call(
-          'NetworkController:getEthQuery',
-        );
-
-        if (this.currentChainId !== provider.chainId) {
-          this.currentChainId = provider.chainId;
+    this.getChainId = getChainId;
+    if (onNetworkStateChange) {
+      this.currentChainId = this.getChainId();
+      onNetworkStateChange(async () => {
+        const newProvider = getProvider();
+        const newChainId = this.getChainId();
+        this.ethQuery = new EthQuery(newProvider);
+        if (this.currentChainId !== newChainId) {
+          this.currentChainId = newChainId;
           await this.resetPolling();
         }
-      },
-    );
+      });
+    } else {
+      const providerConfig = this.messagingSystem.call(
+        'NetworkController:getProviderConfig',
+      );
+      this.currentChainId = providerConfig.chainId;
+      this.ethQuery = this.messagingSystem.call(
+        'NetworkController:getEthQuery',
+      );
+      this.messagingSystem.subscribe(
+        'NetworkController:providerChange',
+        async (provider) => {
+          this.ethQuery = this.messagingSystem.call(
+            'NetworkController:getEthQuery',
+          );
+
+          if (this.currentChainId !== provider.chainId) {
+            this.currentChainId = provider.chainId;
+            await this.resetPolling();
+          }
+        },
+      );
+    }
   }
 
   async resetPolling() {

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -351,6 +351,7 @@ export class GasFeeController extends BaseController<
       this.ethQuery = this.messagingSystem.call(
         'NetworkController:getEthQuery',
       );
+
       this.messagingSystem.subscribe(
         'NetworkController:providerChange',
         async (provider) => {

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -253,8 +253,6 @@ export class GasFeeController extends BaseController<
 
   private getCurrentAccountEIP1559Compatibility;
 
-  private getChainId;
-
   private currentChainId;
 
   private ethQuery: any;
@@ -331,12 +329,11 @@ export class GasFeeController extends BaseController<
     this.EIP1559APIEndpoint = EIP1559APIEndpoint;
     this.legacyAPIEndpoint = legacyAPIEndpoint;
     this.clientId = clientId;
-    this.getChainId = getChainId;
-    if (onNetworkStateChange) {
-      this.currentChainId = this.getChainId();
+    if (onNetworkStateChange && getChainId && getProvider) {
+      this.currentChainId = getChainId();
       onNetworkStateChange(async () => {
         const newProvider = getProvider();
-        const newChainId = this.getChainId();
+        const newChainId = getChainId();
         this.ethQuery = new EthQuery(newProvider);
         if (this.currentChainId !== newChainId) {
           this.currentChainId = newChainId;


### PR DESCRIPTION
- FIXED:

  - `onNetworkStateChanged` callback was mistakenly removed from `TokenListController` in v32.0.0. It is now added back and is available as an option alongside a messaging system subscription for syncing with `NetworkController` updates

