### PR TITLE
Add clear function for NotificationController

### DIFF
--- a/src/notification/NotificationController.test.ts
+++ b/src/notification/NotificationController.test.ts
@@ -110,4 +110,24 @@ describe('NotificationController', () => {
 
     expect(Object.values(controller.state.notifications)).toHaveLength(0);
   });
+
+  it('action: NotificationController:clear', async () => {
+    const unrestricted = getUnrestrictedMessenger();
+    const messenger = getRestrictedMessenger(unrestricted);
+
+    const controller = new NotificationController({
+      messenger,
+    });
+
+    expect(
+      await unrestricted.call('NotificationController:show', origin, message),
+    ).toBeUndefined();
+    const notifications = Object.values(controller.state.notifications);
+    expect(notifications).toHaveLength(1);
+    expect(
+      await unrestricted.call('NotificationController:clear'),
+    ).toBeUndefined();
+
+    expect(Object.values(controller.state.notifications)).toHaveLength(0);
+  });
 });

--- a/src/notification/NotificationController.ts
+++ b/src/notification/NotificationController.ts
@@ -57,11 +57,17 @@ export type MarkNotificationRead = {
   handler: NotificationController['markRead'];
 };
 
+export type ClearNotifications = {
+  type: `${typeof name}:clear`;
+  handler: NotificationController['clear'];
+};
+
 export type NotificationControllerActions =
   | GetNotificationControllerState
   | ShowNotification
   | DismissNotification
-  | MarkNotificationRead;
+  | MarkNotificationRead
+  | ClearNotifications;
 
 export type NotificationControllerMessenger = RestrictedControllerMessenger<
   typeof name,
@@ -122,6 +128,10 @@ export class NotificationController extends BaseController<
       `${name}:markRead` as const,
       (ids: string[]) => this.markRead(ids),
     );
+
+    this.messagingSystem.registerActionHandler(`${name}:clear` as const, () =>
+      this.clear(),
+    );
   }
 
   /**
@@ -171,6 +181,16 @@ export class NotificationController extends BaseController<
           state.notifications[id].readDate = Date.now();
         }
       }
+    });
+  }
+
+  /**
+   * Clears the state of the controller, removing all notifications.
+   *
+   */
+  clear() {
+    this.update(() => {
+      return { ...defaultState };
     });
   }
 }


### PR DESCRIPTION
Adds `clear` function to the `NotificationController` so we can delete the entire controller state at will. This will be useful for when restoring the vault.

_Itemize the changes you have made into the categories below_

- ADDED:
  - Added `clear` function to the `NotificationController`

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented
