### PR TITLE
Keep indent size of 2 for Markdown files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,4 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 [*.md]
-indent_size = 4
 trim_trailing_whitespace = false


### PR DESCRIPTION
It's common in Markdown to indent things by 4 spaces. If you want to make a code block, you can indent it by 4 spaces. If you want to nest a block inside of a block — say, a code block inside of a list item — you use 4 spaces.

Speaking of code blocks, we usually use *fenced* code blocks, which allows you to specify a language in which that code is written, and those don't need to be indented by 4 spaces. Within such a code block, the indentation convention is still usually 2 spaces, so that if indentation is set to 4 spaces via `.editorconfig`, one needs to constantly go back and adjust that indentation. This gets to be annoying after a while, so this commit removes that setting from `.editorconfig`.