### PR TITLE
Export `isTokenDetectionSupportedForNetwork` function

### DIFF
--- a/packages/assets-controllers/src/index.ts
+++ b/packages/assets-controllers/src/index.ts
@@ -8,4 +8,8 @@ export * from './TokenDetectionController';
 export * from './TokenListController';
 export * from './TokenRatesController';
 export * from './TokensController';
-export { formatIconUrlWithProxy, getFormattedIpfsUrl } from './assetsUtil';
+export {
+  isTokenDetectionSupportedForNetwork,
+  formatIconUrlWithProxy,
+  getFormattedIpfsUrl,
+} from './assetsUtil';


### PR DESCRIPTION
The function `isTokenDetectionSupportedForNetwork` is now exported from the `assets-controllets` package. This function was exported from the `utils` before this repository was split into separate packages. This function is used in `metamask-mobile`.

- CHANGED:

  - [assets-controllers]: Export the function `isTokenDetectionSupportedForNetwork` 

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented