### PR TITLE
Fix npm publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,8 @@ jobs:
     permissions:
       contents: write
     uses: ./.github/workflows/publish-release.yml
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   all-jobs-pass:
     name: All jobs pass

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -2,6 +2,9 @@ name: Publish Release
 
 on:
   workflow_call:
+    secrets:
+      NPM_TOKEN:
+        required: true
 
 jobs:
   publish-release:


### PR DESCRIPTION
We discovered since these changes were made that when using `workflow_call`, the top-level workflow needs to explicitly grant access to any secrets used.

If we had tried to publish anything the publish step would have been lacking the `NPM_TOKEN` secret, resulting in two dry runs and no published package.