### PR TITLE
Expose getFormattedIpfsUrl

### DIFF
--- a/packages/assets-controllers/src/index.ts
+++ b/packages/assets-controllers/src/index.ts
@@ -8,4 +8,4 @@ export * from './TokenDetectionController';
 export * from './TokenListController';
 export * from './TokenRatesController';
 export * from './TokensController';
-export { formatIconUrlWithProxy } from './assetsUtil';
+export { formatIconUrlWithProxy, getFormattedIpfsUrl } from './assetsUtil';


### PR DESCRIPTION
This function was previously available before the monorepo conversion under `src/util.ts` and has since been moved to `src/assetsUtil.ts` in `@metamask/assets-controllers`.