### PR TITLE
Add subject type and method to get metadata by origin

### DIFF
--- a/src/subject-metadata/SubjectMetadataController.test.ts
+++ b/src/subject-metadata/SubjectMetadataController.test.ts
@@ -49,20 +49,20 @@ function getSubjectMetadataControllerMessenger() {
  *
  * @param origin - The subject's origin
  * @param name - Optional subject name
- * @param type - Optional subject type
+ * @param subjectType - Optional subject type
  * @param opts - Optional extra options for the metadata
  * @returns The created metadata object
  */
 function getSubjectMetadata(
   origin: string,
   name: string | null = null,
-  type: SubjectType | null = null,
+  subjectType: SubjectType | null = null,
   opts?: Record<string, Json>,
 ) {
   return {
     origin,
     name,
-    type,
+    subjectType,
     iconUrl: null,
     extensionId: null,
     ...opts,

--- a/src/subject-metadata/SubjectMetadataController.test.ts
+++ b/src/subject-metadata/SubjectMetadataController.test.ts
@@ -6,6 +6,7 @@ import {
   SubjectMetadataControllerActions,
   SubjectMetadataControllerEvents,
   SubjectMetadataControllerMessenger,
+  SubjectType,
 } from './SubjectMetadataController';
 
 const controllerName = 'SubjectMetadataController';
@@ -48,17 +49,20 @@ function getSubjectMetadataControllerMessenger() {
  *
  * @param origin - The subject's origin
  * @param name - Optional subject name
+ * @param type - Optional subject type
  * @param opts - Optional extra options for the metadata
  * @returns The created metadata object
  */
 function getSubjectMetadata(
   origin: string,
-  name?: string,
+  name: string | null = null,
+  type: SubjectType | null = null,
   opts?: Record<string, Json>,
 ) {
   return {
     origin,
-    name: name ?? null,
+    name,
+    type,
     iconUrl: null,
     extensionId: null,
     ...opts,
@@ -209,6 +213,34 @@ describe('SubjectMetadataController', () => {
           'bar.io': getSubjectMetadata('bar.io', 'bar'),
         },
       });
+    });
+  });
+
+  describe('getSubjectMetadata', () => {
+    it('returns the subject metadata for the given origin', () => {
+      const [messenger, hasPermissionsSpy] =
+        getSubjectMetadataControllerMessenger();
+      const controller = new SubjectMetadataController({
+        messenger,
+        subjectCacheLimit: 1,
+      });
+      hasPermissionsSpy.mockImplementationOnce(() => true);
+
+      controller.addSubjectMetadata(
+        getSubjectMetadata('foo.com', 'foo', SubjectType.Snap),
+      );
+
+      controller.addSubjectMetadata(
+        getSubjectMetadata('bar.io', 'bar', SubjectType.Website),
+      );
+
+      expect(controller.getSubjectMetadata('foo.com')).toStrictEqual(
+        getSubjectMetadata('foo.com', 'foo', SubjectType.Snap),
+      );
+
+      expect(controller.getSubjectMetadata('bar.io')).toStrictEqual(
+        getSubjectMetadata('bar.io', 'bar', SubjectType.Website),
+      );
     });
   });
 

--- a/src/subject-metadata/SubjectMetadataController.ts
+++ b/src/subject-metadata/SubjectMetadataController.ts
@@ -13,6 +13,10 @@ const controllerName = 'SubjectMetadataController';
 
 type SubjectOrigin = string;
 
+/**
+ * The different kinds of subjects that MetaMask may interact with, including
+ * third parties and itself (e.g., when the background communicated with the UI).
+ */
 export enum SubjectType {
   Extension = 'extension',
   Internal = 'internal',

--- a/src/subject-metadata/SubjectMetadataController.ts
+++ b/src/subject-metadata/SubjectMetadataController.ts
@@ -29,14 +29,14 @@ export type SubjectMetadata = PermissionSubjectMetadata & {
   [key: string]: Json;
   // TODO:TS4.4 make optional
   name: string | null;
-  type: SubjectType | null;
+  subjectType: SubjectType | null;
   extensionId: string | null;
   iconUrl: string | null;
 };
 
 type SubjectMetadataToAdd = PermissionSubjectMetadata & {
   name?: string | null;
-  type?: SubjectType | null;
+  subjectType?: SubjectType | null;
   extensionId?: string | null;
   iconUrl?: string | null;
 } & Record<string, Json>;
@@ -169,7 +169,7 @@ export class SubjectMetadataController extends BaseController<
       extensionId: metadata.extensionId || null,
       iconUrl: metadata.iconUrl || null,
       name: metadata.name || null,
-      type: metadata.type || null,
+      subjectType: metadata.subjectType || null,
     };
 
     let originToForget: string | null = null;

--- a/src/subject-metadata/SubjectMetadataController.ts
+++ b/src/subject-metadata/SubjectMetadataController.ts
@@ -13,16 +13,26 @@ const controllerName = 'SubjectMetadataController';
 
 type SubjectOrigin = string;
 
+export enum SubjectType {
+  Extension = 'extension',
+  Internal = 'internal',
+  Unknown = 'unknown',
+  Website = 'website',
+  Snap = 'snap',
+}
+
 export type SubjectMetadata = PermissionSubjectMetadata & {
   [key: string]: Json;
   // TODO:TS4.4 make optional
   name: string | null;
+  type: SubjectType | null;
   extensionId: string | null;
   iconUrl: string | null;
 };
 
 type SubjectMetadataToAdd = PermissionSubjectMetadata & {
   name?: string | null;
+  type?: SubjectType | null;
   extensionId?: string | null;
   iconUrl?: string | null;
 } & Record<string, Json>;
@@ -44,7 +54,14 @@ export type GetSubjectMetadataState = {
   handler: () => SubjectMetadataControllerState;
 };
 
-export type SubjectMetadataControllerActions = GetSubjectMetadataState;
+export type GetSubjectMetadata = {
+  type: `${typeof controllerName}:getSubjectMetadata`;
+  handler: (origin: SubjectOrigin) => SubjectMetadata | undefined;
+};
+
+export type SubjectMetadataControllerActions =
+  | GetSubjectMetadataState
+  | GetSubjectMetadata;
 
 export type SubjectMetadataStateChange = {
   type: `${typeof controllerName}:stateChange`;
@@ -80,7 +97,7 @@ export class SubjectMetadataController extends BaseController<
 > {
   private subjectCacheLimit: number;
 
-  private subjectsWithoutPermissionsEcounteredSinceStartup: Set<string>;
+  private subjectsWithoutPermissionsEncounteredSinceStartup: Set<string>;
 
   private subjectHasPermissions: GenericPermissionController['hasPermissions'];
 
@@ -110,7 +127,12 @@ export class SubjectMetadataController extends BaseController<
 
     this.subjectHasPermissions = hasPermissions;
     this.subjectCacheLimit = subjectCacheLimit;
-    this.subjectsWithoutPermissionsEcounteredSinceStartup = new Set();
+    this.subjectsWithoutPermissionsEncounteredSinceStartup = new Set();
+
+    this.messagingSystem.registerActionHandler(
+      `${this.name}:getSubjectMetadata`,
+      this.getSubjectMetadata.bind(this),
+    );
   }
 
   /**
@@ -118,7 +140,7 @@ export class SubjectMetadataController extends BaseController<
    * encountered since startup, so as to not prematurely reach the cache limit.
    */
   clearState(): void {
-    this.subjectsWithoutPermissionsEcounteredSinceStartup.clear();
+    this.subjectsWithoutPermissionsEncounteredSinceStartup.clear();
     this.update((_draftState) => {
       return { ...defaultState };
     });
@@ -143,20 +165,22 @@ export class SubjectMetadataController extends BaseController<
       extensionId: metadata.extensionId || null,
       iconUrl: metadata.iconUrl || null,
       name: metadata.name || null,
+      type: metadata.type || null,
     };
 
     let originToForget: string | null = null;
     // We only delete the oldest encountered subject from the cache, again to
     // ensure that the user's experience isn't degraded by missing icons etc.
     if (
-      this.subjectsWithoutPermissionsEcounteredSinceStartup.size >=
+      this.subjectsWithoutPermissionsEncounteredSinceStartup.size >=
       this.subjectCacheLimit
     ) {
-      const cachedOrigin = this.subjectsWithoutPermissionsEcounteredSinceStartup
-        .values()
-        .next().value;
+      const cachedOrigin =
+        this.subjectsWithoutPermissionsEncounteredSinceStartup
+          .values()
+          .next().value;
 
-      this.subjectsWithoutPermissionsEcounteredSinceStartup.delete(
+      this.subjectsWithoutPermissionsEncounteredSinceStartup.delete(
         cachedOrigin,
       );
 
@@ -165,7 +189,7 @@ export class SubjectMetadataController extends BaseController<
       }
     }
 
-    this.subjectsWithoutPermissionsEcounteredSinceStartup.add(origin);
+    this.subjectsWithoutPermissionsEncounteredSinceStartup.add(origin);
 
     this.update((draftState) => {
       // Typecast: ts(2589)
@@ -174,6 +198,16 @@ export class SubjectMetadataController extends BaseController<
         delete draftState.subjectMetadata[originToForget];
       }
     });
+  }
+
+  /**
+   * Gets the subject metadata for the given origin, if any.
+   *
+   * @param origin - The origin for which to get the subject metadata.
+   * @returns The subject metadata, if any, or `undefined` otherwise.
+   */
+  getSubjectMetadata(origin: SubjectOrigin): SubjectMetadata | undefined {
+    return this.state.subjectMetadata[origin];
   }
 
   /**


### PR DESCRIPTION
I've moved [the `SUBJECT_TYPES` enum from the extension](https://github.com/MetaMask/metamask-extension/blob/aba3b94c1abf80de322ddd440ae379b2303084cf/shared/constants/app.ts#L60-L72) to the `SubjectMetadataController`, and added a new field to specify the type in the metadata. I've also added a new method to get the subject metadata for a single origin, rather than getting the entire state. We need this for Snaps, in order to distinguish an origin between Snaps and other subject types.

In the extension we were already using `subjectType`, but this was not defined in the type (since it accepts any `Json` values). In the extension it's pretty much a case of using this exported enum, rather than the one defined in the extension, which I removed. It's implemented here: MetaMask/metamask-extension#16431