### PR TITLE
Allow network requests in instances of the CurrencyRate and TokenRate controllers to be disabled

### DIFF
--- a/packages/assets-controllers/jest.config.js
+++ b/packages/assets-controllers/jest.config.js
@@ -16,10 +16,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 88.66,
-      functions: 96.45,
-      lines: 96.55,
-      statements: 96.63,
+      branches: 87.77,
+      functions: 96.15,
+      lines: 95.28,
+      statements: 95.4,
     },
   },
 

--- a/packages/assets-controllers/src/CurrencyRateController.test.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.test.ts
@@ -307,13 +307,10 @@ describe('CurrencyRateController', () => {
 
     await controller.setNativeCurrency('XYZ');
 
-    expect(
-      fetchExchangeRateStub.notCalled,
-    ).toBe(true);
+    expect(fetchExchangeRateStub.notCalled).toBe(true);
 
     controller.destroy();
   });
-
 
   it('should throw unexpected errors', async () => {
     const cryptoCompareHost = 'https://min-api.cryptocompare.com';

--- a/packages/assets-controllers/src/CurrencyRateController.test.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.test.ts
@@ -325,7 +325,7 @@ describe('CurrencyRateController', () => {
     controller.destroy();
   });
 
-  it('should fetch exchange rates after calling setNativeCurrency by default', async () => {
+  it('should fetch exchange rates after starting and again after calling setNativeCurrency', async () => {
     const fetchExchangeRateStub = jest.fn().mockResolvedValue({});
     const messenger = getRestrictedMessenger();
     const controller = new CurrencyRateController({

--- a/packages/assets-controllers/src/CurrencyRateController.test.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.test.ts
@@ -298,7 +298,21 @@ describe('CurrencyRateController', () => {
 
     controller.destroy();
   });
+  it('should NOT fetch exchange rates after calling setNativeCurrency if start has not been called', async () => {
+    const fetchExchangeRateStub = sinon.stub().resolves({});
+    const messenger = getRestrictedMessenger();
+    const controller = new CurrencyRateController({
+      includeUsdRate: true,
+      fetchExchangeRate: fetchExchangeRateStub,
+      messenger,
+    });
+    fetchExchangeRateStub.resetHistory();
+    await controller.setNativeCurrency('XYZ');
 
+    expect(fetchExchangeRateStub.notCalled).toBe(true);
+
+    controller.destroy();
+  });
   it('should NOT fetch exchange rates after calling setNativeCurrency if stop has been called', async () => {
     const fetchExchangeRateStub = sinon.stub().resolves({});
     const messenger = getRestrictedMessenger();

--- a/packages/assets-controllers/src/CurrencyRateController.test.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.test.ts
@@ -277,7 +277,7 @@ describe('CurrencyRateController', () => {
     controller.destroy();
   });
 
-  it('should fetch exchange rates after calling setNativeCurrency if start has been called', async () => {
+  it('should fetch exchange rates after calling setNativeCurrency by default', async () => {
     const fetchExchangeRateStub = sinon.stub().resolves({});
     const messenger = getRestrictedMessenger();
     const controller = new CurrencyRateController({

--- a/packages/assets-controllers/src/CurrencyRateController.test.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.test.ts
@@ -169,6 +169,7 @@ describe('CurrencyRateController', () => {
       fetchExchangeRate: fetchExchangeRateStub,
       messenger,
     });
+    controller.start();
     expect(controller.state.conversionRate).toStrictEqual(0);
     await controller.updateExchangeRate();
     expect(controller.state.conversionRate).toStrictEqual(10);
@@ -198,7 +199,7 @@ describe('CurrencyRateController', () => {
       fetchExchangeRate: fetchExchangeRateStub,
       messenger,
     });
-
+    controller.start();
     await controller.setNativeCurrency('DAI');
     await controller.updateExchangeRate();
     expect(controller.state.conversionRate).toStrictEqual(1);
@@ -217,6 +218,7 @@ describe('CurrencyRateController', () => {
       fetchExchangeRate: fetchExchangeRateStub,
       messenger,
     });
+    controller.start();
     expect(controller.state.conversionRate).toStrictEqual(0);
     await controller.setCurrentCurrency('CAD');
     expect(controller.state.conversionRate).toStrictEqual(10);
@@ -232,6 +234,7 @@ describe('CurrencyRateController', () => {
       fetchExchangeRate: fetchExchangeRateStub,
       messenger,
     });
+    controller.start();
     expect(controller.state.conversionRate).toStrictEqual(0);
     await controller.setNativeCurrency('xDAI');
     expect(controller.state.conversionRate).toStrictEqual(10);
@@ -248,7 +251,7 @@ describe('CurrencyRateController', () => {
       messenger,
       state: { currentCurrency: 'xyz' },
     });
-
+    controller.start();
     await controller.updateExchangeRate();
 
     expect(
@@ -269,7 +272,7 @@ describe('CurrencyRateController', () => {
       messenger,
       state: { currentCurrency: 'xyz' },
     });
-
+    controller.start();
     await controller.updateExchangeRate();
 
     expect(controller.state.conversionRate).toStrictEqual(2000.42);
@@ -286,6 +289,7 @@ describe('CurrencyRateController', () => {
       messenger,
     });
 
+    controller.start();
     await controller.setNativeCurrency('XYZ');
 
     expect(
@@ -303,8 +307,9 @@ describe('CurrencyRateController', () => {
       fetchExchangeRate: fetchExchangeRateStub,
       messenger,
     });
+    controller.start();
     controller.stop();
-
+    fetchExchangeRateStub.resetHistory();
     await controller.setNativeCurrency('XYZ');
 
     expect(fetchExchangeRateStub.notCalled).toBe(true);
@@ -327,7 +332,7 @@ describe('CurrencyRateController', () => {
       messenger,
       state: { currentCurrency: 'xyz' },
     });
-
+    controller.start();
     await expect(controller.updateExchangeRate()).rejects.toThrow(
       'this method has been deprecated',
     );
@@ -349,7 +354,7 @@ describe('CurrencyRateController', () => {
       messenger,
       state: { currentCurrency: 'xyz' },
     });
-
+    controller.start();
     await controller.updateExchangeRate();
     expect(controller.state.conversionRate).toBeNull();
     controller.destroy();
@@ -369,7 +374,7 @@ describe('CurrencyRateController', () => {
       messenger,
       state: existingState,
     });
-
+    controller.start();
     await controller.updateExchangeRate();
 
     expect(controller.state).toStrictEqual({

--- a/packages/assets-controllers/src/CurrencyRateController.test.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.test.ts
@@ -277,6 +277,44 @@ describe('CurrencyRateController', () => {
     controller.destroy();
   });
 
+  it('should fetch exchange rates after calling setNativeCurrency if start has been called', async () => {
+    const fetchExchangeRateStub = sinon.stub().resolves({});
+    const messenger = getRestrictedMessenger();
+    const controller = new CurrencyRateController({
+      includeUsdRate: true,
+      fetchExchangeRate: fetchExchangeRateStub,
+      messenger,
+    });
+
+    await controller.setNativeCurrency('XYZ');
+
+    expect(
+      fetchExchangeRateStub.alwaysCalledWithExactly('usd', 'XYZ', true),
+    ).toBe(true);
+
+    controller.destroy();
+  });
+
+  it('should NOT fetch exchange rates after calling setNativeCurrency if stop has been called', async () => {
+    const fetchExchangeRateStub = sinon.stub().resolves({});
+    const messenger = getRestrictedMessenger();
+    const controller = new CurrencyRateController({
+      includeUsdRate: true,
+      fetchExchangeRate: fetchExchangeRateStub,
+      messenger,
+    });
+    controller.stop();
+
+    await controller.setNativeCurrency('XYZ');
+
+    expect(
+      fetchExchangeRateStub.notCalled,
+    ).toBe(true);
+
+    controller.destroy();
+  });
+
+
   it('should throw unexpected errors', async () => {
     const cryptoCompareHost = 'https://min-api.cryptocompare.com';
     nock(cryptoCompareHost)

--- a/packages/assets-controllers/src/CurrencyRateController.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.ts
@@ -132,6 +132,7 @@ export class CurrencyRateController extends BaseControllerV2<
    */
   async start() {
     this.#enabled = true;
+
     await this.startPolling();
   }
 
@@ -140,6 +141,7 @@ export class CurrencyRateController extends BaseControllerV2<
    */
   stop() {
     this.#enabled = false;
+
     this.stopPolling();
   }
 
@@ -189,9 +191,11 @@ export class CurrencyRateController extends BaseControllerV2<
   private async startPolling(): Promise<void> {
     this.stopPolling();
     // TODO: Expose polling currency rate update errors
-    await safelyExecute(() => this.updateExchangeRate());
+
+    await safelyExecute(async () => await this.updateExchangeRate());
+
     this.intervalId = setInterval(async () => {
-      await safelyExecute(() => this.updateExchangeRate());
+      await safelyExecute(async () => await this.updateExchangeRate());
     }, this.intervalDelay);
   }
 
@@ -235,11 +239,14 @@ export class CurrencyRateController extends BaseControllerV2<
         currentCurrency !== '' &&
         nativeCurrency !== ''
       ) {
-        ({ conversionRate, usdConversionRate } = await this.fetchExchangeRate(
+        const fetchExchangeRateResponse = await this.fetchExchangeRate(
           currentCurrency,
           nativeCurrencyForExchangeRate,
           this.includeUsdRate,
-        ));
+        );
+
+        conversionRate = fetchExchangeRateResponse.conversionRate;
+        usdConversionRate = fetchExchangeRateResponse.usdConversionRate;
         conversionDate = Date.now() / 1000;
       }
     } catch (error) {

--- a/packages/assets-controllers/src/CurrencyRateController.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.ts
@@ -209,6 +209,7 @@ export class CurrencyRateController extends BaseControllerV2<
    */
   async updateExchangeRate(): Promise<CurrencyRateState | void> {
     if (!this.#enabled) {
+      console.info('[CurrencyRateController] Not updating exchange rate since network requests have been disabled');
       return this.state;
     }
     const releaseLock = await this.mutex.acquire();

--- a/packages/assets-controllers/src/CurrencyRateController.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.ts
@@ -209,7 +209,9 @@ export class CurrencyRateController extends BaseControllerV2<
    */
   async updateExchangeRate(): Promise<CurrencyRateState | void> {
     if (!this.#enabled) {
-      console.info('[CurrencyRateController] Not updating exchange rate since network requests have been disabled');
+      console.info(
+        '[CurrencyRateController] Not updating exchange rate since network requests have been disabled',
+      );
       return this.state;
     }
     const releaseLock = await this.mutex.acquire();

--- a/packages/assets-controllers/src/CurrencyRateController.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.ts
@@ -90,7 +90,10 @@ export class CurrencyRateController extends BaseControllerV2<
 
   private includeUsdRate;
 
-  #enabled; // A boolean that controls whether or not network requests can be made by the controller.
+  /**
+   * A boolean that controls whether or not network requests can be made by the controller
+   */
+  #enabled;
 
   /**
    * Creates a CurrencyRateController instance.

--- a/packages/assets-controllers/src/CurrencyRateController.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.ts
@@ -90,6 +90,8 @@ export class CurrencyRateController extends BaseControllerV2<
 
   private includeUsdRate;
 
+  #enabled;
+
   /**
    * Creates a CurrencyRateController instance.
    *
@@ -99,6 +101,7 @@ export class CurrencyRateController extends BaseControllerV2<
    * @param options.messenger - A reference to the messaging system.
    * @param options.state - Initial state to set on this controller.
    * @param options.fetchExchangeRate - Fetches the exchange rate from an external API. This option is primarily meant for use in unit tests.
+   * @param options.enabled - A boolean that controls whether or not network requests can be made by the controller.
    */
   constructor({
     includeUsdRate = false,
@@ -122,12 +125,14 @@ export class CurrencyRateController extends BaseControllerV2<
     this.includeUsdRate = includeUsdRate;
     this.intervalDelay = interval;
     this.fetchExchangeRate = fetchExchangeRate;
+    this.#enabled = true;
   }
 
   /**
    * Start polling for the currency rate.
    */
   async start() {
+    this.#enabled = true;
     await this.startPolling();
   }
 
@@ -135,6 +140,7 @@ export class CurrencyRateController extends BaseControllerV2<
    * Stop polling for the currency rate.
    */
   stop() {
+    this.#enabled = false;
     this.stopPolling();
   }
 
@@ -196,6 +202,9 @@ export class CurrencyRateController extends BaseControllerV2<
    * @returns The controller state.
    */
   async updateExchangeRate(): Promise<CurrencyRateState | void> {
+    if (!this.#enabled) {
+      return;
+    }
     const releaseLock = await this.mutex.acquire();
     const {
       currentCurrency: stateCurrentCurrency,

--- a/packages/assets-controllers/src/CurrencyRateController.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.ts
@@ -124,7 +124,7 @@ export class CurrencyRateController extends BaseControllerV2<
     this.includeUsdRate = includeUsdRate;
     this.intervalDelay = interval;
     this.fetchExchangeRate = fetchExchangeRate;
-    this.#enabled = true;
+    this.#enabled = false;
   }
 
   /**
@@ -202,7 +202,7 @@ export class CurrencyRateController extends BaseControllerV2<
    */
   async updateExchangeRate(): Promise<CurrencyRateState | void> {
     if (!this.#enabled) {
-      return null;
+      return this.state;
     }
     const releaseLock = await this.mutex.acquire();
     const {

--- a/packages/assets-controllers/src/CurrencyRateController.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.ts
@@ -90,7 +90,7 @@ export class CurrencyRateController extends BaseControllerV2<
 
   private includeUsdRate;
 
-  #enabled;
+  #enabled; // A boolean that controls whether or not network requests can be made by the controller.
 
   /**
    * Creates a CurrencyRateController instance.
@@ -101,7 +101,6 @@ export class CurrencyRateController extends BaseControllerV2<
    * @param options.messenger - A reference to the messaging system.
    * @param options.state - Initial state to set on this controller.
    * @param options.fetchExchangeRate - Fetches the exchange rate from an external API. This option is primarily meant for use in unit tests.
-   * @param options.enabled - A boolean that controls whether or not network requests can be made by the controller.
    */
   constructor({
     includeUsdRate = false,
@@ -203,7 +202,7 @@ export class CurrencyRateController extends BaseControllerV2<
    */
   async updateExchangeRate(): Promise<CurrencyRateState | void> {
     if (!this.#enabled) {
-      return;
+      return null;
     }
     const releaseLock = await this.mutex.acquire();
     const {

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -203,9 +203,10 @@ export class TokenRatesController extends BaseController<
       contractExchangeRates: {},
     };
     this.initialize();
-    if(config?.disabled === true){
+    if (config?.disabled === true) {
       this.configure({ disabled: true }, false, false);
     }
+
     onTokensStateChange(({ tokens, detectedTokens }) => {
       this.configure({ tokens: [...tokens, ...detectedTokens] });
     });

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -191,7 +191,7 @@ export class TokenRatesController extends BaseController<
   ) {
     super(config, state);
     this.defaultConfig = {
-      disabled: true,
+      disabled: false,
       interval: 3 * 60 * 1000,
       nativeCurrency: 'eth',
       chainId: '',
@@ -203,7 +203,9 @@ export class TokenRatesController extends BaseController<
       contractExchangeRates: {},
     };
     this.initialize();
-    this.configure({ disabled: false }, false, false);
+    if(config?.disabled === true){
+      this.configure({ disabled: true }, false, false);
+    }
     onTokensStateChange(({ tokens, detectedTokens }) => {
       this.configure({ tokens: [...tokens, ...detectedTokens] });
     });

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -203,7 +203,7 @@ export class TokenRatesController extends BaseController<
       contractExchangeRates: {},
     };
     this.initialize();
-    if (config?.disabled === true) {
+    if (config?.disabled) {
       this.configure({ disabled: true }, false, false);
     }
 


### PR DESCRIPTION
**Allow network requests in instances of the CurrencyRate and TokenRate controllers to be disabled**

**Description**

- BREAKING:
  - A new private property is added to the CurrencyRateController: `enabled`. If this is false, then the function in that controller which makes network requests will not make any requests when called. This property is controlled by the `start` and `stop` methods, so that these methods will effectively enable or disable network requests. Previously, even if `stop` had been called, `setNativeCurrency` or `setCurrentCurrency` would trigger a network request. That is now prevented.

- FIXED:
  - The TokenRatesController previously had a bug whereby if a `disabled` property was passed to the constructive as part of the `config` object, it would be ignored / overwritten to false. This PR fixes that.


**Checklist**

- [ ] Tests are included if applicable
- [ ] Any added code is fully documented

**Issue**
Part of [#16724](https://github.com/MetaMask/metamask-extension/issues/16724)