### PR TITLE
Improve build preview message

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -52,8 +52,10 @@ jobs:
         run: yarn publish-previews
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.PUBLISH_PREVIEW_NPM_TOKEN }}
+      - name: Generate preview build message
+        run: yarn ts-node scripts/generate-preview-build-message.ts
       - name: Post build preview in comment
-        run: gh pr comment "${PR_NUMBER}" -b "Packages published as '[current-version]-preview.${COMMIT_SHA}'"
+        run: gh pr comment "${PR_NUMBER}" --body-file preview-build-message.txt
         env:
           COMMIT_SHA: ${{ steps.commit-sha.outputs.COMMIT_SHA }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ package-lock.json
 .eslintcache
 
 .DS_STORE
+
+# Build preview message
+preview-build-message.txt
+
 packages/*/coverage
 packages/*/dist
 packages/*/docs

--- a/scripts/generate-preview-build-message.ts
+++ b/scripts/generate-preview-build-message.ts
@@ -1,0 +1,54 @@
+#!yarn ts-node
+
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Write a preview build message to the path "preview-build-message.txt".
+ */
+async function main() {
+  const packageMap: Record<string, string> = {};
+
+  const packagesDirectory = path.resolve(__dirname, '../packages');
+  const packageEntries = await fs.promises.readdir(packagesDirectory, {
+    withFileTypes: true,
+  });
+  const packageDirectories = packageEntries.filter((entry) =>
+    entry.isDirectory(),
+  );
+  const packageDirectoryNames = packageDirectories.map((entry) => entry.name);
+  const packageManifestsPaths = packageDirectoryNames.map((name) =>
+    path.join(packagesDirectory, name, 'package.json'),
+  );
+  for (const manifestPath of packageManifestsPaths) {
+    const rawManifest = await fs.promises.readFile(manifestPath, {
+      encoding: 'utf8',
+    });
+    const { name, version } = JSON.parse(rawManifest);
+
+    packageMap[name] = version;
+  }
+
+  const previewBuildMessage = `
+Preview builds have been published. [See these instructions]() for more information about preview builds.
+
+<details>
+
+<summary>Expand for full list of packages and versions:</summary>
+
+
+\`\`\`
+${JSON.stringify(packageMap, null, 2)}
+\`\`\`
+
+</details>
+`;
+
+  const messagePath = path.resolve(__dirname, '../preview-build-message.txt');
+  await fs.promises.writeFile(messagePath, previewBuildMessage);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/generate-preview-build-message.ts
+++ b/scripts/generate-preview-build-message.ts
@@ -34,7 +34,7 @@ Preview builds have been published. [See these instructions](https://github.com/
 
 <details>
 
-<summary>Expand for full list of packages and versions:</summary>
+<summary>Expand for full list of packages and versions.</summary>
 
 
 \`\`\`

--- a/scripts/generate-preview-build-message.ts
+++ b/scripts/generate-preview-build-message.ts
@@ -17,10 +17,10 @@ async function main() {
     '--json',
   ]);
   const packages = stdout.split('\n').map((line) => JSON.parse(line));
-  const packageManifestsPaths = packages.map(({ location }) =>
+  const packageManifestPaths = packages.map(({ location }) =>
     path.join(location, 'package.json'),
   );
-  for (const manifestPath of packageManifestsPaths) {
+  for (const manifestPath of packageManifestPaths) {
     const rawManifest = await fs.promises.readFile(manifestPath, {
       encoding: 'utf8',
     });

--- a/scripts/generate-preview-build-message.ts
+++ b/scripts/generate-preview-build-message.ts
@@ -30,7 +30,7 @@ async function main() {
   }
 
   const previewBuildMessage = `
-Preview builds have been published. [See these instructions]() for more information about preview builds.
+Preview builds have been published. [See these instructions](https://github.com/MetaMask/controllers/blob/main/docs/contributing.md#using-controllers-in-other-projects-during-developmenttesting) for more information about preview builds.
 
 <details>
 


### PR DESCRIPTION
The build preview message now includes a link to the build preview instructions, and a collapsible list of all published packages.