### PR TITLE
Make controller-utils the trunk

### DIFF
--- a/packages/approval-controller/package.json
+++ b/packages/approval-controller/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@metamask/base-controller": "workspace:~",
+    "@metamask/controller-utils": "workspace:~",
     "eth-rpc-errors": "^4.0.0",
     "immer": "^9.0.6",
     "nanoid": "^3.1.31"

--- a/packages/approval-controller/src/ApprovalController.ts
+++ b/packages/approval-controller/src/ApprovalController.ts
@@ -4,8 +4,8 @@ import { nanoid } from 'nanoid';
 import {
   BaseControllerV2,
   RestrictedControllerMessenger,
-  Json,
 } from '@metamask/base-controller';
+import { Json } from '@metamask/controller-utils';
 import { ApprovalRequestNotFoundError } from './errors';
 
 const controllerName = 'ApprovalController';

--- a/packages/approval-controller/tsconfig.build.json
+++ b/packages/approval-controller/tsconfig.build.json
@@ -5,6 +5,13 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "references": [{ "path": "../base-controller/tsconfig.build.json" }],
+  "references": [
+    {
+      "path": "../base-controller/tsconfig.build.json"
+    },
+    {
+      "path": "../controller-utils/tsconfig.build.json"
+    }
+  ],
   "include": ["../../types", "./src"]
 }

--- a/packages/approval-controller/tsconfig.json
+++ b/packages/approval-controller/tsconfig.json
@@ -3,6 +3,13 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [{ "path": "../base-controller" }],
+  "references": [
+    {
+      "path": "../base-controller"
+    },
+    {
+      "path": "../controller-utils"
+    }
+  ],
   "include": ["../../types", "./src"]
 }

--- a/packages/base-controller/package.json
+++ b/packages/base-controller/package.json
@@ -29,6 +29,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@metamask/controller-utils": "workspace:~",
     "immer": "^9.0.6"
   },
   "devDependencies": {

--- a/packages/base-controller/src/BaseControllerV2.ts
+++ b/packages/base-controller/src/BaseControllerV2.ts
@@ -4,6 +4,8 @@ import { enablePatches, produceWithPatches } from 'immer';
 // eslint-disable-next-line no-duplicate-imports
 import type { Draft, Patch } from 'immer';
 
+import type { Json } from '@metamask/controller-utils';
+
 import type {
   RestrictedControllerMessenger,
   Namespaced,
@@ -60,14 +62,6 @@ export interface StatePropertyMetadata<T extends Json> {
   persist: boolean | StateDeriver<T>;
   anonymous: boolean | StateDeriver<T>;
 }
-
-export type Json =
-  | null
-  | boolean
-  | number
-  | string
-  | Json[]
-  | { [prop: string]: Json };
 
 /**
  * Controller class that provides state management, subscriptions, and state metadata

--- a/packages/base-controller/src/index.ts
+++ b/packages/base-controller/src/index.ts
@@ -10,7 +10,6 @@ export {
   StateDeriver,
   StateMetadata,
   StatePropertyMetadata,
-  Json,
   getAnonymizedState,
   getPersistentState,
 } from './BaseControllerV2';

--- a/packages/base-controller/tsconfig.build.json
+++ b/packages/base-controller/tsconfig.build.json
@@ -5,5 +5,10 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
+  "references": [
+    {
+      "path": "../controller-utils/tsconfig.build.json"
+    }
+  ],
   "include": ["../../types", "./src"]
 }

--- a/packages/base-controller/tsconfig.json
+++ b/packages/base-controller/tsconfig.json
@@ -3,5 +3,10 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
+  "references": [
+    {
+      "path": "../controller-utils"
+    }
+  ],
   "include": ["../../types", "./src"]
 }

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -29,7 +29,6 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "workspace:~",
     "eth-ens-namehash": "^2.0.8",
     "eth-rpc-errors": "^4.0.0",
     "ethereumjs-util": "^7.0.10",

--- a/packages/controller-utils/src/types.ts
+++ b/packages/controller-utils/src/types.ts
@@ -19,3 +19,11 @@ export enum NetworksChainId {
   localhost = '',
   rpc = '',
 }
+
+export type Json =
+  | null
+  | boolean
+  | number
+  | string
+  | Json[]
+  | { [prop: string]: Json };

--- a/packages/controller-utils/src/util.ts
+++ b/packages/controller-utils/src/util.ts
@@ -9,7 +9,7 @@ import {
 import { fromWei, toWei } from 'ethjs-unit';
 import ensNamehash from 'eth-ens-namehash';
 import deepEqual from 'fast-deep-equal';
-import { Json } from '@metamask/base-controller';
+import type { Json } from './types';
 
 const TIMEOUT_ERROR = new Error('timeout');
 

--- a/packages/controller-utils/tsconfig.build.json
+++ b/packages/controller-utils/tsconfig.build.json
@@ -6,10 +6,5 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "references": [
-    {
-      "path": "../base-controller/tsconfig.build.json"
-    }
-  ],
   "include": ["../../types", "./src"]
 }

--- a/packages/controller-utils/tsconfig.json
+++ b/packages/controller-utils/tsconfig.json
@@ -4,10 +4,5 @@
     "baseUrl": "./",
     "lib": ["ES2017", "DOM"]
   },
-  "references": [
-    {
-      "path": "../base-controller"
-    }
-  ],
   "include": ["../../types", "./src"]
 }

--- a/packages/permission-controller/src/PermissionController.test.ts
+++ b/packages/permission-controller/src/PermissionController.test.ts
@@ -6,8 +6,8 @@ import {
   HasApprovalRequest,
   RejectRequest as RejectApprovalRequest,
 } from '@metamask/approval-controller';
-import { Json, ControllerMessenger } from '@metamask/base-controller';
-import { hasProperty, isPlainObject } from '@metamask/controller-utils';
+import { ControllerMessenger } from '@metamask/base-controller';
+import { Json, hasProperty, isPlainObject } from '@metamask/controller-utils';
 import * as errors from './errors';
 import { EndowmentGetterParams } from './Permission';
 import {

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -12,7 +12,6 @@ import {
 } from '@metamask/approval-controller';
 import {
   BaseControllerV2,
-  Json,
   StateMetadata,
   RestrictedControllerMessenger,
 } from '@metamask/base-controller';
@@ -21,6 +20,7 @@ import {
   isNonEmptyArray,
   isPlainObject,
   isValidJson,
+  Json,
   NonEmptyArray,
 } from '@metamask/controller-utils';
 import {

--- a/packages/subject-metadata-controller/package.json
+++ b/packages/subject-metadata-controller/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^3.1.0",
+    "@metamask/controller-utils": "workspace:~",
     "@types/jest": "^26.0.22",
     "deepmerge": "^4.2.2",
     "jest": "^26.4.2",

--- a/packages/subject-metadata-controller/src/SubjectMetadataController.test.ts
+++ b/packages/subject-metadata-controller/src/SubjectMetadataController.test.ts
@@ -1,4 +1,5 @@
-import { Json, ControllerMessenger } from '@metamask/base-controller';
+import { Json } from '@metamask/controller-utils';
+import { ControllerMessenger } from '@metamask/base-controller';
 import { HasPermissions } from '@metamask/permission-controller';
 import {
   SubjectMetadataController,

--- a/packages/subject-metadata-controller/tsconfig.build.json
+++ b/packages/subject-metadata-controller/tsconfig.build.json
@@ -6,8 +6,15 @@
     "rootDir": "./src"
   },
   "references": [
-    { "path": "../base-controller/tsconfig.build.json" },
-    { "path": "../permission-controller/tsconfig.build.json" }
+    {
+      "path": "../base-controller/tsconfig.build.json"
+    },
+    {
+      "path": "../controller-utils/tsconfig.build.json"
+    },
+    {
+      "path": "../permission-controller/tsconfig.build.json"
+    }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/subject-metadata-controller/tsconfig.json
+++ b/packages/subject-metadata-controller/tsconfig.json
@@ -4,8 +4,15 @@
     "baseUrl": "./"
   },
   "references": [
-    { "path": "../base-controller" },
-    { "path": "../permission-controller" }
+    {
+      "path": "../base-controller"
+    },
+    {
+      "path": "../controller-utils"
+    },
+    {
+      "path": "../permission-controller"
+    }
   ],
   "include": ["../../types", "./src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1349,6 +1349,7 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:~"
+    "@metamask/controller-utils": "workspace:~"
     "@types/jest": ^26.0.22
     deepmerge: ^4.2.2
     eth-rpc-errors: ^4.0.0
@@ -1422,6 +1423,7 @@ __metadata:
   resolution: "@metamask/base-controller@workspace:packages/base-controller"
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
+    "@metamask/controller-utils": "workspace:~"
     "@types/jest": ^26.0.22
     "@types/sinon": ^9.0.10
     deepmerge: ^4.2.2
@@ -1483,7 +1485,6 @@ __metadata:
   resolution: "@metamask/controller-utils@workspace:packages/controller-utils"
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
-    "@metamask/base-controller": "workspace:~"
     "@types/jest": ^26.0.22
     abort-controller: ^3.0.0
     deepmerge: ^4.2.2
@@ -1880,6 +1881,7 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/base-controller": "workspace:~"
+    "@metamask/controller-utils": "workspace:~"
     "@metamask/permission-controller": "workspace:~"
     "@metamask/types": ^1.1.0
     "@types/jest": ^26.0.22


### PR DESCRIPTION
Currently, `controller-utils` depends on `base-controller` (in order to access the `Json` type). This seems wrong. Despite its imperfect name, `controller-utils` holds code that needs to be shared across the whole monorepo, so it should be the thing that everything depends on. This commit fixes that.