### PR TITLE
Fix occasional type errors when running tests

### DIFF
--- a/tests/setupAfterEnv.ts
+++ b/tests/setupAfterEnv.ts
@@ -1,15 +1,3 @@
-declare global {
-  // Using `namespace` here is okay because this is how the Jest types are
-  // defined.
-  /* eslint-disable-next-line @typescript-eslint/no-namespace */
-  namespace jest {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/ban-types
-    interface Matchers<R, T = {}> {
-      toNeverResolve(): Promise<R>;
-    }
-  }
-}
-
 const UNRESOLVED = Symbol('timedOut');
 // Store this in case it gets stubbed later
 const originalSetTimeout = global.setTimeout;

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,0 +1,14 @@
+declare global {
+  // Using `namespace` here is okay because this is how the Jest types are
+  // defined.
+  /* eslint-disable-next-line @typescript-eslint/no-namespace */
+  namespace jest {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/ban-types
+    interface Matchers<R, T = {}> {
+      toNeverResolve(): Promise<R>;
+    }
+  }
+}
+
+// Export something so that TypeScript knows to interpret this as a module
+export {};


### PR DESCRIPTION
I have noticed that locally `yarn test` will succeed the first time, the will fail with a type error saying `toNeverResolve` is undefined. After running `yarn jest --clearCache`, tests will pass again once then fail again.

This custom Jest matcher was added in #930. Seemingly the way the type was added is causing this problem.

I'm not entirely sure what's going on here. Something about the way Jest is loading this file is making Jest confused about this type. I found that it works more reliably if the type is moved to a separate file in the `types` directory.