### PR TITLE
Add constraint for `bugs` field in `package.json`

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -156,8 +156,13 @@ gen_enforced_field(WorkspaceCwd, 'repository.type', 'git').
 gen_enforced_field(WorkspaceCwd, 'repository.url', 'https://github.com/MetaMask/controllers.git').
 
 % "bugs.url" must be "https://github.com/MetaMask/controllers/issues" for all
-% packages.
-gen_enforced_field(WorkspaceCwd, 'bugs.url', 'https://github.com/MetaMask/controllers/issues').
+% workspace packages.
+gen_enforced_field(WorkspaceCwd, 'bugs.url', 'https://github.com/MetaMask/controllers/issues') :-
+  \+ workspace_field(WorkspaceCwd, 'private', true).
+
+% "bugs" must unset for the root.
+gen_enforced_field(WorkspaceCwd, 'bugs', null) :-
+  workspace_field(WorkspaceCwd, 'private', true).
 
 % "license" must be "MIT" for all workspace packages and unset for the root.
 gen_enforced_field(WorkspaceCwd, 'license', 'MIT') :-

--- a/constraints.pro
+++ b/constraints.pro
@@ -155,6 +155,10 @@ gen_enforced_field(WorkspaceCwd, 'repository.type', 'git').
 % packages.
 gen_enforced_field(WorkspaceCwd, 'repository.url', 'https://github.com/MetaMask/controllers.git').
 
+% "bugs.url" must be "https://github.com/MetaMask/controllers/issues" for all
+% packages.
+gen_enforced_field(WorkspaceCwd, 'bugs.url', 'https://github.com/MetaMask/controllers/issues').
+
 % "license" must be "MIT" for all workspace packages and unset for the root.
 gen_enforced_field(WorkspaceCwd, 'license', 'MIT') :-
   \+ workspace_field(WorkspaceCwd, 'private', true).

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "37.0.0",
   "private": true,
   "description": "Collection of platform-agnostic modules for creating secure data models for cryptocurrency wallets",
-  "bugs": {
-    "url": "https://github.com/MetaMask/controllers/issues"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/controllers.git"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "37.0.0",
   "private": true,
   "description": "Collection of platform-agnostic modules for creating secure data models for cryptocurrency wallets",
+  "bugs": {
+    "url": "https://github.com/MetaMask/controllers/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/controllers.git"


### PR DESCRIPTION
A constraint has been added to ensure that the `bugs` field in `package.json` is always set to the correct value. This field was not covered by existing validation.

This constraint is useful for a subsequent PR, where the repository is renamed.

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented