### PR TITLE
NetworkController setProviderType doesn't reset the rpcTarget and nickname

### DIFF
--- a/src/network/NetworkController.test.ts
+++ b/src/network/NetworkController.test.ts
@@ -166,6 +166,20 @@ describe('NetworkController', () => {
     expect(controller.state.provider.nickname).toBeUndefined();
   });
 
+  it('should set rpcTarget and nickname props to undefined when set a provider type', () => {
+    const controller = new NetworkController({
+      messenger,
+      infuraProjectId: '123',
+    });
+    controller.setRpcTarget(RPC_TARGET, NetworksChainId.rpc);
+    controller.setProviderType('mainnet' as NetworkType);
+    expect(controller.state.provider.type).toBe('mainnet');
+    expect(controller.state.provider.ticker).toBe('ETH');
+    expect(controller.state.isCustomNetwork).toBe(false);
+    expect(controller.state.provider.rpcTarget).toBeUndefined();
+    expect(controller.state.provider.nickname).toBeUndefined();
+  });
+
   it('should throw when setting an unrecognized provider type', () => {
     const controller = new NetworkController({ messenger });
     expect(() => controller.setProviderType('junk' as NetworkType)).toThrow(

--- a/src/network/NetworkController.test.ts
+++ b/src/network/NetworkController.test.ts
@@ -145,10 +145,12 @@ describe('NetworkController', () => {
       messenger,
       infuraProjectId: '123',
     });
-    controller.setProviderType('rinkeby' as NetworkType);
-    expect(controller.state.provider.type).toBe('rinkeby');
-    expect(controller.state.provider.ticker).toBe('RinkebyETH');
+    controller.setProviderType('goerli' as NetworkType);
+    expect(controller.state.provider.type).toBe('goerli');
+    expect(controller.state.provider.ticker).toBe('GoerliETH');
     expect(controller.state.isCustomNetwork).toBe(false);
+    expect(controller.state.provider.rpcTarget).toBeUndefined();
+    expect(controller.state.provider.nickname).toBeUndefined();
   });
 
   it('should set mainnet provider type', () => {
@@ -160,6 +162,8 @@ describe('NetworkController', () => {
     expect(controller.state.provider.type).toBe('mainnet');
     expect(controller.state.provider.ticker).toBe('ETH');
     expect(controller.state.isCustomNetwork).toBe(false);
+    expect(controller.state.provider.rpcTarget).toBeUndefined();
+    expect(controller.state.provider.nickname).toBeUndefined();
   });
 
   it('should throw when setting an unrecognized provider type', () => {

--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -361,6 +361,8 @@ export class NetworkController extends BaseController<
       state.provider.type = type;
       state.provider.ticker = ticker;
       state.provider.chainId = NetworksChainId[type];
+      state.provider.rpcTarget = undefined;
+      state.provider.nickname = undefined;
     });
     this.refreshNetwork();
   }


### PR DESCRIPTION
**Description**
From version 30.0.2 to 32.0.2 the setProviderType method of NetworkController has changed, it was resetting the rpcTarget and the nickname and now it's not

![image](https://user-images.githubusercontent.com/46944231/199736588-2712f61a-d7ff-4c6d-a474-700bbb9d0744.png)

- CHANGED:
The rpcTarget and nickname is turned to undefined when used the setProviderType

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented

**Issue**

Resolves #???
