### PR TITLE
Add `applyPatches` function to BaseControllerV2

### DIFF
--- a/packages/base-controller/src/BaseControllerV2.test.ts
+++ b/packages/base-controller/src/BaseControllerV2.test.ts
@@ -77,8 +77,8 @@ class CountController extends BaseController<
     return res;
   }
 
-  rollback(inversePatches: Patch[]) {
-    super.rollback(inversePatches);
+  applyPatches(patches: Patch[]) {
+    super.applyPatches(patches);
   }
 
   destroy() {
@@ -216,7 +216,7 @@ describe('BaseController', () => {
     );
   });
 
-  it('should allow for rolling back state changes', () => {
+  it('should allow for applying immer patches to state', () => {
     const controller = new CountController({
       messenger: getCountMessenger(),
       name: 'CountController',
@@ -228,7 +228,7 @@ describe('BaseController', () => {
       draft.count += 1;
     });
 
-    controller.rollback(returnObj.inversePatches);
+    controller.applyPatches(returnObj.inversePatches);
 
     expect(controller.state).toStrictEqual({ count: 0 });
   });

--- a/packages/base-controller/src/BaseControllerV2.ts
+++ b/packages/base-controller/src/BaseControllerV2.ts
@@ -175,7 +175,7 @@ export class BaseController<
 
   /**
    * Applies immer patches to the current state. The patches come from the
-   * update function itself and can either be normal or inverse patches
+   * update function itself and can either be normal or inverse patches.
    *
    * @param patches - An array of immer patches that are to be applied to make
    * or undo changes.

--- a/packages/base-controller/src/BaseControllerV2.ts
+++ b/packages/base-controller/src/BaseControllerV2.ts
@@ -146,10 +146,10 @@ export class BaseController<
    *
    * @param callback - Callback for updating state, passed a draft state
    * object. Return a new state object or mutate the draft to update state.
-   * @returns A tuple of the next state, patches applied in the update and inverse patches to 
+   * @returns An object that has the next state, patches applied in the update and inverse patches to 
    * rollback the update.
    */
-  protected update(callback: (state: Draft<S>) => void | S): [S, Patch[], Patch[]] {
+  protected update(callback: (state: Draft<S>) => void | S): {nextState: S, patches: Patch[], inversePatches: Patch[]} {
     // We run into ts2589, "infinite type depth", if we don't cast
     // produceWithPatches here.
     const [nextState, patches, inversePatches] = (
@@ -166,7 +166,7 @@ export class BaseController<
       patches,
     );
 
-    return [nextState, patches, inversePatches];
+    return { nextState, patches, inversePatches };
   }
 
   /**

--- a/packages/base-controller/src/BaseControllerV2.ts
+++ b/packages/base-controller/src/BaseControllerV2.ts
@@ -174,20 +174,19 @@ export class BaseController<
   }
 
   /**
-   * Rolls back controller state. Accepts an array of inverse patches
-   * that are applied to the current state. The inverse patches come from the
-   * update function itself.
+   * Applies immer patches to the current state. The patches come from the
+   * update function itself and can either be normal or inverse patches
    *
-   * @param inversePatches - An array of immer patches that are to be applied to rollback
-   * changes made in a previous update.
+   * @param patches - An array of immer patches that are to be applied to make
+   * or undo changes.
    */
-  protected rollback(inversePatches: Patch[]) {
-    const nextState = applyPatches(this.internalState, inversePatches);
+  protected applyPatches(patches: Patch[]) {
+    const nextState = applyPatches(this.internalState, patches);
     this.internalState = nextState;
     this.messagingSystem.publish(
       `${this.name}:stateChange` as Namespaced<N, any>,
       nextState,
-      inversePatches,
+      patches,
     );
   }
 

--- a/packages/base-controller/src/BaseControllerV2.ts
+++ b/packages/base-controller/src/BaseControllerV2.ts
@@ -146,10 +146,14 @@ export class BaseController<
    *
    * @param callback - Callback for updating state, passed a draft state
    * object. Return a new state object or mutate the draft to update state.
-   * @returns An object that has the next state, patches applied in the update and inverse patches to 
+   * @returns An object that has the next state, patches applied in the update and inverse patches to
    * rollback the update.
    */
-  protected update(callback: (state: Draft<S>) => void | S): {nextState: S, patches: Patch[], inversePatches: Patch[]} {
+  protected update(callback: (state: Draft<S>) => void | S): {
+    nextState: S;
+    patches: Patch[];
+    inversePatches: Patch[];
+  } {
     // We run into ts2589, "infinite type depth", if we don't cast
     // produceWithPatches here.
     const [nextState, patches, inversePatches] = (
@@ -172,9 +176,9 @@ export class BaseController<
   /**
    * Rolls back controller state. Accepts an array of inverse patches
    * that are applied to the current state. The inverse patches come from the
-   * update function itself.  
+   * update function itself.
    *
-   * @param inversePatches - An array of immer patches that are to be applied to rollback 
+   * @param inversePatches - An array of immer patches that are to be applied to rollback
    * changes made in a previous update.
    */
   protected rollback(inversePatches: Patch[]) {


### PR DESCRIPTION
This PR is meant to preface snap update rollback work in the `SnapController`. As it stands, the `update` function in `BaseControllerV2` does not expose `inversePatches` produced by Immer's `produceWithPatches` function. The `update` function has been updated to expose `nextState`, `patches` and `inversePatches`. A function called `applyPatches` was added to apply any patches that a controller may grab from an `update` call. I'm aware that the extension treats rollbacks as "updates", however I do think that controllers should have access to the `produceWithPatches` call's resulting patches in case they wish to implement some further functionality beyond a simple update.
