### PR TITLE
Release 38.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/controllers-monorepo",
-  "version": "37.0.0",
+  "version": "38.0.0",
   "private": true,
   "description": "Collection of platform-agnostic modules for creating secure data models for cryptocurrency wallets",
   "repository": {

--- a/packages/announcement-controller/CHANGELOG.md
+++ b/packages/announcement-controller/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0]
+### Uncategorized
+- AnnouncementController migration to BaseControllerV2 ([#959](https://github.com/MetaMask/controllers/pull/959))
+
 ## [1.0.1]
 ### Changed
 - Relax dependency on `@metamask/base-controller` (use `^` instead of `~`) ([#998](https://github.com/MetaMask/controllers/pull/998))
@@ -18,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/controllers/compare/@metamask/announcement-controller@1.0.1...HEAD
+[Unreleased]: https://github.com/MetaMask/controllers/compare/@metamask/announcement-controller@2.0.0...HEAD
+[2.0.0]: https://github.com/MetaMask/controllers/compare/@metamask/announcement-controller@1.0.1...@metamask/announcement-controller@2.0.0
 [1.0.1]: https://github.com/MetaMask/controllers/compare/@metamask/announcement-controller@1.0.0...@metamask/announcement-controller@1.0.1
 [1.0.0]: https://github.com/MetaMask/controllers/releases/tag/@metamask/announcement-controller@1.0.0

--- a/packages/announcement-controller/CHANGELOG.md
+++ b/packages/announcement-controller/CHANGELOG.md
@@ -7,8 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [2.0.0]
-### Uncategorized
-- AnnouncementController migration to BaseControllerV2 ([#959](https://github.com/MetaMask/controllers/pull/959))
+### Changed
+- **BREAKING:** Migrate to BaseControllerV2 ([#959](https://github.com/MetaMask/controllers/pull/959))
+  - The announcement controller now extends `BaseControllerV2` rather than `BaseController`, which includes the following changes:
+    - The constructor now accepts a single "args" object rather than positional parameters.
+    - A restricted controller messenger instance must be passed into the constructor.
+    - The controller configuration has been replaced by an `allAnnouncements` constructor parameter.
+    - The following properties previously inherited from `BaseController` are no longer present:
+      - `defaultConfig`
+      - `defaultState`
+      - `disabled`
+      - `config`
+      - `state`
+    - The following methods previously inherited from `BaseController` are no longer present:
+      - `configure`
+      - `notify`
+      - `subscribe`
+      - `unsubscribe`
+      - `update`
+    - The `name` property is now readonly.
 
 ## [1.0.1]
 ### Changed

--- a/packages/announcement-controller/package.json
+++ b/packages/announcement-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/announcement-controller",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Manages in-app announcements",
   "keywords": [
     "MetaMask",

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1]
+### Uncategorized
+- Export `isTokenDetectionSupportedForNetwork` function ([#1034](https://github.com/MetaMask/controllers/pull/1034))
+- DetectedTokens getting reloaded from allDetectedTokens even after the tokens are imported for a chain and selectedAddress ([#1015](https://github.com/MetaMask/controllers/pull/1015))
+- Bump @metamask/contract-metadata from 1.35.0 to 2.1.0 ([#1013](https://github.com/MetaMask/controllers/pull/1013))
+
 ## [3.0.0]
 ### Changed
 - **BREAKING:** A new private property, controlled by the `start` and `stop` methods, is added to the CurrencyRateController: `enabled`. When this is false, no network requests will be made from the controller. Previously, setNativeCurrency or setCurrentCurrency would trigger a network request. That is now prevented if `enabled` is false. ([#1002](https://github.com/MetaMask/controllers/pull/1002))
@@ -44,7 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Use Ethers for AssetsContractController ([#845](https://github.com/MetaMask/controllers/pull/845))
 
-[Unreleased]: https://github.com/MetaMask/controllers/compare/@metamask/assets-controllers@3.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/controllers/compare/@metamask/assets-controllers@3.0.1...HEAD
+[3.0.1]: https://github.com/MetaMask/controllers/compare/@metamask/assets-controllers@3.0.0...@metamask/assets-controllers@3.0.1
 [3.0.0]: https://github.com/MetaMask/controllers/compare/@metamask/assets-controllers@2.0.0...@metamask/assets-controllers@3.0.0
 [2.0.0]: https://github.com/MetaMask/controllers/compare/@metamask/assets-controllers@1.0.1...@metamask/assets-controllers@2.0.0
 [1.0.1]: https://github.com/MetaMask/controllers/compare/@metamask/assets-controllers@1.0.0...@metamask/assets-controllers@1.0.1

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [3.0.1]
-### Uncategorized
+### Changed
 - Export `isTokenDetectionSupportedForNetwork` function ([#1034](https://github.com/MetaMask/controllers/pull/1034))
-- DetectedTokens getting reloaded from allDetectedTokens even after the tokens are imported for a chain and selectedAddress ([#1015](https://github.com/MetaMask/controllers/pull/1015))
-- Bump @metamask/contract-metadata from 1.35.0 to 2.1.0 ([#1013](https://github.com/MetaMask/controllers/pull/1013))
+- Update `@metamask/contract-metadata` from 1.35.0 to 2.1.0 ([#1013](https://github.com/MetaMask/controllers/pull/1013))
+
+### Fixed
+- Fix token controller state updates ([#1015](https://github.com/MetaMask/controllers/pull/1015))
+  - Attempts to empty the list of "added", "ignored", or "detected" tokens were not saved in state correctly, resulting in that operation being undone after switching account or network.
 
 ## [3.0.0]
 ### Changed

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/assets-controllers",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Controllers which manage interactions involving ERC-20, ERC-721, and ERC-1155 tokens (including NFTs)",
   "keywords": [
     "MetaMask",


### PR DESCRIPTION
Changelogs:

# `announcement-controller`
## [2.0.0]
### Changed
- **BREAKING:** Migrate to BaseControllerV2 ([#959](https://github.com/MetaMask/controllers/pull/959))
  - The announcement controller now extends `BaseControllerV2` rather than `BaseController`, which includes the following changes:
    - The constructor now accepts a single "args" object rather than positional parameters.
    - A restricted controller messenger instance must be passed into the constructor.
    - The controller configuration has been replaced by an `allAnnouncements` constructor parameter.
    - The following properties previously inherited from `BaseController` are no longer present:
      - `defaultConfig`
      - `defaultState`
      - `disabled`
      - `config`
      - `state`
    - The following methods previously inherited from `BaseController` are no longer present:
      - `configure`
      - `notify`
      - `subscribe`
      - `unsubscribe`
      - `update`
    - The `name` property is now readonly.

# `assets-controllers`
## [3.0.1]
### Changed
- Export `isTokenDetectionSupportedForNetwork` function ([#1034](https://github.com/MetaMask/controllers/pull/1034))
- Update `@metamask/contract-metadata` from 1.35.0 to 2.1.0 ([#1013](https://github.com/MetaMask/controllers/pull/1013))

### Fixed
- Fix token controller state updates ([#1015](https://github.com/MetaMask/controllers/pull/1015))
  - Attempts to empty the list of "added", "ignored", or "detected" tokens were not saved in state correctly, resulting in that operation being undone after switching account or network.