### PR TITLE
Add TransactionController to tsconfig

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -53,6 +53,9 @@
     },
     {
       "path": "./packages/subject-metadata-controller/tsconfig.build.json"
+    },
+    {
+      "path": "./packages/transaction-controller/tsconfig.build.json"
     }
   ],
   "files": [],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -57,6 +57,9 @@
     },
     {
       "path": "./packages/subject-metadata-controller"
+    },
+    {
+      "path": "./packages/transaction-controller"
     }
   ],
   "files": [],


### PR DESCRIPTION
The TransactionController package was missing from our TypeScript config, so it wasn't being built.
