### PR TITLE
Add peer dependencies between packages

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -224,14 +224,13 @@ gen_enforced_dependency(WorkspaceCwd, DependencyIdent, OtherDependencyRange, Dep
   npm_version_range_out_of_sync(DependencyRange, OtherDependencyRange).
 
 % If a dependency is listed under "dependencies", it should not be listed under
-% any other "*dependencies" lists. We match on the same dependency range so that
-% if a dependency is listed twice in the same manifest, their versions are
-% synchronized and then this constraint will apply and remove the "right"
-% duplicate.
+% "devDependencies". We match on the same dependency range so that if a
+% dependency is listed under both lists, their versions are synchronized and
+% then this constraint will apply and remove the "right" duplicate.
 gen_enforced_dependency(WorkspaceCwd, DependencyIdent, null, DependencyType) :-
   workspace_has_dependency(WorkspaceCwd, DependencyIdent, DependencyRange, 'dependencies'),
   workspace_has_dependency(WorkspaceCwd, DependencyIdent, DependencyRange, DependencyType),
-  DependencyType \= 'dependencies'.
+  DependencyType == 'devDependencies'.
 
 % eth-query has an unlisted dependency on babel-runtime, so that package needs
 % to be present if eth-query is present.

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -65,6 +65,9 @@
     "typedoc-plugin-missing-exports": "^0.22.6",
     "typescript": "~4.6.3"
   },
+  "peerDependencies": {
+    "@metamask/network-controller": "workspace:^"
+  },
   "engines": {
     "node": ">=14.0.0"
   },

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -54,6 +54,9 @@
     "typedoc-plugin-missing-exports": "^0.22.6",
     "typescript": "~4.6.3"
   },
+  "peerDependencies": {
+    "@metamask/network-controller": "workspace:^"
+  },
   "engines": {
     "node": ">=14.0.0"
   },

--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -50,6 +50,9 @@
     "typedoc-plugin-missing-exports": "^0.22.6",
     "typescript": "~4.6.3"
   },
+  "peerDependencies": {
+    "@metamask/approval-controller": "workspace:^"
+  },
   "engines": {
     "node": ">=14.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1434,6 +1434,8 @@ __metadata:
     typedoc-plugin-missing-exports: ^0.22.6
     typescript: ~4.6.3
     uuid: ^8.3.2
+  peerDependencies:
+    "@metamask/network-controller": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -1707,6 +1709,8 @@ __metadata:
     typedoc-plugin-missing-exports: ^0.22.6
     typescript: ~4.6.3
     uuid: ^8.3.2
+  peerDependencies:
+    "@metamask/network-controller": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -1844,6 +1848,8 @@ __metadata:
     typedoc: ^0.22.15
     typedoc-plugin-missing-exports: ^0.22.6
     typescript: ~4.6.3
+  peerDependencies:
+    "@metamask/approval-controller": "workspace:^"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Packages now list `peerDependencies` to represent the expectation that a specific package version is setup with the controller messenger. This ensures that projects using these packages get a warning upon install if they are using incompatible package versions.

This lets us safely make breaking changes to controller messenger events and actions.

The constraints needed adjustment to allow the same dependency to be declared both in `dependencies` and `peerDependencies`. The constraint now ensures packages aren't listed both in `dependencies` and `devDependencies` instead.

- FIXED:

  - The following packages now warn if a required package is not present:
    - `assets-controllers`
    - `gas-fee-controller`
    - `permission-controller`

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented