### PR TITLE
Add "preview." to the preview build version

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.PUBLISH_PREVIEW_NPM_TOKEN }}
       - name: Post build preview in comment
-        run: gh pr comment "${PR_NUMBER}" -b "Packages published as '[current-version]-${COMMIT_SHA}'"
+        run: gh pr comment "${PR_NUMBER}" -b "Packages published as '[current-version]-preview.${COMMIT_SHA}'"
         env:
           COMMIT_SHA: ${{ steps.commit-sha.outputs.COMMIT_SHA }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/prepare-preview-manifest.sh
+++ b/scripts/prepare-preview-manifest.sh
@@ -18,7 +18,7 @@ shorthash="$1"
 # of the version. Technically we'd want to bump the non-prerelease portion as
 # well if we wanted this to be SemVer-compliant, but it was simpler not to.
 # This is just for testing, it doesn't need to strictly follow SemVer.
-jq --raw-output ".version |= split(\"-\")[0] + \"-${shorthash}\"" ./package.json > temp.json
+jq --raw-output ".version |= split(\"-\")[0] + \"-preview.${shorthash}\"" ./package.json > temp.json
 
 # The registry is updated here because the manifest publish config always takes
 # precedence, and cannot be overwritten from the command-line.


### PR DESCRIPTION
The preview build version names have been updated to include `preview.` in the prerelease version. This should make it more clear what the build is.