### PR TITLE
DetectedTokens getting reloaded from allDetectedTokens even after the tokens are imported for a chain and selectedAddress

### DIFF
--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -756,6 +756,7 @@ describe('TokensController', () => {
         [DETECTED_CHAINID]: {
           [DETECTED_ADDRESS]: [detectedToken],
         },
+        '4': { '0xabc': [] },
       });
 
       expect(tokensController.state.allTokens).toStrictEqual({
@@ -763,7 +764,6 @@ describe('TokensController', () => {
           [CONFIGURED_ADDRESS]: [directlyAddedToken],
         },
       });
-
       stub.restore();
     });
   });
@@ -850,6 +850,21 @@ describe('TokensController', () => {
           dummySelectedAddress
         ],
       ).toStrictEqual(dummyTokens);
+    });
+
+    it('should nest detectedTokens under chain ID and selected address when detectedTokens provided is an empty list', () => {
+      tokensController.configure({
+        selectedAddress: dummySelectedAddress,
+        chainId: NetworksChainId.mainnet,
+      });
+      const processedTokens = tokensController._getNewAllTokensState({
+        newDetectedTokens: [],
+      });
+      expect(
+        processedTokens.newAllDetectedTokens[NetworksChainId.mainnet][
+          dummySelectedAddress
+        ],
+      ).toStrictEqual([]);
     });
 
     it('should nest ignoredTokens under chain ID and selected address when provided with ignoredTokens as input', () => {

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -851,54 +851,6 @@ describe('TokensController', () => {
       ).toStrictEqual(dummyTokens);
     });
 
-    it('should nest allTokens under chain ID and selected address when detectedTokens provided is an empty list', async () => {
-      tokensController.configure({
-        selectedAddress: dummySelectedAddress,
-        chainId: NetworksChainId.mainnet,
-      });
-      await tokensController.addTokens(dummyTokens);
-      const processedTokens = tokensController._getNewAllTokensState({
-        newTokens: [],
-      });
-      expect(
-        processedTokens.newAllTokens[NetworksChainId.mainnet][
-          dummySelectedAddress
-        ],
-      ).toStrictEqual([]);
-    });
-
-    it('should nest allIgnoredTokens under chain ID and selected address when detectedTokens provided is an empty list', async () => {
-      tokensController.configure({
-        selectedAddress: dummySelectedAddress,
-        chainId: NetworksChainId.mainnet,
-      });
-      await tokensController.ignoreTokens(['0xabc']);
-      const processedTokens = tokensController._getNewAllTokensState({
-        newIgnoredTokens: [],
-      });
-      expect(
-        processedTokens.newAllIgnoredTokens[NetworksChainId.mainnet][
-          dummySelectedAddress
-        ],
-      ).toStrictEqual([]);
-    });
-
-    it('should nest allDetectedTokens under chain ID and selected address when detectedTokens provided is an empty list', async () => {
-      tokensController.configure({
-        selectedAddress: dummySelectedAddress,
-        chainId: NetworksChainId.mainnet,
-      });
-      await tokensController.addDetectedTokens(dummyTokens);
-      const processedTokens = tokensController._getNewAllTokensState({
-        newDetectedTokens: [],
-      });
-      expect(
-        processedTokens.newAllDetectedTokens[NetworksChainId.mainnet][
-          dummySelectedAddress
-        ],
-      ).toStrictEqual([]);
-    });
-
     it('should nest ignoredTokens under chain ID and selected address when provided with ignoredTokens as input', () => {
       tokensController.configure({
         selectedAddress: dummySelectedAddress,
@@ -1240,6 +1192,65 @@ describe('TokensController', () => {
       expect(initialTokensSecond).toStrictEqual(tokensController.state.tokens);
 
       stub.restore();
+    });
+  });
+
+  describe('Clearing nested lists', function () {
+    const dummyTokens: Token[] = [
+      {
+        address: '0x01',
+        symbol: 'barA',
+        decimals: 2,
+        aggregators: [],
+        image: undefined,
+      },
+    ];
+    const selectedAddress = '0x1';
+    const tokenAddress = '0x01';
+
+    it('should clear nest allTokens under chain ID and selected address when an added token is ignored', async () => {
+      tokensController.configure({
+        selectedAddress,
+        chainId: NetworksChainId.mainnet,
+      });
+      await tokensController.addTokens(dummyTokens);
+      await tokensController.ignoreTokens(['0x01']);
+      expect(
+        tokensController.state.allTokens[NetworksChainId.mainnet][
+          selectedAddress
+        ],
+      ).toStrictEqual([]);
+    });
+
+    it('should clear nest allIgnoredTokens under chain ID and selected address when an ignored token is re-added', async () => {
+      tokensController.configure({
+        selectedAddress,
+        chainId: NetworksChainId.mainnet,
+      });
+      await tokensController.addTokens(dummyTokens);
+      await tokensController.ignoreTokens([tokenAddress]);
+      await tokensController.addTokens(dummyTokens);
+
+      expect(
+        tokensController.state.allIgnoredTokens[NetworksChainId.mainnet][
+          selectedAddress
+        ],
+      ).toStrictEqual([]);
+    });
+
+    it('should clear nest allDetectedTokens under chain ID and selected address when an detected token is added to tokens list', async () => {
+      tokensController.configure({
+        selectedAddress,
+        chainId: NetworksChainId.mainnet,
+      });
+      await tokensController.addDetectedTokens(dummyTokens);
+      await tokensController.addTokens(dummyTokens);
+
+      expect(
+        tokensController.state.allDetectedTokens[NetworksChainId.mainnet][
+          selectedAddress
+        ],
+      ).toStrictEqual([]);
     });
   });
 });

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -756,7 +756,6 @@ describe('TokensController', () => {
         [DETECTED_CHAINID]: {
           [DETECTED_ADDRESS]: [detectedToken],
         },
-        '4': { '0xabc': [] },
       });
 
       expect(tokensController.state.allTokens).toStrictEqual({
@@ -852,11 +851,44 @@ describe('TokensController', () => {
       ).toStrictEqual(dummyTokens);
     });
 
-    it('should nest detectedTokens under chain ID and selected address when detectedTokens provided is an empty list', () => {
+    it('should nest allTokens under chain ID and selected address when detectedTokens provided is an empty list', async () => {
       tokensController.configure({
         selectedAddress: dummySelectedAddress,
         chainId: NetworksChainId.mainnet,
       });
+      await tokensController.addTokens(dummyTokens);
+      const processedTokens = tokensController._getNewAllTokensState({
+        newTokens: [],
+      });
+      expect(
+        processedTokens.newAllTokens[NetworksChainId.mainnet][
+          dummySelectedAddress
+        ],
+      ).toStrictEqual([]);
+    });
+
+    it('should nest allIgnoredTokens under chain ID and selected address when detectedTokens provided is an empty list', async () => {
+      tokensController.configure({
+        selectedAddress: dummySelectedAddress,
+        chainId: NetworksChainId.mainnet,
+      });
+      await tokensController.ignoreTokens(['0xabc']);
+      const processedTokens = tokensController._getNewAllTokensState({
+        newIgnoredTokens: [],
+      });
+      expect(
+        processedTokens.newAllIgnoredTokens[NetworksChainId.mainnet][
+          dummySelectedAddress
+        ],
+      ).toStrictEqual([]);
+    });
+
+    it('should nest allDetectedTokens under chain ID and selected address when detectedTokens provided is an empty list', async () => {
+      tokensController.configure({
+        selectedAddress: dummySelectedAddress,
+        chainId: NetworksChainId.mainnet,
+      });
+      await tokensController.addDetectedTokens(dummyTokens);
       const processedTokens = tokensController._getNewAllTokensState({
         newDetectedTokens: [],
       });

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -767,7 +767,7 @@ export class TokensController extends BaseController<
     }
 
     let newAllDetectedTokens = allDetectedTokens;
-    if (newDetectedTokens?.length) {
+    if (newDetectedTokens !== undefined) {
       const networkDetectedTokens = allDetectedTokens[chainIdToAddTokens];
       const newDetectedNetworkTokens = {
         ...networkDetectedTokens,

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -743,7 +743,7 @@ export class TokensController extends BaseController<
     let newAllTokens = allTokens;
     if (
       newTokens?.length ||
-      (newTokens !== undefined &&
+      (newTokens &&
         allTokens &&
         allTokens[chainIdToAddTokens] &&
         allTokens[chainIdToAddTokens][userAddressToAddTokens])
@@ -762,7 +762,7 @@ export class TokensController extends BaseController<
     let newAllIgnoredTokens = allIgnoredTokens;
     if (
       newIgnoredTokens?.length ||
-      (newIgnoredTokens !== undefined &&
+      (newIgnoredTokens &&
         allIgnoredTokens &&
         allIgnoredTokens[chainIdToAddTokens] &&
         allIgnoredTokens[chainIdToAddTokens][userAddressToAddTokens])
@@ -781,7 +781,7 @@ export class TokensController extends BaseController<
     let newAllDetectedTokens = allDetectedTokens;
     if (
       newDetectedTokens?.length ||
-      (newDetectedTokens !== undefined &&
+      (newDetectedTokens &&
         allDetectedTokens &&
         allDetectedTokens[chainIdToAddTokens] &&
         allDetectedTokens[chainIdToAddTokens][userAddressToAddTokens])

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -741,7 +741,13 @@ export class TokensController extends BaseController<
     const chainIdToAddTokens = detectionChainId ?? chainId;
 
     let newAllTokens = allTokens;
-    if (newTokens?.length) {
+    if (
+      newTokens?.length ||
+      (newTokens !== undefined &&
+        allTokens &&
+        allTokens[chainIdToAddTokens] &&
+        allTokens[chainIdToAddTokens][userAddressToAddTokens])
+    ) {
       const networkTokens = allTokens[chainIdToAddTokens];
       const newNetworkTokens = {
         ...networkTokens,
@@ -754,7 +760,13 @@ export class TokensController extends BaseController<
     }
 
     let newAllIgnoredTokens = allIgnoredTokens;
-    if (newIgnoredTokens?.length) {
+    if (
+      newIgnoredTokens?.length ||
+      (newIgnoredTokens !== undefined &&
+        allIgnoredTokens &&
+        allIgnoredTokens[chainIdToAddTokens] &&
+        allIgnoredTokens[chainIdToAddTokens][userAddressToAddTokens])
+    ) {
       const networkIgnoredTokens = allIgnoredTokens[chainIdToAddTokens];
       const newIgnoredNetworkTokens = {
         ...networkIgnoredTokens,
@@ -767,7 +779,13 @@ export class TokensController extends BaseController<
     }
 
     let newAllDetectedTokens = allDetectedTokens;
-    if (newDetectedTokens !== undefined) {
+    if (
+      newDetectedTokens?.length ||
+      (newDetectedTokens !== undefined &&
+        allDetectedTokens &&
+        allDetectedTokens[chainIdToAddTokens] &&
+        allDetectedTokens[chainIdToAddTokens][userAddressToAddTokens])
+    ) {
       const networkDetectedTokens = allDetectedTokens[chainIdToAddTokens];
       const newDetectedNetworkTokens = {
         ...networkDetectedTokens,


### PR DESCRIPTION
Fixes [16854](https://github.com/MetaMask/metamask-extension/issues/16854) 
When used to import the detectedTokens by calling `addTokens` we should clear the `detectedTokens` and `allDetectedTokens[chainId][selectedAddress]` ie entry in `allDetectedTokens` for that particular chainId and selectedAddress, otherwise the data from allDetectedTokens getting repopulated/reloaded into the `detectedtokens` when the networkState or preferenceState changes.

Edit: upon further inspection, we had to do the same clearing for allTokens and allIgnoredtokens as well.