### PR TITLE
Lint, then build, then test

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -1,4 +1,4 @@
-name: Build, Lint, and Test
+name: Lint, Build, and Test
 
 on:
   push:
@@ -6,8 +6,8 @@ on:
   pull_request:
 
 jobs:
-  build-lint-test:
-    name: Build, Lint, and Test
+  check-build-test:
+    name: Lint, Build, and Test
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -30,19 +30,19 @@ jobs:
           path: ${{ steps.yarn-cache-dir.outputs.YARN_CACHE_DIR }}
           key: yarn-cache-${{ runner.os }}-${{ steps.yarn-version.outputs.YARN_VERSION }}-${{ hashFiles('yarn.lock') }}
       - run: yarn --immutable
-      - run: yarn build
       - run: yarn lint
-      - run: yarn test --maxWorkers=1
       - name: Validate RC changelog
         if: ${{ startsWith(github.ref, 'release/') }}
         run: yarn auto-changelog validate --rc
       - name: Validate changelog
         if: ${{ !startsWith(github.ref, 'release/') }}
         run: yarn auto-changelog validate
+      - run: yarn build
+      - run: yarn test --maxWorkers=1
   all-jobs-pass:
     name: All jobs pass
     runs-on: ubuntu-20.04
     needs:
-      - build-lint-test
+      - lint-build-test
     steps:
       - run: echo "Great success!"

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  check-build-test:
+  lint-build-test:
     name: Lint, Build, and Test
     runs-on: ubuntu-20.04
     strategy:


### PR DESCRIPTION
Make a couple of updates to the GitHub workflow that executes on pushes to pull requests and `main`:

1. Lint before building instead of afterward. Why? Typically when running checks, the lint step fails more often than the build step, and compiling TypeScript can take longer than linting especially on larger repos like this one. Switching around these steps in the workflow config means that a developer who has pushed changes to their pull request is now able to monitor the GitHub checks in real time more easily, because if there any linting violations with their latest changes, the developer will be able to see them more quickly.
2. Validate the changelog directly after the  linting step. As with the linting step, the changelog validation step is likely to fail, especially on a release branch, so again, the whole workflow should fail more quickly if there are any formatting issues.