### PR TITLE
fix issue where ethQuery is not instantiated correctly when GasFeeController is constructed

### DIFF
--- a/src/gas/GasFeeController.test.ts
+++ b/src/gas/GasFeeController.test.ts
@@ -199,6 +199,7 @@ describe('GasFeeController', () => {
     legacyAPIEndpoint = 'http://legacy.endpoint/<chain_id>',
     EIP1559APIEndpoint = 'http://eip-1559.endpoint/<chain_id>',
     clientId,
+    getChainId,
   }: {
     getChainId?: jest.Mock<`0x${string}` | `${number}` | number>;
     getIsEIP1559Compatible?: jest.Mock<Promise<boolean>>;
@@ -211,6 +212,8 @@ describe('GasFeeController', () => {
     setupNetworkController(controllerMessenger);
     const messenger = getRestrictedMessenger(controllerMessenger);
     gasFeeController = new GasFeeController({
+      getProvider: jest.fn(),
+      getChainId,
       messenger,
       getCurrentNetworkLegacyGasAPICompatibility,
       getCurrentNetworkEIP1559Compatibility: getIsEIP1559Compatible, // change this for networkController.state.properties.isEIP1559Compatible ???

--- a/src/gas/GasFeeController.ts
+++ b/src/gas/GasFeeController.ts
@@ -304,7 +304,7 @@ export class GasFeeController extends BaseController<
     getCurrentNetworkLegacyGasAPICompatibility: () => boolean;
     getCurrentAccountEIP1559Compatibility?: () => boolean;
     getChainId?: () => `0x${string}` | `${number}` | number;
-    getProvider?: () => NetworkController['provider'];
+    getProvider: () => NetworkController['provider'];
     onNetworkStateChange?: (listener: (state: NetworkState) => void) => void;
     legacyAPIEndpoint?: string;
     EIP1559APIEndpoint?: string;
@@ -329,7 +329,9 @@ export class GasFeeController extends BaseController<
     this.EIP1559APIEndpoint = EIP1559APIEndpoint;
     this.legacyAPIEndpoint = legacyAPIEndpoint;
     this.clientId = clientId;
-    if (onNetworkStateChange && getChainId && getProvider) {
+    const initialProvider = getProvider();
+    this.ethQuery = new EthQuery(initialProvider);
+    if (onNetworkStateChange && getChainId) {
       this.currentChainId = getChainId();
       onNetworkStateChange(async () => {
         const newProvider = getProvider();


### PR DESCRIPTION
- FIXED:

  - Fixes an issue (I) introduced in v32.0.1 where an instance of `ethQuery` is not instantiated correctly when `GasFeeController` is constructed, which is currently causing an E2E test failure on this [PR in the extension](https://github.com/MetaMask/metamask-extension/pull/16033).
