### PR TITLE
Bump @metamask/auto-changelog to 3.1.0

### DIFF
--- a/packages/address-book-controller/package.json
+++ b/packages/address-book-controller/package.json
@@ -31,7 +31,7 @@
     "@metamask/controller-utils": "workspace:~"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.0.0",
+    "@metamask/auto-changelog": "^3.1.0",
     "@types/jest": "^26.0.22",
     "deepmerge": "^4.2.2",
     "jest": "^26.4.2",

--- a/packages/announcement-controller/package.json
+++ b/packages/announcement-controller/package.json
@@ -30,7 +30,7 @@
     "@metamask/base-controller": "workspace:~"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.0.0",
+    "@metamask/auto-changelog": "^3.1.0",
     "@types/jest": "^26.0.22",
     "deepmerge": "^4.2.2",
     "jest": "^26.4.2",

--- a/packages/approval-controller/package.json
+++ b/packages/approval-controller/package.json
@@ -33,7 +33,7 @@
     "nanoid": "^3.1.31"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.0.0",
+    "@metamask/auto-changelog": "^3.1.0",
     "@types/jest": "^26.0.22",
     "deepmerge": "^4.2.2",
     "jest": "^26.4.2",

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -50,7 +50,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.0.0",
+    "@metamask/auto-changelog": "^3.1.0",
     "@types/jest": "^26.0.22",
     "@types/node": "^14.14.31",
     "deepmerge": "^4.2.2",

--- a/packages/base-controller/package.json
+++ b/packages/base-controller/package.json
@@ -30,7 +30,7 @@
     "immer": "^9.0.6"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.0.0",
+    "@metamask/auto-changelog": "^3.1.0",
     "@types/jest": "^26.0.22",
     "@types/sinon": "^9.0.10",
     "deepmerge": "^4.2.2",

--- a/packages/composable-controller/package.json
+++ b/packages/composable-controller/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@metamask/address-book-controller": "workspace:~",
     "@metamask/assets-controllers": "workspace:~",
-    "@metamask/auto-changelog": "^3.0.0",
+    "@metamask/auto-changelog": "^3.1.0",
     "@metamask/controller-utils": "workspace:~",
     "@metamask/ens-controller": "workspace:~",
     "@metamask/network-controller": "workspace:~",

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -36,7 +36,7 @@
     "isomorphic-fetch": "^3.0.0"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.0.0",
+    "@metamask/auto-changelog": "^3.1.0",
     "@types/jest": "^26.0.22",
     "abort-controller": "^3.0.0",
     "deepmerge": "^4.2.2",

--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -31,7 +31,7 @@
     "@metamask/controller-utils": "workspace:~"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.0.0",
+    "@metamask/auto-changelog": "^3.1.0",
     "@types/jest": "^26.0.22",
     "deepmerge": "^4.2.2",
     "jest": "^26.4.2",

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -39,7 +39,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.0.0",
+    "@metamask/auto-changelog": "^3.1.0",
     "@types/jest": "^26.0.22",
     "@types/jest-when": "^2.7.3",
     "deepmerge": "^4.2.2",

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -42,7 +42,7 @@
     "@ethereumjs/common": "^2.3.1",
     "@ethereumjs/tx": "^3.2.1",
     "@keystonehq/bc-ur-registry-eth": "^0.9.0",
-    "@metamask/auto-changelog": "^3.0.0",
+    "@metamask/auto-changelog": "^3.1.0",
     "@types/jest": "^26.0.22",
     "deepmerge": "^4.2.2",
     "jest": "^26.4.2",

--- a/packages/message-manager/package.json
+++ b/packages/message-manager/package.json
@@ -36,7 +36,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.0.0",
+    "@metamask/auto-changelog": "^3.1.0",
     "@types/jest": "^26.0.22",
     "deepmerge": "^4.2.2",
     "jest": "^26.4.2",

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -37,7 +37,7 @@
     "web3-provider-engine": "^16.0.3"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.0.0",
+    "@metamask/auto-changelog": "^3.1.0",
     "@types/jest": "^26.0.22",
     "deepmerge": "^4.2.2",
     "jest": "^26.4.2",

--- a/packages/notification-controller/package.json
+++ b/packages/notification-controller/package.json
@@ -33,7 +33,7 @@
     "nanoid": "^3.1.31"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.0.0",
+    "@metamask/auto-changelog": "^3.1.0",
     "@types/jest": "^26.0.22",
     "deepmerge": "^4.2.2",
     "jest": "^26.4.2",

--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -39,7 +39,7 @@
     "nanoid": "^3.1.31"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.0.0",
+    "@metamask/auto-changelog": "^3.1.0",
     "@types/jest": "^26.0.22",
     "deepmerge": "^4.2.2",
     "jest": "^26.4.2",

--- a/packages/phishing-controller/package.json
+++ b/packages/phishing-controller/package.json
@@ -35,7 +35,7 @@
     "punycode": "^2.1.1"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.0.0",
+    "@metamask/auto-changelog": "^3.1.0",
     "@types/jest": "^26.0.22",
     "deepmerge": "^4.2.2",
     "jest": "^26.4.2",

--- a/packages/preferences-controller/package.json
+++ b/packages/preferences-controller/package.json
@@ -31,7 +31,7 @@
     "@metamask/controller-utils": "workspace:~"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.0.0",
+    "@metamask/auto-changelog": "^3.1.0",
     "@types/jest": "^26.0.22",
     "deepmerge": "^4.2.2",
     "jest": "^26.4.2",

--- a/packages/rate-limit-controller/package.json
+++ b/packages/rate-limit-controller/package.json
@@ -32,7 +32,7 @@
     "immer": "^9.0.6"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.0.0",
+    "@metamask/auto-changelog": "^3.1.0",
     "@types/jest": "^26.0.22",
     "deepmerge": "^4.2.2",
     "jest": "^26.4.2",

--- a/packages/subject-metadata-controller/package.json
+++ b/packages/subject-metadata-controller/package.json
@@ -33,7 +33,7 @@
     "immer": "^9.0.6"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.0.0",
+    "@metamask/auto-changelog": "^3.1.0",
     "@types/jest": "^26.0.22",
     "deepmerge": "^4.2.2",
     "jest": "^26.4.2",

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -41,7 +41,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@metamask/auto-changelog": "^3.0.0",
+    "@metamask/auto-changelog": "^3.1.0",
     "@types/jest": "^26.0.22",
     "@types/node": "^14.14.31",
     "deepmerge": "^4.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1314,7 +1314,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/address-book-controller@workspace:packages/address-book-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.0.0
+    "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:~"
     "@metamask/controller-utils": "workspace:~"
     "@types/jest": ^26.0.22
@@ -1331,7 +1331,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/announcement-controller@workspace:packages/announcement-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.0.0
+    "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:~"
     "@types/jest": ^26.0.22
     deepmerge: ^4.2.2
@@ -1347,7 +1347,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/approval-controller@workspace:packages/approval-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.0.0
+    "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:~"
     "@types/jest": ^26.0.22
     deepmerge: ^4.2.2
@@ -1371,7 +1371,7 @@ __metadata:
     "@ethersproject/bignumber": ^5.7.0
     "@ethersproject/contracts": ^5.7.0
     "@ethersproject/providers": ^5.7.0
-    "@metamask/auto-changelog": ^3.0.0
+    "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:~"
     "@metamask/contract-metadata": ^1.35.0
     "@metamask/controller-utils": "workspace:~"
@@ -1403,9 +1403,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/auto-changelog@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@metamask/auto-changelog@npm:3.0.0"
+"@metamask/auto-changelog@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@metamask/auto-changelog@npm:3.1.0"
   dependencies:
     diff: ^5.0.0
     execa: ^5.1.1
@@ -1413,7 +1413,7 @@ __metadata:
     yargs: ^17.0.1
   bin:
     auto-changelog: dist/cli.js
-  checksum: ee6f41b466e8f0deb8bc454936513602c4767b7be94f704da3579e3100154c92779dcfde542076158138d5fcfb64ce491ab7fc30248ae097c7d903be0cad9fb4
+  checksum: cd3c833100c19a80e0b7ae8c174fbbe225700eef5fbabd9b0d6c4b439c8af839792111a17d9ddf2e1939839736413afd7402d2cc08ece373622b5a410da5e9fe
   languageName: node
   linkType: hard
 
@@ -1421,7 +1421,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/base-controller@workspace:packages/base-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.0.0
+    "@metamask/auto-changelog": ^3.1.0
     "@types/jest": ^26.0.22
     "@types/sinon": ^9.0.10
     deepmerge: ^4.2.2
@@ -1453,7 +1453,7 @@ __metadata:
   dependencies:
     "@metamask/address-book-controller": "workspace:~"
     "@metamask/assets-controllers": "workspace:~"
-    "@metamask/auto-changelog": ^3.0.0
+    "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:~"
     "@metamask/controller-utils": "workspace:~"
     "@metamask/ens-controller": "workspace:~"
@@ -1482,7 +1482,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/controller-utils@workspace:packages/controller-utils"
   dependencies:
-    "@metamask/auto-changelog": ^3.0.0
+    "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:~"
     "@types/jest": ^26.0.22
     abort-controller: ^3.0.0
@@ -1555,7 +1555,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/ens-controller@workspace:packages/ens-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.0.0
+    "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:~"
     "@metamask/controller-utils": "workspace:~"
     "@types/jest": ^26.0.22
@@ -1647,7 +1647,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/gas-fee-controller@workspace:packages/gas-fee-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.0.0
+    "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:~"
     "@metamask/controller-utils": "workspace:~"
     "@metamask/network-controller": "workspace:~"
@@ -1680,7 +1680,7 @@ __metadata:
     "@ethereumjs/tx": ^3.2.1
     "@keystonehq/bc-ur-registry-eth": ^0.9.0
     "@keystonehq/metamask-airgapped-keyring": ^0.6.1
-    "@metamask/auto-changelog": ^3.0.0
+    "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:~"
     "@metamask/controller-utils": "workspace:~"
     "@metamask/message-manager": "workspace:~"
@@ -1706,7 +1706,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/message-manager@workspace:packages/message-manager"
   dependencies:
-    "@metamask/auto-changelog": ^3.0.0
+    "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:~"
     "@metamask/controller-utils": "workspace:~"
     "@types/jest": ^26.0.22
@@ -1735,7 +1735,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/network-controller@workspace:packages/network-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.0.0
+    "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:~"
     "@metamask/controller-utils": "workspace:~"
     "@types/jest": ^26.0.22
@@ -1759,7 +1759,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/notification-controller@workspace:packages/notification-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.0.0
+    "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:~"
     "@metamask/controller-utils": "workspace:~"
     "@types/jest": ^26.0.22
@@ -1789,7 +1789,7 @@ __metadata:
   resolution: "@metamask/permission-controller@workspace:packages/permission-controller"
   dependencies:
     "@metamask/approval-controller": "workspace:~"
-    "@metamask/auto-changelog": ^3.0.0
+    "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:~"
     "@metamask/controller-utils": "workspace:~"
     "@metamask/types": ^1.1.0
@@ -1813,7 +1813,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/phishing-controller@workspace:packages/phishing-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.0.0
+    "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:~"
     "@metamask/controller-utils": "workspace:~"
     "@types/jest": ^26.0.22
@@ -1836,7 +1836,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/preferences-controller@workspace:packages/preferences-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.0.0
+    "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:~"
     "@metamask/controller-utils": "workspace:~"
     "@types/jest": ^26.0.22
@@ -1853,7 +1853,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/rate-limit-controller@workspace:packages/rate-limit-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.0.0
+    "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:~"
     "@types/jest": ^26.0.22
     deepmerge: ^4.2.2
@@ -1878,7 +1878,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/subject-metadata-controller@workspace:packages/subject-metadata-controller"
   dependencies:
-    "@metamask/auto-changelog": ^3.0.0
+    "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:~"
     "@metamask/permission-controller": "workspace:~"
     "@metamask/types": ^1.1.0
@@ -1899,7 +1899,7 @@ __metadata:
   dependencies:
     "@ethereumjs/common": ^2.3.1
     "@ethereumjs/tx": ^3.2.1
-    "@metamask/auto-changelog": ^3.0.0
+    "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:~"
     "@metamask/controller-utils": "workspace:~"
     "@metamask/network-controller": "workspace:~"


### PR DESCRIPTION
This allows us to issue prereleases.