### PR TITLE
Fix `lookupNetwork` deadlock

### DIFF
--- a/src/network/NetworkController.ts
+++ b/src/network/NetworkController.ts
@@ -326,20 +326,24 @@ export class NetworkController extends BaseController<
     this.ethQuery.sendAsync(
       { method: 'net_version' },
       (error: Error, network: string) => {
-        if (this.state.network === network) {
-          return;
+        try {
+          if (this.state.network === network) {
+            return;
+          }
+
+          this.update((state) => {
+            state.network = error
+              ? /* istanbul ignore next*/ 'loading'
+              : network;
+          });
+
+          this.messagingSystem.publish(
+            `NetworkController:providerChange`,
+            this.state.provider,
+          );
+        } finally {
+          releaseLock();
         }
-
-        this.update((state) => {
-          state.network = error ? /* istanbul ignore next*/ 'loading' : network;
-        });
-
-        this.messagingSystem.publish(
-          `NetworkController:providerChange`,
-          this.state.provider,
-        );
-
-        releaseLock();
       },
     );
   }


### PR DESCRIPTION
This fixes a deadlock accidentally introduced as part of #903. That PR introduced an early exit in the `net_version` callback that did not release the lock.

**Checklist**

- [ ] Tests are included if applicable
- [x] Any added code is fully documented