### PR TITLE
Remove `is-release` condition

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
   is-release:
     name: Determine whether this is a release merge commit
     needs: lint-build-test
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,6 @@ jobs:
   is-release:
     name: Determine whether this is a release merge commit
     needs: lint-build-test
-    if: startsWith(github.event.commits[0].author.name, 'github-actions')
     runs-on: ubuntu-latest
     outputs:
       IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}


### PR DESCRIPTION
The `is-release` job was configured to only run for commits made by GitHub actions. Our old release workflow always started with a commit made by an action, so this was an easy way to skip all release steps for commits that obviously were not releases.

Our new workflow does not work this way, so this check no longer makes sense.

The `action-is-release` action should still work in determining whether or not the current commit is a release. It checks the contents of the commit, specifically whether or not the base manifest version has changed. This technique still works for our new workflow.