### PR TITLE
Use the `--immutable-cache` flag upon install

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
-      - run: yarn --immutable
+      - run: yarn --immutable --immutable-cache
       - run: yarn lint
       - run: yarn changelog:validate
       - name: Require clean working directory
@@ -58,7 +58,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
-      - run: yarn --immutable
+      - run: yarn --immutable --immutable-cache
       - run: yarn build
       - name: Require clean working directory
         shell: bash
@@ -82,7 +82,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
-      - run: yarn --immutable
+      - run: yarn --immutable --immutable-cache
       - run: yarn test
       - name: Require clean working directory
         shell: bash


### PR DESCRIPTION
The `--immutable-cache` flag is now used during CI in steps where the cache is expected to be populated. This ensures we are alerted if our CI is misconfigured.