### PR TITLE
Add lastFetched PhishingController state

### DIFF
--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -103,7 +103,7 @@ describe('PhishingController', () => {
       expect(controller.isOutOfDate()).toBe(true);
     });
 
-    it('should not call update if it is out of date', async () => {
+    it('should call update only if it is out of date, otherwise it should not call update', async () => {
       nock(PHISHING_CONFIG_BASE_URL)
         .get(METAMASK_CONFIG_FILE)
         .reply(200, {

--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -93,14 +93,11 @@ describe('PhishingController', () => {
       const clock = sinon.useFakeTimers();
       const controller = new PhishingController({ refreshInterval: 10 });
       clock.tick(10);
-      await controller.maybeUpdatePhishingLists();
-      expect(controller.isOutOfDate()).toBe(false);
-      clock.tick(10);
-      expect(controller.isOutOfDate()).toBe(true);
       // do not wait
-      controller.maybeUpdatePhishingLists();
+      const maybeUpdatePhisingListPromise =
+        controller.maybeUpdatePhishingLists();
       expect(controller.isOutOfDate()).toBe(true);
-      await controller.maybeUpdatePhishingLists();
+      await maybeUpdatePhisingListPromise;
       expect(controller.isOutOfDate()).toBe(false);
       clock.tick(10);
       expect(controller.isOutOfDate()).toBe(true);

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -143,7 +143,7 @@ export class PhishingController extends BaseController<
     };
 
     this.initialize();
-    this.detector = new PhishingDetector(this.state.phishing);    
+    this.detector = new PhishingDetector(this.state.phishing);
   }
 
   /**
@@ -222,7 +222,7 @@ export class PhishingController extends BaseController<
       this.updatePhishingLists();
     }
   }
-  
+
   /**
    * Update the phishing configuration.
    *
@@ -247,8 +247,8 @@ export class PhishingController extends BaseController<
       // Set `lastFetched` even for failed requests to prevent server from being overwhelmed with
       // traffic after a network disruption.
       this.update({
-        lastFetched: Date.now()
-      })
+        lastFetched: Date.now(),
+      });
     }
 
     // Correctly shaping MetaMask config.

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -286,7 +286,7 @@ export class PhishingController extends BaseController<
 
     this.detector = new PhishingDetector(configs);
     this.update({
-      phishing: configs,      
+      phishing: configs,
     });
   }
 

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -216,10 +216,10 @@ export class PhishingController extends BaseController<
     }
   }
 
-  maybeUpdatePhishingLists() {
+  async maybeUpdatePhishingLists() {
     const phishingListsAreOutOfDate = this.isOutOfDate();
     if (phishingListsAreOutOfDate) {
-      this.updatePhishingLists();
+      await this.updatePhishingLists();
     }
   }
 

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -216,6 +216,12 @@ export class PhishingController extends BaseController<
     }
   }
 
+  /**
+   * Conditionally update the phishing configuration.
+   *
+   * If the phishing configuration is out of date, this function will call `updatePhishingLists`
+   * to update the configuration.
+   */
   async maybeUpdatePhishingLists() {
     const phishingListsAreOutOfDate = this.isOutOfDate();
     if (phishingListsAreOutOfDate) {


### PR DESCRIPTION
**Pass in initial state to PhishingController and load the initialState from persisted state**
In Manifest V3, there's need to 

1. Persist phishingcontroller state
2. Load phishingcontroller from persistent state

Thos PR makes sure state is loaded from persistent state and also abstracts out the checks required before updating the lists

- BREAKING:
 - All the code bases using PhishingController should continue to work as expected
- CHANGED:
  -   We should call initialise before calling PhishingDetector controller.

- ADDED:

  - Added `maybeUpdatePhishingLists` method so that controllers don't have to do the check logic anymore

**Checklist**

- [ ] Tests are included if applicable
- [ ] Any added code is fully documented

**Issue**

Resolves https://github.com/MetaMask/metamask-extension/issues/16551
