### PR TITLE
Add documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,9 @@ package-lock.json
 .eslintcache
 
 .DS_STORE
-coverage
-dist
-docs
+packages/*/coverage
+packages/*/dist
+packages/*/docs
 
 # yarn v3 (w/o zero-install)
 # See: https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
@@ -26,4 +26,4 @@ docs
 !.yarn/versions
 
 # typescript
-*.tsbuildinfo
+packages/*/*.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A collection of platform-agnostic modules for creating secure data models for cr
 
 ## Modules
 
-This is a monorepo that houses the following packages. Please refer to the READMEs for these packages for installation and usage instructions:
+This repo houses the following packages, which you can examine for installation and usage instructions:
 
 - [`@metamask/address-book-controller`](packages/address-book-controller)
 - [`@metamask/announcement-controller`](packages/announcement-controller)
@@ -26,12 +26,22 @@ This is a monorepo that houses the following packages. Please refer to the READM
 - [`@metamask/subject-metadata-controller`](packages/subject-metadata-controller)
 - [`@metamask/transaction-controller`](packages/transaction-controller)
 
-Here is a graph that shows the dependencies among all packages:
+Or, in graph form:
 
 ![Dependency graph](assets/dependency-graph.png)
 
 > **Note**
 > To regenerate this graph, run `yarn generate-dependency-graph`.
+
+## Architecture
+
+This is a monorepo that houses multiple packages published under the `@metamask` namespace on NPM. Here are some topics you may find useful when developing:
+
+- [What is a controller and how are they used?](docs/what.md)
+- [Why we're using a monorepo](docs/why.md)
+- [How the monorepo works](docs/how.md)
+- [Common tasks you may need to perform when working on a package](docs/common-tasks.md)
+- [How to test in-progress changes to a package within a project](docs/preview-builds.md)
 
 ## Contributing
 
@@ -41,17 +51,17 @@ Here is a graph that shows the dependencies among all packages:
   - If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm use` will automatically choose the right node version for you.
 - Install [Yarn v3](https://yarnpkg.com/getting-started/install).
 - Run `yarn install` to install dependencies and run any required post-install scripts.
-- Run `yarn simple-git-hooks` to add a [Git hook](https://github.com/toplenboren/simple-git-hooks#what-is-a-git-hook) which will ensure that all files pass the linter before you push a branch.
+- Run `yarn simple-git-hooks` to add a [Git hook](https://github.com/toplenboren/simple-git-hooks#what-is-a-git-hook) to your local development environment which will ensure that all files pass the linter before you push a branch.
 
 ### Testing and Linting
 
-Run `yarn test` to run tests for all packages. Run `yarn workspace <package-name> run test` to run tests for a single package.
+Run `yarn test` to run tests for all packages. Run `yarn workspace <package-name> run test` to run tests for a single package (where `<package-name>` is the published name of a package, e.g. `@metamask/announcement-controller`, not its location within the monorepo, e.g. `packages/announcement-controller`).
 
 Run `yarn lint` to lint all files and show possible violations, or run `yarn lint:fix` to fix any automatically fixable violations.
 
 ### Release & Publishing
 
-This project follows a unique release process. The [`create-release-branch`](https://github.com/MetaMask/create-release-branch) tool and [`action-publish-release`](https://github.com/MetaMask/action-publish-release) GitHub action are used to automate the release process; see those repositories for more information about how they work.
+This project follows a process which is unique to this repo. The [`create-release-branch`](https://github.com/MetaMask/create-release-branch) tool and [`action-publish-release`](https://github.com/MetaMask/action-publish-release) GitHub action are used to automate the release process; see those repositories for more information about how they work.
 
 1. To begin the release process, run `create-release-branch`, specifying the packages you want to release. This tool will bump versions and update changelogs across the monorepo automatically, then create a new branch for you.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A collection of platform-agnostic modules for creating secure data models for cr
 
 ## Modules
 
-This repo houses the following packages, which you can examine for installation and usage instructions:
+This repository houses the following packages:
 
 - [`@metamask/address-book-controller`](packages/address-book-controller)
 - [`@metamask/announcement-controller`](packages/announcement-controller)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This is a monorepo that houses multiple packages published under the `@metamask`
 
 ### Testing and Linting
 
-Run `yarn test` to run tests for all packages. Run `yarn workspace <package-name> run test` to run tests for a single package (where `<package-name>` is the published name of a package, e.g. `@metamask/announcement-controller`, not its location within the monorepo, e.g. `packages/announcement-controller`).
+Run `yarn test` to run tests for all packages. Run `yarn workspace <package-name> run test` to run tests for a single package (where `<package-name>` is the `name` field in its `package.json`, e.g. `@metamask/announcement-controller` rather than its location within the monorepo `packages/announcement-controller`).
 
 Run `yarn lint` to lint all files and show possible violations, or run `yarn lint:fix` to fix any automatically fixable violations.
 

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -1,0 +1,76 @@
+# Common monorepo tasks
+
+When working with the monorepo, you will always be concerned with one of two needs:
+
+- How do I do something for only one package?
+- How do I do the same thing across all packages?
+
+If you've read the ["How"](./how.md) section you know that we can use Yarn for both of these, because it treats the monorepo as a workspace of workspaces.
+
+## Doing something for only one package
+
+Use `yarn workspace <package> <rest...>`.
+
+That `package` argument is important: it's the name of the package you want to target, not the directory where the package is located.
+
+As for the `rest`, it depends on what you want to do:
+
+- If you want to run a package script (a command configured under the package's `scripts` field) or an executable (a command that a dependency provides), use `run` followed by the name of the script and the arguments.
+- If you want to run an arbitrary command, use `exec` followed by the name of the command and the arguments.
+
+### Examples
+
+We'll assume you're working with the package `@metamask/address-book-controller`:
+
+If you want to use the package script `test` to run all tests:
+
+```
+yarn workspace @metamask/address-book-controller run test
+```
+
+If you want to use the `jest` executable to run Jest directly instead:
+
+```
+yarn workspace @metamask/address-book-controller run jest
+```
+
+If you want to read `package.json` and run it through `jq` to grab the current version:
+
+```
+yarn workspace @metamask/address-book-controller exec cat package.json | jq '.version'
+```
+
+## Doing the same thing across all packages
+
+Use `yarn workspaces foreach <rest...>` (notice the `s`).
+
+As with `yarn workspace`, it depends on what you want to do:
+
+- If you want to run a package script, use `run` followed by the name of the script and the arguments.
+- If you want to run an arbitrary command, use `exec` followed by the name of the command and the arguments.
+
+This command takes a bunch of options, but these are the ones we've found useful:
+
+- `--verbose` is practically necessary, because without it, you won't know which part of the output came from which package.
+- `--parallel` will run the command across a set pool of packages at the same time. This can be handy for speeding up your run.
+- `--topological` / `--topological-dev` is neat because it will sort packages in dependency order. This means that the command will run first for packages that do not depend on any other packages, then it will run the command for all of the packages that depend on those packages, etc. (The `-dev` variant includes `devDependencies` when determining what a package's dependencies are, otherwise they are ignored.)
+
+### Examples
+
+If you want to use the package script `test` to run all tests across all packages (note: the `yarn test` command does this already):
+
+```
+yarn workspaces foreach --verbose test
+```
+
+If you want to use the `jest` executable to run Jest directly for all packages:
+
+```
+yarn workspaces foreach --verbose run jest
+```
+
+If you want to read `package.json` and run it through `jq` to grab the current version for all packages in parallel (note the double quotes):
+
+```
+yarn workspaces foreach --verbose --parallel exec "cat package.json | jq '.version'"
+```

--- a/docs/how.md
+++ b/docs/how.md
@@ -1,0 +1,140 @@
+# How the monorepo works
+
+## Structure
+
+All monorepos need to follow some sort of organizational system. If the goal of a monorepo is to house the code for multiple packages, then the code for each package needs to live somewhere that makes it easy to developers to manage the files inside it and publish that package later.
+
+In our case, we have a directory in the root called `packages/`, and each directory in this directory represents a package:
+
+```
+packages/
+  package-one/
+  package-two/
+  package-three/
+  ...
+```
+
+Although there may be minor differences from one package to another, all packages follow a common structure:
+
+```
+some-package/
+  src/
+  CHANGELOG.md
+  jest.config.js
+  LICENSE
+  package.json
+  README.md
+  tsconfig.build.json
+  tsconfig.json
+  typedoc.json
+```
+
+For a given configuration file, there are even a common set of properties. For instance, every `package.json` has a `name`, `version`, `description`, etc.
+
+## Supporting technologies
+
+### Yarn v3
+
+You probably know that Yarn is a package manager which keeps track of dependencies and makes sure that they are installed. However, did you also know that it is instrumental in orchestrating changes across the monorepo?
+
+Say we want to run tests across all of the packages in the monorepo. We could certainly do this by writing a script which would gather the names of the directories within `packages/` and then run the test command for each directory. But what if we want to run tests in parallel? We'd have to figure out how to write that code.
+
+Additionally, if you take another look at the [dependency graph in the README](../README.md#modules), you'll realize that some of our packages depend on another package. What if we want to run some other operation which stores data as it does along, and in order to do this right, we need to walk through our packages in dependency order — first packages that have no dependencies, then the packages that depend on those packages, etc.? In this case, we need something that understands how each package is connected to each other.
+
+We solve both of these problems by using Yarn's [workspaces](https://yarnpkg.com/features/workspaces) feature.
+
+As it has first-class support for monorepos, Yarn knows how to find our packages. It does this because we've told it so: in the `package.json` located in the root, we've included a property called `workspaces`, which expands to all of the directories within `packages/`. Once it has this information, it is able to build a dependency graph, a code version of the picture mentioned above.
+
+> **Note**
+> In Yarn's parlance, the existence of `workspaces` defines our project as a _worktree_ that holds a set of _workspaces_, and the existence of `package.json` means that our project is also a workspace itself. (It's a workspace of workspaces, hence, a worktree.) This terminology can get a bit confusing, so throughout this document and elsewhere, we call the packages located in `packages/` _workspace packages_, and we call the package located at the root level, the one representing the whole project, the _root package_. Just keep in mind that from a tooling perspective, the project is a workspace too.
+
+When it comes to working with workspace packages, Yarn provides two commands which we use heavily:
+
+- [`yarn workspaces foreach`](https://yarnpkg.com/cli/workspaces/foreach): Runs a package script or command for all (or a subset of) workspace packages. There are options for running things in parallel or walking through the set of workspace packages in a specific order.
+- [`yarn workspaces list`](https://yarnpkg.com/cli/workspaces/list): Gets a list of all (or a subset of) workspace packages. Useful for scripting.
+
+### TypeScript
+
+All of the code that we ship in this repo is written in TypeScript. This allows us to write more bulletproof code and it helps us keep track of the APIs that we expose more easily. We love it.
+
+That said, there are a few obstacles that we've had to overcome for the monorepo which shape how we've wired everything up.
+
+#### Building all the things
+
+In order for our code to be used in Node and in the browser, we can't ship TypeScript directly. We can ship TypeScript _definition_ files, but we must also ship JavaScript files. That means that we need some sort of build step to create these files before we release a package.
+
+The TypeScript compiler (`tsc`) can accomplish this, but compiling TypeScript in the context of a monorepo presents some new challenges. As mentioned above, some of our packages depend on other packages. So if we want to build a package that uses another package internally, that other package needs to be built first. In other words, we have the same problem as Yarn: we need a dependency graph of our project to do this right.
+
+Fortunately, TypeScript can construct such a graph just like Yarn. And, similarly, we need to instruct TypeScript how our packages are connected. We do this via TypeScript's [project references](https://www.typescriptlang.org/docs/handbook/project-references.html) feature.
+
+- If you look at `tsconfig.json` in the root, you will notice two things: this file has a `references` field, and it also has a empty `files` array. TypeScript calls this type of file a ["solution" file](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html#support-for-solution-style-tsconfigjson-files)). It doesn't compile any files directly, but merely acts a pointer to other TypeScript projects that need to be compiled, which, in our case, match the same list of packages that we've told Yarn about.
+- If you go one level deeper and skim over the `tsconfig.json` file for a few of the packages, you will see that typically the file extends `tsconfig.packages.json` in the root, meaning all packages share the same core TypeScript settings. In addition, most of the package-level TypeScript config files even have `references` fields themselves, which correspond to the dependencies for those packages.
+
+By following all of the references from the root project, TypeScript is able to build the dependency graph that we desire. It will then use this to build all of our packages in the correct order. You can see this by running `yarn build`, which runs `tsc --build` behind the scenes.
+
+#### Linking dependencies
+
+If some of our packages depend on other packages, it stands to reason that we would need to import those packages somewhere in the code. For instance, if we looked at a controller package, it would have an import like this:
+
+```typescript
+import { ... } from '@metamask/base-controller';
+```
+
+In the real world, this code lives on NPM, and so `@metamask/base-controller` is a reference to the NPM package with the same name. But in development, we don't want to use the NPM versions of our packages, because then we'd be forced to create new versions of our packages constantly and keep them in sync with each other. Instead, we want to be able to use the TypeScript code in our packages directly.
+
+In theory, we ought to be able to accomplish this without any additional configuration. When we want to codify a dependency for one package on another in `package.json`, instead of a version, we use [a special specifier, `workspace:~`](https://yarnpkg.com/features/protocols#workspace). This will get replaced with the appropriate version (plus the leading `~`) when we build the package, but in development, this instructs Yarn to place a symlink in `node_modules` that points to the package. For instance, `@metamask/address-book-controller` has the following:
+
+```
+{
+  ...,
+  "dependencies": {
+    ...
+    "@metamask/base-controller": "workspace:~"
+    ...
+  },
+  ...
+}
+```
+
+and if you look in `node_modules`, you will see that `node_modules/@metamask/base-controller` is a symlink to `packages/base-controller`.
+
+Because this symlink exists, we can import this package anywhere in TypeScript as though it were published. There's a problem here, though: TypeScript doesn't know it's not published, because when it resolves the import, it attempts to look for the files that will end up in the published version. This happens because it's using `types` from `package.json`, and that field points to a file which is only available once the package is built. Of course, we could solve this by running `yarn build` every time we change a package, but that would be a pain.
+
+A more efficient route would be for TypeScript to make use of the original source files which live in each package's `src/` directory. To fix this, we have to add a rule to the TypeScript compiler that effectively replaces all imports that look like `@metamask/<name>` with their appropriate path within the project. Hence, if you look in `tsconfig.packages.json` — which all packages use — you will see a `paths` field which does just this.
+
+#### Testing
+
+There's one other thing to talk about with regard to TypeScript config files: the fact that there are two versions, `tsconfig.json` and `tsconfig.build.json`. What gives? When we build files for a release, we want to make sure that test files do not appear in the final package, and so we exclude them from TypeScript's purview. But when we are developing locally, we've found that this exclusion will cause extra warnings to appear in-editor if we are extending types from third-party libraries using [type augmentations](https://dev.to/wojciechmatuszewski/extending-various-typescript-type-declarations-36km). To solve this problem, we use one config file for development and another file for building. This dichotomy is reflected from the root level to the package level.
+
+### Jest
+
+Each package has its own unit tests that live along their implementation files. We run Jest for each package individually, so this means that each package has its own `jest.config.js`, with common settings extracted to `jest.config.packages.js` (located in the root) and overrides specified per-package as needed.
+
+Ordinarily, this setup would be simple enough, but there is a wrinkle that emerges when we combine Jest and TypeScript, and it results in a similar problem as TypeScript with regard to package references. To understand why, we need to know a bit more about Jest.
+
+Jest is very sophisticated, and there are a lot of steps that take place happen under the hood when you run your tests, but two are worth mentioning:
+
+- Jest [runs each file it sees through a transformer](https://jestjs.io/docs/code-transformation). By default, it uses Babel, so that if you want to use an EcmaScript feature that isn't support in your version of Node, you can do so.
+- Jest will [statically analyze your code in order to derive dependencies between files](https://youtu.be/3YDiloj8_d0?t=549). During this preprocessing step, when Jest sees an import, it will attempt to follow that import using specific resolution logic. By default it reuses the [same logic that Node uses](https://nodejs.org/api/modules.html).
+
+In our case, we need Jest to work hand in hand with TypeScript. We use the [`ts-jest`](https://github.com/kulshekhar/ts-jest) plugin to accomplish this. This plugin changes the transformation step, so that when Jest sees a TypeScript file, it uses the TypeScript engine to convert it to JavaScript. It's important to realize, however, that `ts-jest` doesn't change the resolution logic: [Jest still statically analyzes the resulting JavaScript file for imports](https://github.com/kulshekhar/ts-jest/issues/414#issuecomment-369909761).
+
+And therein lies the wrinkle. When Jest sees an import like:
+
+```typescript
+import { ... } from '@metamask/base-controller';
+```
+
+it ends up in the same boat that TypeScript does: it tries to look for the `dist/` files, and if it can't find any, it will bail. Unfortunately, the `paths` option that we configure TypeScript with doesn't take effect, because it's too late.
+
+To address this issue, then, we need another tactic. Fortunately, Jest offers us a lifeline here via the `moduleNameMapper` option, which you will see employed in `jest.config.packages.js`. We do have to account for `@metamask/*` packages that live outside of this monorepo, but other than that, the configuration is very similar to the one in `tsconfig.json`.
+
+### ESLint/Prettier
+
+We have extensive linting rules for all of our repos, and the monorepo is no exception. Unlike Yarn and TypeScript there is nothing complicated going on here: we can define a global set of rules in `.eslintrc.js`, just like a polyrepo project, and lint and/or format all of our TypeScript files in one go. The same goes for formatting code via Prettier (which we use for Markdown and JSON files).
+
+### TypeDoc
+
+We try to add inline documentation for our code in the form of JSDoc blocks as much as possible. This is _immensely_ helpful when writing code, because if we are working with a type, interface, function, class, method, or even a variable that we're not quite familiar with, we can hover over it to learn more.
+
+We use [TypeDoc](https://github.com/TypeStrong/typedoc) to scan for these JSDoc blocks and generate HTML documentation. The `typedoc` command is run per package, and the generated files end up in `docs/`.

--- a/docs/preview-builds.md
+++ b/docs/preview-builds.md
@@ -1,0 +1,33 @@
+# Testing monorepo changes against other projects
+
+Let's say that you're working on a feature in one of our products and this feature relies on changes that you need to make to one or more packages within this repo. You make those changes here, but now you want to make sure that they fulfill the need you have in your product and don't break anything. How do you integrate these changes into your product?
+
+Previously you might have used the "commit id" method to solve this problem, where you:
+
+- push up a branch in this repo
+- copy the commit id of the latest commit on that branch
+- open `package.json` in your project
+- replace the version of some package with `MetaMask/controllers#<commit id>`
+
+That method won't work anymore (at least until we have all repos using Yarn v3). So now what do you do?
+
+Enter **preview builds**. These are ephemeral versions of packages which are built on demand and published to GitHub Package Registry.
+
+To use them, you'll need to do a few of things:
+
+1. You'll need to create a personal access token within your GitHub account. If you have not already done so, go into the [token settings for your account](https://github.com/settings/tokens) and [create a token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic). (Note: there are two types of tokens; you'll want a **classic** token.)
+2. In your product, you'll need to add an `.npmrc` file with the following content:
+
+   ```
+   @metamask:registry=https://npm.pkg.github.com
+
+   //npm.pkg.github.com/:_authToken=<insert your personal access token here>
+   ```
+
+3. Over here in `controllers`, push up a draft PR for this repo (or place an existing PR into draft mode), then make a comment on the PR with the text:
+
+```
+@metamask-bot preview-build
+```
+
+This will trigger a GitHub Action which will build all of the packages in the monorepo using the code in the branch and publish them to GitHub Package Registry. You might need to wait a bit, but after a few minutes, you'll see a new comment with the new version that was published. 4. Back in your project, look for the package where you made your changes and replace its version with the one posted in the comment. 5. Run `yarn install`. You should be using the changes now. 5. Continue to keep your `controllers` PR in draft mode until you're sure that you don't need to make any new changes. If you do push up a new commit to your PR, however, simply post another `@metamask-bot preview-build` comment and this will trigger another build.

--- a/docs/what.md
+++ b/docs/what.md
@@ -4,8 +4,7 @@ If you've come here from the [README](../README.md), you already know that this 
 
 The short answer is that it's our solution to managing and disseminating state changes within our products.
 
-Every application needs to manage state. Some state is temporary. Perhaps the
-user is on a screen which keeps track of whether a button is clickable/tappable depending on whether a request is taking place; but as soon as the user leaves that screen, that information is discarded. But some state is more permanent. Perhaps a screen needs to reuse information that was gathered on a previous screen, in which case the state is cached in memory; or perhaps the entire application needs to load all of the user's data when it starts, in which case the state is persisted to disk. Either way, we need a place to store that state, and that's where controllers come into play.
+Every application needs to manage state. Some state is temporary. Perhaps the user is on a screen which keeps track of whether a button is clickable/tappable depending on whether a request is taking place; but as soon as the user leaves that screen, that information is discarded. But some state is more permanent. Perhaps a screen needs to reuse information that was gathered on a previous screen, in which case the state is cached in memory; or perhaps the entire application needs to load all of the user's data when it starts, in which case the state is persisted to disk. Either way, we need a place to store that state, and that's where controllers come into play.
 
 Currently, there are two styles of creating controllers which we've dubbed [BaseController v1](../packages/base-controller/src/BaseController.ts) and [BaseController v2](../packages/base-controller/src/BaseControllerV2.ts). Both versions offer the same set of basic functionality:
 

--- a/docs/what.md
+++ b/docs/what.md
@@ -1,0 +1,16 @@
+# All about controllers
+
+If you've come here from the [README](../README.md), you already know that this repo holds controllers. But what even _is_ a controller?
+
+The short answer is that it's our solution to managing and disseminating state changes within our products.
+
+Every application needs to manage state. Some state is temporary. Perhaps the
+user is on a screen which keeps track of whether a button is clickable/tappable depending on whether a request is taking place; but as soon as the user leaves that screen, that information is discarded. But some state is more permanent. Perhaps a screen needs to reuse information that was gathered on a previous screen, in which case the state is cached in memory; or perhaps the entire application needs to load all of the user's data when it starts, in which case the state is persisted to disk. Either way, we need a place to store that state, and that's where controllers come into play.
+
+Currently, there are two styles of creating controllers which we've dubbed [BaseController v1](../packages/base-controller/src/BaseController.ts) and [BaseController v2](../packages/base-controller/src/BaseControllerV2.ts). Both versions offer the same set of basic functionality:
+
+- The developer can preload the state (say, from a persistent location) when initializing.
+- The application can update the state at any time.
+- In another location, the application can listen for and respond to state changes (or stop listening altogether).
+
+v2 includes a number of improvements over v1, resulting in a more simplified and solidified API. One aspect worth noting with v2, however, is that not only can controllers communicate with the application, but controllers can also communicate with each other — and this is done in a way that doesn't require the controller package that's doing the receiving to depend on the controller that's doing the sending. This capability is provided by [ControllerMessenger](../packages/base-controller/src/ControllerMessenger.ts).

--- a/docs/why.md
+++ b/docs/why.md
@@ -1,0 +1,15 @@
+# Why a monorepo?
+
+Prior to November 2022, this repo was a monolithic repo, where the code for many [controllers](./what.md) lived under one roof and was published as one package (`@metamask/controllers`). This led to a few problems:
+
+- Even if a product team wanted to use a small subset of controllers, they were forced to add the entire package to their project, which bloated the dependency tree unnecessarily.
+- Occasionally, a product team tasked with carving out a new feature needed to make temporary modifications to one or more controllers during development, but this was difficult, as they were forced to fork the repo and keep it up to date.
+- Beyond the controllers repo, we were maintaining code for other shared libraries in separate repos, and keeping these repos architecturally aligned with each other had grown to be painful.
+
+We aimed to improve these situations by splitting up `@metamask/controllers` into many packages, where each package corresponded to a single controller (except for a few cases). By doing this:
+
+- Product teams could now choose which controllers they wanted to use in their project without the fear of relying on more dependencies than were necessary.
+- Instead of forking, product teams can publish [preview builds](./preview-builds.md) for in-progress work and make use of those builds in products to test them out as they are working on new features.
+- Although not carried out yet, in the future we hope to bring shared libraries as well as additional controllers not hosted here into this repo so that we can standardize the shape of each package much more easily than we can today.
+
+For a more in-depth explanation of challenges and solutions, read the [kickoff document for the monorepo project](https://docs.google.com/document/d/1G3M-lcwvfNFs3Tq4lVzhywqzYhCqPqBN7c5n8TC9sWM/edit).


### PR DESCRIPTION
Those of us that have worked on the monorepo have a lot of context around why it exists, what it does, and how to work with it, but for everyone else, this context may not exist. The set of guides in this commit aims to fill in the missing gaps. I've also included a bit around preview builds at the end. We may also need an expanded section on creating new releases, as people may not immediately jump to the docs for `create-release-branch`, and those docs may not be as comprehensive as they could be. This could come in a future PR, however.

---

Fixes https://github.com/MetaMask/controllers/issues/992.